### PR TITLE
Fixes #1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
     * Fix for bug ##1042419 : Gtg-0.2.9.tar.gz file has 'gtg' and 'GTG', by Izidor Matušov
     * Moving to Sphinx for documentation and improving the scripts, by Izidor Matušov
     * Fixing the error getting thrown on drag-drop of text in taskeditor, by Sagar Ghuge
+    * Fixes #1 : Searching for something and then clicking on any place in the tag sidebar doesn't clear the quick-add bar text, by Parth Panchal
 
 2013-11-24 Getting Things GNOME! 0.3.1
     * Fix for bug #1024473: Have 'Show Main Window' in notification area, by Antonio Roquentin

--- a/GTG/gtk/browser/browser.py
+++ b/GTG/gtk/browser/browser.py
@@ -1163,6 +1163,9 @@ class TaskBrowser(GObject.GObject):
 
     def apply_filter_on_panes(self, filter_name, refresh=True):
         """ Apply filters for every pane: active tasks, closed tasks """
+        # Reset quickadd_entry if another filter is applied
+        self.quickadd_entry.set_text("")
+        
         for pane in self.vtree_panes:
             vtree = self.req.get_tasks_tree(name=pane, refresh=False)
             vtree.apply_filter(filter_name, refresh=refresh)


### PR DESCRIPTION
Searching for something and then clicking on any place in the tag
sidebar now clears the quick-add bar text.
