### PR TITLE
Updated documentation in GTG with most up-to-date information and adding a script to launch GTG straight from the parent directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ virtualenv:
   system_site_packages: true
 
 install:
-  - pip install -e git+git://github.com/getting-things-gnome/liblarch.git#egg=liblarch
-  - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
 
 script:
   - ./run-tests

--- a/HACKING
+++ b/HACKING
@@ -24,11 +24,8 @@ Coding style
 
 In general, follow PEP 8 <http://www.python.org/dev/peps/pep-0008/>.
 
-Not all code in GTG currently follows PEP 8. If you are changing a section of
-code, please update it to follow PEP 8.
-
 You should also avoid adding any 'flakes', simple Python mistakes caught by
-Pyflakes <http://www.divmod.org/trac/wiki/DivmodPyflakes>.
+Pyflakes <https://pypi.python.org/pypi/pyflakes>.
 
 To check the complete cleanliness of your code, run::
 
@@ -93,18 +90,18 @@ codebase by either commenting why it's disabled, or remove it.
 
 API Style
 ---------
-Whereever possible, prefer using tid/tagname instead of passing task/tag
+Whenever possible, prefer using task_id/tagname instead of passing task/tag
 objects directly.  In experimentation it's been found that passing and
 using the objects directly is very expensive.  Looking in a list of
 objects is *much* slower than looking in a list of Strings.
 
-If you create a method, try that that method take a tid/tagname as
-argument and return a tid/tagname. (of course, don't apply this
+If you create a method, try that that method take a task_id/tagname as
+argument and return a task_id/tagname. (of course, don't apply this
 blindly).
 
 As a rule of thumb, if you put objects in a list for whatever purpose,
 it should light a big warning sign ! It probably means than you have to
-use the tid/tagname instead.
+use the task_id/tagname instead.
 
 The req.get_task/get_tag methods are pretty cheap (access to a
 dictionary with Strings as keys) and, anyway, I discovered that a lot of
@@ -145,7 +142,7 @@ Submitting Patches
 ------------------
 
 For information about contributing code to GTG, see
-<http://live.gnome.org/gtg/contributing>.
+<http://gtg.readthedocs.org/en/latest/contributing.html>.
 
 
 Landing Branches
@@ -155,13 +152,10 @@ Landing Branches
 
   2. Run the tests, ``make check``.
 
-  3. Run ``make lint``, check that the number of PEP 8 warnings is lower than
-     trunk and that there are no new pyflakes warnings.
+  3. Launch GTG with debugging data, just in case, ``./gtg.sh``.
 
-  4. Launch GTG with debugging data, just in case, ``./gtg.sh``.
+  4. Update ``CHANGELOG`` if it isn't already.
 
-  5. Update ``CHANGELOG`` if it isn't already.
+  5. Update ``AUTHORS`` if the patch author is not already in there.
 
-  6. Update ``AUTHORS`` if the patch author is not already in there.
-
-  7. Commit your changes and propose a merge request.
+  6. Commit your changes and propose a merge request.

--- a/HACKING
+++ b/HACKING
@@ -14,9 +14,9 @@ the tests with ``trial GTG``.
 
 You can also manually test your changes with debugging data with::
 
-  ./scripts/debug.sh
+  ./gtg.sh
 
-Using ``debug.sh`` will prevent GTG from messing with your real data. Instead,
+Using ``gtg.sh`` will prevent GTG from messing with your real data. Instead,
 the debug GTG will store data in ``./tmp/default/``.
 
 Unit tests live in ``GTG/tests/``, and are all named ``test_foo``. When you
@@ -195,7 +195,7 @@ Landing Branches
   3. Run ``make lint``, check that the number of PEP 8 warnings is lower than
      trunk and that there are no new pyflakes warnings.
 
-  4. Launch GTG with debugging data, just in case, ``./scripts/debug.sh``.
+  4. Launch GTG with debugging data, just in case, ``./gtg.sh``.
 
   5. Update ``CHANGELOG`` if it isn't already.
 

--- a/HACKING
+++ b/HACKING
@@ -9,9 +9,6 @@ You can run the unit tests for GTG with::
 
   make check
 
-If you are so inclined and have the right software installed, you can also run
-the tests with ``trial GTG``.
-
 You can also manually test your changes with debugging data with::
 
   ./gtg.sh
@@ -19,36 +16,7 @@ You can also manually test your changes with debugging data with::
 Using ``gtg.sh`` will prevent GTG from messing with your real data. Instead,
 the debug GTG will store data in ``./tmp/default/``.
 
-Unit tests live in ``GTG/tests/``, and are all named ``test_foo``. When you
-add a new test module, make sure it has a ``test_suite()`` method that returns
-the suite of all the tests in that module. Also make sure that the new module
-is imported in ``GTG.tests`` and returned from the ``test_suite()`` function
-there.
-
-For example, GTG/tests/test_newthing.py::
-
-  import unittest
-
-  class TestNewThing(unittest.TestCase):
-      # ...
-
-  def test_suite():
-      return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-And GTG/tests/__init__.py::
-
-  import unittest
-
-  from GTG.tests import test_backends, test_newthing
-
-  def test_suite():
-      return unittest.TestSuite([
-          test_backends.test_suite(),
-          test_newthing.test_suite(),
-          ])
-
-When in doubt, copy from an existing test module!
+Unit tests live in ``tests/``.
 
 
 Coding style
@@ -62,23 +30,18 @@ code, please update it to follow PEP 8.
 You should also avoid adding any 'flakes', simple Python mistakes caught by
 Pyflakes <http://www.divmod.org/trac/wiki/DivmodPyflakes>.
 
-To check the cleanliness of your code, run::
+To check the complete cleanliness of your code, run::
 
-  make lint
+  $ make check
 
-The ``make`` will fail if Pyflakes emits any warnings. You can the Pyflakes
-checker separately using ``make pyflakes`` and the PEP 8 checker using ``make
-pep8``. If you wish to find all PEP 8 violations in a particular file, use::
-
-  ./scripts/pep8.py --repeat FILENAME
 
 
 Commenting-out Code
 -------------------
-Try to avoid leaving commented out code in the codebase.  Or at least,
-if some code must be left commented out, also include a comment
-or TODO or FIXME explaining why it was disabled.  If possible include a
-bug lp#.
+Try to avoid leaving commented out code in the codebase. 
+IT IS NOT A GOOD PRACTICE! 
+Or at least, if some code must be left commented out, also include a comment
+or TODO or FIXME explaining why it was disabled.  
 
 Some common reasons why one might create commented code are:
 
@@ -93,7 +56,7 @@ Obviously none of these are great situations to be in, but it happens.
 
 Ideally, commenting out a line of code should be a signal to yourself
 that one of these things has happened, and that you probably should ask
-for help before merging it to trunk, and it should stay in a branch for
+for help before merging it to master, and it should stay in a branch for
 now.
 
 But that may not always be possible.  So more practically, when

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Getting Things GNOME!
 
-[![Build Status](https://travis-ci.org/getting-things-gnome/gtg.svg?branch=master)](https://travis-ci.org/getting-things-gnome/gtg)
-
 Getting Things GNOME! (GTG) is a personal tasks and TODO list items organizer
 for the GNOME desktop environment inspired by the Getting Things Done (GTD)
 methodology. GTG is designed with flexibility, adaptability, and ease of use
@@ -10,31 +8,51 @@ in mind so it can be used as more than just GTD software.
 GTG is intended to help you track everything you need to do and need to know,
 from small tasks to large projects.
 
-## Dependencies
+## INSTALLING AND RUNNING
 
-GTG depends on the following packages:
+In order to download and run GTG Developer Version, do the following steps 
+(Debian-based systems):
 
- * Python, version 3.0 or above
- * PyGTK
- * python-support
- * python-xdg
- * python-dbus
- * python-liblarch 
- * yelp (to read GTG documentation)
+DOWNLOAD: 
+Execute this command to get the latest Developer package:
 
-Please refer to your system documentation for information on how to install
-these modules if they're not currently available.
+	$ git clone https://github.com/getting-things-gnome/gtg.git
 
-To install the all the required packages providing the basic features on
-Debian-based systems, execute the following command:
-    $ sudo apt-get install python-support python-gtk2 python-gnome2 \
-         python-glade2 python-xdg python-dbus python-liblarch yelp
+RUNNING: 
+At first, install python3 dependencies by typing the following command:
+ 
+	$ sudo apt-get install python3-pip
+
+Running of this developer version of GTG will not be possible without installing 
+liblarch at first so clone and install liblarch:
+
+	$ git clone https://github.com/getting-things-gnome/liblarch.git
+
+	$ cd path/to/liblarch
+
+	$ sudo python3 setup.py install
+
+RUN:
+In order to run GTG from this Developers repository, you need to launch the debug.sh script:
+
+	$ cd path/to/gtg
+
+	$ ./scripts/debug.sh
+
+Getting Things GNOME launches.
+
+If prompted, you may be required to install also python-xdg and python-dbus packages manually. Simply write a command:
+
+	$ sudo apt-get install python-xdg python-dbus
+
+Run the script again.
+
 
 There are additional plugins (modules for extending the user interface) and
 synchronization services (modules for importing/exporting tasks from/to
 external services) which needs additional packages to work correctly.
 
-### Dependencies for Plugins
+### DEPENDENCIES FOR PLUGINS
 
 "Bugzilla" plugin dependencies:
   * python-bugz
@@ -46,7 +64,7 @@ external services) which needs additional packages to work correctly.
   * pdfjam
 
 Installable on Debian-based system via
-    $ sudo apt-get install python-cheetah pdftk pdfjam texlive-latex-base
+    	$ sudo apt-get install python-cheetah pdftk pdfjam texlive-latex-base
 
 "Geolocalized tasks" plugin is not maintained for a long time and needs to be
 rewritten from scratch. Dependencies:
@@ -71,7 +89,7 @@ python-dbus
 
 "Urgency Color" plugin does not have any external dependencies.
 
-### Dependencies for Synchronization Services
+### DEPENDENCIES FOR SYNCHRONIZATION SERVICES
 
 Evolution synchronization service has dependencies:
   * python-evolution
@@ -96,29 +114,7 @@ Remember the Milk synchronization service is shipped with a library for RTM api.
 
 Remember the Milk is not maintained for a long time and might be potentially harmful.
 
-## Installing and Running
-
-To install GTG, either unpack the tarball:
-
-    $ tar xzvf gtg.tar.gz
-
-or check out our bazaar branch for a development version (we try to keep those
-unbroken and ready for production use):
-
-    $ bzr branch lp:gtg
-
-To run GTG, either execute it directly from the source folder:
-
-    $ cd gtg/
-    $ ./gtg
-
-or install it system-wide (must install as root to install system-wide):
-
-    $ cd gtg
-    $ sudo python setup.py install # must be root to install system-wide
-    $ gtg
-
-### How To Use GTG?
+### HOW TO USE GTG?
 
 Please refer to our documentation to get a thorough explanation on how GTG
 works.
@@ -139,7 +135,7 @@ this command (from the source root dir):
 
     $ yelp docs/userdoc/C/index.page
 
-### Using GTG from the command line
+### USING GTG FROM COMMAND LINE
 
 GTG provides two command line tools that allows to interact with GTG:
 
@@ -157,14 +153,15 @@ If you have installed gtg, you can access those by executing:
     $ man gtcli
     $ man gtg_new_task
 
-## Want to know more?
+## WANT TO KNOW MORE?
 
  * GTG Website: http://gtgnome.net/
+ * GTG GitHub latest repository: https://github.com/getting-things-gnome/gtg
  * GTG project page on Launchpad: https://launchpad.net/gtg
  * GTG Wiki: http://live.gnome.org/gtg/
  * GTG developer's documentation: http://gtg.readthedocs.org/en/latest/index.html
 
 Feel free to join our user mailing-list to receive news about GTG. You can
-register on this mailing-list from this page: https://launchpad.net/~gtg-user
+register to our mailing-list from this page: https://launchpad.net/~gtg-user
 
 Thanks for using GTG!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ DOWNLOAD:
 Execute this command to get the latest Developer package and then move to that directory:
 
 	$ git clone https://github.com/getting-things-gnome/gtg.git
-
   $ cd gtg
 
 RUNNING: 
@@ -75,7 +74,7 @@ which supports indicators:
 "Closed tasks remover" plugin does not have any external dependencies.
 
 "Tomboy/Gnote" plugin needs a running instance of Tomboy or Gnote.
-python3-dbus
+  * python3-dbus
 
 "Urgency Color" plugin does not have any external dependencies.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Getting Things GNOME!
 
+[![Build Status](https://travis-ci.org/getting-things-gnome/gtg.svg?branch=master)](https://travis-ci.org/getting-things-gnome/gtg)
+
 Getting Things GNOME! (GTG) is a personal tasks and TODO list items organizer
 for the GNOME desktop environment inspired by the Getting Things Done (GTD)
 methodology. GTG is designed with flexibility, adaptability, and ease of use
@@ -26,24 +28,20 @@ At first, install python3 dependencies by typing the following command:
 Running of this developer version of GTG will not be possible without installing 
 liblarch at first so clone and install liblarch:
 
-	$ git clone https://github.com/getting-things-gnome/liblarch.git
-
-	$ cd path/to/liblarch
-
-	$ sudo python3 setup.py install
+	$ pip3 install -r requirements.txt
 
 RUN:
 In order to run GTG from this Developers repository, you need to launch the debug.sh script:
 
 	$ cd path/to/gtg
 
-	$ ./scripts/debug.sh
+	$ ./gtg.sh
 
 Getting Things GNOME launches.
 
-If prompted, you may be required to install also python-xdg and python-dbus packages manually. Simply write a command:
+If prompted, you may be required to install also python3-xdg and python3-dbus packages manually. Simply write a command:
 
-	$ sudo apt-get install python-xdg python-dbus
+	$ sudo apt-get install python3-xdg python3-dbus
 
 Run the script again.
 
@@ -55,54 +53,54 @@ external services) which needs additional packages to work correctly.
 ### DEPENDENCIES FOR PLUGINS
 
 "Bugzilla" plugin dependencies:
-  * python-bugz
+  * python3-bugz
 
 "Export and print" plugin dependencies:
-  * python-cheetah
+  * python3-cheetah
   * pdflatex
   * pdftk
   * pdfjam
 
 Installable on Debian-based system via
-    	$ sudo apt-get install python-cheetah pdftk pdfjam texlive-latex-base
+    	$ sudo apt-get install python3-cheetah pdftk pdfjam texlive-latex-base
 
 "Geolocalized tasks" plugin is not maintained for a long time and needs to be
 rewritten from scratch. Dependencies:
-  * python-geoclue
-  * python-clutter
-  * python-clutter-gtk
-  * python-champlain
-  * python-champlain-gtk
+  * python3-geoclue
+  * python3-clutter
+  * python3-clutter-gtk
+  * python3-champlain
+  * python3-champlain-gtk
 
 "Hamster Time Tracker Integration" plugin needs a running instance of Hamster.
 
 "Notification area" plugin has only an optional dependence for systems
 which supports indicators:
-  * python-appindicator
+  * python3-appindicator
 
 "Send task via email" plugin does not have any external dependencies.
 
 "Closed tasks remover" plugin does not have any external dependencies.
 
 "Tomboy/Gnote" plugin needs a running instance of Tomboy or Gnote.
-python-dbus
+python3-dbus
 
 "Urgency Color" plugin does not have any external dependencies.
 
 ### DEPENDENCIES FOR SYNCHRONIZATION SERVICES
 
 Evolution synchronization service has dependencies:
-  * python-evolution
-  * python-dateutil
+  * python3-evolution
+  * python3-dateutil
 
 Because of a bug in PyGTK (see https://bugs.launchpad.net/gtg/+bug/936183),
 the synchronization service freezes GTG and the synchronization service can't be used.
 
 MantisBT synchronization service has a dependency:
-  * python-suds
+  * python3-suds
 
 Launchpad synchronization service has a dependency:
-  * python-launchpadlib
+  * python3-launchpadlib
 
 Gnote and Tomboy synchronization services has no external dependency.
 
@@ -110,7 +108,7 @@ Identica and Twitter synchronization services are shipped with the local
 version of Tweety library.
 
 Remember the Milk synchronization service is shipped with a library for RTM api. It has an external dependency:
-  * python-dateutil
+  * python3-dateutil
 
 Remember the Milk is not maintained for a long time and might be potentially harmful.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ In order to download and run GTG Developer Version, do the following steps
 (Debian-based systems):
 
 DOWNLOAD: 
-Execute this command to get the latest Developer package:
+Execute this command to get the latest Developer package and then move to that directory:
 
 	$ git clone https://github.com/getting-things-gnome/gtg.git
+
+  $ cd gtg
 
 RUNNING: 
 At first, install python3 dependencies by typing the following command:
@@ -32,8 +34,6 @@ liblarch at first so clone and install liblarch:
 
 RUN:
 In order to run GTG from this Developers repository, you need to launch the debug.sh script:
-
-	$ cd path/to/gtg
 
 	$ ./gtg.sh
 
@@ -63,14 +63,6 @@ external services) which needs additional packages to work correctly.
 
 Installable on Debian-based system via
     	$ sudo apt-get install python3-cheetah pdftk pdfjam texlive-latex-base
-
-"Geolocalized tasks" plugin is not maintained for a long time and needs to be
-rewritten from scratch. Dependencies:
-  * python3-geoclue
-  * python3-clutter
-  * python3-clutter-gtk
-  * python3-champlain
-  * python3-champlain-gtk
 
 "Hamster Time Tracker Integration" plugin needs a running instance of Hamster.
 

--- a/README.md
+++ b/README.md
@@ -18,29 +18,29 @@ In order to download and run GTG Developer Version, do the following steps
 DOWNLOAD: 
 Execute this command to get the latest Developer package and then move to that directory:
 
-	$ git clone https://github.com/getting-things-gnome/gtg.git
-  $ cd gtg
+    $ git clone https://github.com/getting-things-gnome/gtg.git
+    $ cd gtg
 
 RUNNING: 
 At first, install python3 dependencies by typing the following command:
  
-	$ sudo apt-get install python3-pip
+    $ sudo apt-get install python3-pip
 
 Running of this developer version of GTG will not be possible without installing 
 liblarch at first so clone and install liblarch:
 
-	$ pip3 install -r requirements.txt
+    $ pip3 install -r requirements.txt
 
 RUN:
 In order to run GTG from this Developers repository, you need to launch the debug.sh script:
 
-	$ ./gtg.sh
+    $ ./gtg.sh
 
 Getting Things GNOME launches.
 
 If prompted, you may be required to install also python3-xdg and python3-dbus packages manually. Simply write a command:
 
-	$ sudo apt-get install python3-xdg python3-dbus
+    $ sudo apt-get install python3-xdg python3-dbus
 
 Run the script again.
 
@@ -61,7 +61,8 @@ external services) which needs additional packages to work correctly.
   * pdfjam
 
 Installable on Debian-based system via
-    	$ sudo apt-get install python3-cheetah pdftk pdfjam texlive-latex-base
+    
+    $ sudo apt-get install python3-cheetah pdftk pdfjam texlive-latex-base
 
 "Hamster Time Tracker Integration" plugin needs a running instance of Hamster.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -2,17 +2,11 @@
 Contributing to GTG
 ===================
 
-GTG uses GitHub_ for versioning. It might be useful to read `GitHub's Guide`_ first.
+GTG uses Git_ for versioning. It might be useful to take a look at this `Git tutorial`_ first.
 
-.. _GitHub: https://github.com/
-.. _`GitHub's Guide`: https://guides.github.com/
+.. _Git: https://git-scm.com/
+.. _`Git tutorial`: https://learnxinyminutes.com/docs/git/
 
-Dependencies
-============
-
-You need to have python3 installed. For complete info look at README_.
-
-.. _README: https://github.com/getting-things-gnome/gtg/blob/master/README.md
 
 Getting the code
 ================
@@ -34,11 +28,11 @@ Choosing a feature to work on
 
 If you are a happy user of GTG and nothing bothers you but you would like to contribute you can:
 
-* choose a bug from our `Bugs list`_ and try to solve
+* choose a bug from our `Love bugs list`_ and try to solve
 * ask people on IRC channel #gtg on irc://irc.gimp.org/#gtg
 * ask on our `mailing list`_
 
-.. _`Bugs list`: https://github.com/getting-things-gnome/gtg/issues
+.. _`Love bugs list`: https://github.com/getting-things-gnome/gtg/labels/love
 .. _`mailing list`: https://launchpad.net/~gtg-user
 
 
@@ -50,8 +44,6 @@ local branch of your local branch (yes, it is)::
 
     $ cd path/to/gtg
     $ git checkout -b cool-new-feature
-
-(your *master* folder is branched in a new *cool-new-feature* folder)
 
 When working with GitHub, it's a good idea to keep your local *master* branch as
 a pristine copy of master on GitHub.
@@ -102,10 +94,9 @@ important and ensures we are not letting a patch rotting.
 
 You can file a bug at https://github.com/getting-things-gnome/gtg/issues/new
 
-If your branch is solving specific reported bugs, please also register your
-branch to these bugs. It allows to link together all related resources (which 
-in turn is useful to dig out precious information from all the discussions that 
-happened around those bugs).
+If your branch is solving specific reported issue, please include the number of the issue
+in the commit message or the pull request description. This will enable others to 
+quickly navigate to the issue being solved.
 
 For more detailed information, see the `HACKING`_ guide included in the GTG code.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -2,49 +2,43 @@
 Contributing to GTG
 ===================
 
-GTG uses Bazaar_ for versioning. It might be useful to read `Bazaar's tutorial`_ first.
+GTG uses GitHub_ for versioning. It might be useful to read `GitHub's Guide`_ first.
 
-.. _Bazaar: http://bazaar.canonical.com/
-.. _`Bazaar's tutorial`: http://doc.bazaar.canonical.com/latest/en/mini-tutorial/
+.. _GitHub: https://github.com/
+.. _`GitHub's Guide`: https://guides.github.com/
 
 Dependencies
 ============
 
-You need to have python-configobj installed
+You need to have python3 installed. For complete info look at README_.
+
+.. _README: https://github.com/getting-things-gnome/gtg/blob/master/README.md
 
 Getting the code
 ================
 
-Get the latest version of the code on Launchpad_::
+Get the latest version of the code on GitHub_. We suggest forking the master branch at first.
+Then clone the forked master to your local::
 
-    $ bzr branch lp:gtg trunk
+    $ git clone https://github.com/YOUR_GITHUB_USERNAME/gtg.git
 
-Although if you're thinking of contributing more than one patch, you might want to do::
+Launch GTG with debugging data (so it doesn't mess with your data)::
 
-    $ bzr init-repo gtg
-    $ cd gtg
-    $ bzr branch lp:gtg trunk
+    $ cd path/to/gtg
+    $ ./gtg.sh
 
-This will share revision data between branches, reducing storage costs & network time.
-
-
-Launch gtg with debugging data (so it doesn't mess with your data)::
-
-    $ cd trunk
-    $ ./scripts/debug.sh
-
-.. _Launchpad: https://launchpad.net
+.. _GitHub: https://github.com/getting-things-gnome/gtg
 
 Choosing a feature to work on
 =============================
 
 If you are a happy user of GTG and nothing bothers you but you would like to contribute you can:
 
-* choose a `LOVE bug`_ which are easier to solve
+* choose a bug from our `Bugs list`_ and try to solve
 * ask people on IRC channel #gtg on irc://irc.gimp.org/#gtg
 * ask on our `mailing list`_
 
-.. _`LOVE bug`: https://bugs.launchpad.net/gtg/+bugs?field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&assignee_option=none&field.tag=love
+.. _`Bugs list`: https://github.com/getting-things-gnome/gtg/issues
 .. _`mailing list`: https://launchpad.net/~gtg-user
 
 
@@ -54,17 +48,18 @@ Working on the feature in a branch
 You have your local copy of the code (see "Getting the code"). Now, create a
 local branch of your local branch (yes, it is)::
 
-    $ cd ..
-    $ bzr branch trunk cool-new-feature
+    $ cd path/to/gtg
+    $ git checkout -b cool-new-feature
 
-(your *trunk* folder is branched in a new *cool-new-feature* folder)
+(your *master* folder is branched in a new *cool-new-feature* folder)
 
-When working with Bazaar, it's a good idea to keep your local *trunk* branch as
-a pristine copy of trunk on Launchpad.
+When working with GitHub, it's a good idea to keep your local *master* branch as
+a pristine copy of master on GitHub.
 
-Hack and commit your changes::
+Hack, add and commit your changes::
 
-    bzr commit -m "description of my change"
+    $ git add names_of_changed_files
+    $ git commit -m "description of your changes"
 
 Repeat as much as you want. Don't hesitate to abuse the local commits. Think of
 *commit* like *quick save* in a video game :)
@@ -82,59 +77,37 @@ Run the units tests to see if all is fine::
 Modify CHANGELOG to reflect your changes. If it's your first contribution, add
 yourself in the AUTHORS file with your email address.
 
-If the trunk has been updated while you were hacking, you should update your
-local trunk branch, and merge modification in **your** branch::
+If the master has been updated while you were hacking, you should update your
+local master branch, and merge modification in **your** branch::
 
-    $ cd ../trunk
-    $ bzr pull trunk
-    $ cd ../cool-new-feature
-    $ bzr merge ../trunk
+    $ git checkout master
+    $ git pull origin master
+    $ git checkout cool-new-feature
+    $ git merge master
 
-If you have conflicts, you must solve them. Refer to `conflicts guide`_.
 
-.. _`conflicts guide`: http://doc.bazaar.canonical.com/bzr.0.92/en/user-guide/conflicts.html
+When you have done some changes or solved a bug, add and commit the changes.
+Afterwards, you need to push your work to your own fork on GitHub (where cool-new-feature
+is the name of your local branch which you changed.)::
 
-Once you don't have any conflict anymore, you must commit the changes related
-to the merge. Use a clear commit message, like::
+    $ git push origin cool-new-feature
 
-    Updating branch by merging the last trunk version.
+If you have made changes and pushed them to your forked master branch on GitHub,
+you can do a pull request to merge your work with the original GTG master.
+To do this, go to your account on GitHub and click on "New Pull Request".
 
-Pushing your work to your own branch on Launchpad (where *ploum* is your
-Launchpad username)::
-
-    $ bzr push lp:~ploum/gtg/cool-new-feature
-
-Alternatively, if you want other gtg users to be able to write to your branch,
-push it in the gtg-user group (you have to be part of it)::
-
-    $ bzr push lp:~gtg-user/gtg/ploum_branch
-
-Ask for a merge request and comment on the corresponding bug. (Open one if
-there is none). Add the tag *toreview* to the bug in Launchpad. This is very
+Create a pull request and comment on the corresponding bug. (Open one if
+there is none). Add the tag *toreview* to the bug in GitHub. This is very
 important and ensures we are not letting a patch rotting.
 
-You can file a bug at https://bugs.launchpad.net/gtg/+filebug.
-
-To ask for a merge request, run::
-
-$ cd cool-new-feature
-$ bzr lp-open
-
-This will open the branch's web page on Launchpad. From there, click *Propose for merging*.
+You can file a bug at https://github.com/getting-things-gnome/gtg/issues/new
 
 If your branch is solving specific reported bugs, please also register your
-branch to these bugs (there is an link for that in each bug report page). It
-allows to link together all related resources (which in turn is useful to dig
-out precious information from all the discussions that happened around those
-bugs).
+branch to these bugs. It allows to link together all related resources (which 
+in turn is useful to dig out precious information from all the discussions that 
+happened around those bugs).
 
 For more detailed information, see the `HACKING`_ guide included in the GTG code.
 
-.. _`HACKING`: http://bazaar.launchpad.net/~gtg/gtg/trunk/annotate/head%3A/HACKING
+.. _`HACKING`: https://github.com/getting-things-gnome/gtg/blob/master/HACKING
 
-Troubleshooting
-===============
-
-If you have a problem with SSH keys while uploading to Launchpad, look at this `SuperUser question`_.
-
-.. _`SuperUser question`: http://superuser.com/questions/161337/big-ssh-problem

--- a/gtg.sh
+++ b/gtg.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
 exec ./scripts/debug.sh
-
-	

--- a/gtg.sh
+++ b/gtg.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
+# This script allows contributors to run GTG directly from the gtg directory without the need to navigate
+# to the scripts folder. 
+# It refers to the GTG debug script originally placed in /scripts/debug.sh.
+# Makes life much easier.
+
 exec ./scripts/debug.sh

--- a/gtg.sh
+++ b/gtg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+exec ./scripts/debug.sh
+
+	

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose
 spec
 pyxdg
+-e git+git://github.com/getting-things-gnome/liblarch.git#egg=liblarch


### PR DESCRIPTION
README was outdated and contained misleading information.
I have updated it so that it is more informative and can be used easily in order to run the developer's version for new-comers.

