### PR TITLE
order backend name in alphabetical order

### DIFF
--- a/GTG/gtk/backends_dialog/backendscombo.py
+++ b/GTG/gtk/backends_dialog/backendscombo.py
@@ -69,7 +69,10 @@ class BackendsCombo(Gtk.ComboBox):
         '''
         self.liststore.clear()
         backend_types = BackendFactory().get_all_backends()
-        for name, module in backend_types.items():
+        ordered_backend_types = sorted(
+            backend_types.items(),
+            key=lambda btype: btype[1].Backend.get_human_default_name())
+        for name, module in ordered_backend_types:
             # FIXME: Disable adding another localfile backend.
             # It just produce many warnings, provides no use case
             # See LP bug #940917 (Izidor)


### PR DESCRIPTION
Without this patch, avialable backends are shown in random order when adding a backend
