### PR TITLE
fix: #81 TaskView._detect_url run into infinite loop under GTK 3.14.6

### DIFF
--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -610,8 +610,9 @@ class TaskView(Gtk.TextView):
         # Now we add the tag URL
         it = start.copy()
         prev = start.copy()
-        while (it.get_offset() < end.get_offset()) and (it.get_char() != '\0'):
-            it.forward_word_end()
+        not_reach_end = not it.is_end()
+        while not_reach_end and (it.get_char() != '\0'):
+            not_reach_end = it.forward_word_end()
             prev = it.copy()
             prev.backward_word_start()
             text = buff.get_text(prev, it, True)


### PR DESCRIPTION
This bug report describes why this patch is needed for users who are using latest GTK+ release 3.14.x https://bugzilla.gnome.org/show_bug.cgi?id=742000

The original way to test whether to reach the end of text buffer by comparing the iterator's offset is not stable in GTK+ 3.14.x.

Without this patch, some tasks cannot be opened and GTG would crash due to the infinite loop.