### PR TITLE
Minor error in the README.md docs instead of doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ command:
 If you want to read the documentation directly from the source code, use
 this command (from the source root dir):
 
-    $ yelp doc/userdoc/C/index.page
+    $ yelp docs/userdoc/C/index.page
 
 ### Using GTG from the command line
 


### PR DESCRIPTION
Hi, I noticed that there is a minor error in the README.md file. It has a command that says 
$ yelp doc/userdoc/C/index.page

the doc folder doesn't exist in the gtg repository, which led in me getting an error while running that so instead I changed that to  docs which is the correct name of the folder according to the gtg repository. 

$ yelp docs/userdoc/C/index.page

I hope this little change is helpful. 

