### PR TITLE
Fix whitespace error in browser.py

### DIFF
--- a/GTG/gtk/browser/browser.py
+++ b/GTG/gtk/browser/browser.py
@@ -1246,8 +1246,8 @@ class TaskBrowser(GObject.GObject):
         """Updates the status of the selection in active tasks.
         Unselects all closed tasks."""
 
-        if selection.count_selected_rows() > 0 and
-        		'closed' in self.vtree_panes:
+        if selection.count_selected_rows() > 0 and \
+            'closed' in self.vtree_panes:
             self.vtree_panes['closed'].get_selection().unselect_all()
             self.update_task_status(Task.STA_ACTIVE)
         if self.get_selected_task() is None:


### PR DESCRIPTION
Fixes the following error:

    $ ./gtg.sh 
    Setting XDG vars to use default dataset.
    
    ** (gtg:15976): WARNING **: Couldn't register with accessibility bus: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
    Traceback (most recent call last):
      File "./GTG/gtg", line 62, in <module>
        from GTG.gtk.manager import Manager
      File "/home/shtrom/src/archlinux-packages/gtg-git/src/gtg-git/GTG/gtk/manager.py", line 28, in <module>
        from GTG.gtk.browser.browser import TaskBrowser
      File "/home/shtrom/src/archlinux-packages/gtg-git/src/gtg-git/GTG/gtk/browser/browser.py", line 1249
        if selection.count_selected_rows() > 0 and
                                                 ^
    SyntaxError: invalid syntax


Signed-off-by: Olivier Mehani <shtrom@ssji.net>
