### PR TITLE
Fixed task urgency (LP #1258451).

### DIFF
--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -362,6 +362,8 @@ class Task(TreeNode):
         """
         urg_date = self.due_date
         for sub in self.get_subtasks():
+            if sub.get_closed_date() != Date.no_date():
+                continue
             sub_urg_date = sub.get_urgent_date()
             if urg_date >= sub_urg_date:
                 urg_date = sub_urg_date


### PR DESCRIPTION
[launchpad bug](https://bugs.launchpad.net/gtg/+bug/1258451)

(Not sure how this fix got missed. The Launchpad bug said it was already
committed.)

The calculated "urgent" due date for a task, i.e. the quantity used
for sorting the "Due" column, is wrong for a task with closed
sub-tasks.

Take these tasks:

* Task1 due:2013-12-17
   \
    '--Subtask1 due:2013-12-05 closed:2013-12-01

* Task2 due:2013-12-07

When the task browser shows these tasks, sorted as "Due ^", Task1 is
shown at the top (with due description "in 11 days") before Task2
(with due description "tomorrow").

This is because get_urgent_date() for Task1 is returning 2013-12-05,
even though that task has already been closed.

The fix is to ignore closed sub-tasks.