### PR TITLE
fix gtk.Builder localization

### DIFF
--- a/GTG/__init__.py
+++ b/GTG/__init__.py
@@ -45,9 +45,9 @@ LOCAL_ROOTDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 GETTEXT_DOMAIN = 'gtg'
 LOCALE_PATH = gettext.bindtextdomain(GETTEXT_DOMAIN)
 
-gettext.bindtextdomain(GETTEXT_DOMAIN, LOCALE_PATH)
-gettext.textdomain(GETTEXT_DOMAIN)
-# FIXME set translation for Builder as well!
+for module in locale, gettext:
+    module.bindtextdomain(GETTEXT_DOMAIN, LOCALE_PATH)
+    module.textdomain(GETTEXT_DOMAIN)
 
 translation = gettext.translation(GETTEXT_DOMAIN, LOCALE_PATH, fallback=True)
 


### PR DESCRIPTION
This patch fixes gettext issues with gtk.Builder.

At least this calls fixes translation with 0.3.1, current head not tested.

Please review and comment if there are and issues.
