### PR TITLE
Bugfix 83 Closed tasks remover imposes a too low limit for the days period option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@
     * Fix for bug #1078306: Not all interface can be localized, by Àlex Magaz Graça
     * Fix for bug #33: Ctrl-Q doesn't work from task windows, by Àlex Magaz Graça
     * Fixing the Tooltip for open parent, by Sagar Ghuge
+    * Fix for bug #83: Closed tasks remover imposes a too low limit for the days period option, by Àlex Magaz Graça
 
 2013-11-24 Getting Things GNOME! 0.3.1
     * Fix for bug #1024473: Have 'Show Main Window' in notification area, by Antonio Roquentin

--- a/GTG/plugins/task_reaper/reaper.ui
+++ b/GTG/plugins/task_reaper/reaper.ui
@@ -32,7 +32,7 @@
                   <object class="GtkSpinButton" id="pref_spinbtn_max_days">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="max_length">3</property>
+                    <property name="max_length">4</property>
                     <property name="invisible_char">&#x2022;</property>
                     <property name="adjustment">adjustment1</property>
                     <property name="climb_rate">0.5</property>
@@ -130,7 +130,7 @@
   </object>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">1</property>
-    <property name="upper">100</property>
+    <property name="upper">9999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>


### PR DESCRIPTION
Fixes #83