### PR TITLE
Headerbar implementation into GTG!

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -29,6 +29,8 @@ from GTG.core.dirs import CONFIG_DIR
 from GTG.tools.logger import Log
 
 DEFAULTS = {
+    # TODO: Remove toolbar and quick_add options from configuration
+    # They won't be used in GTG 0.4
     'browser': {
         "bg_color_enable": True,
         "contents_preview_enable": False,

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -6,531 +6,200 @@
     <property name="title" translatable="yes">Getting Things GNOME!</property>
     <property name="default_width">700</property>
     <property name="default_height">550</property>
-    <signal name="configure-event" handler="on_move" swapped="no"/>
-    <signal name="size-allocate" handler="on_size_allocate" swapped="no"/>
+    <signal handler="on_move" name="configure-event" swapped="no"/>
+    <signal handler="on_size_allocate" name="size-allocate" swapped="no"/>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="visible">True</property>
+        <property name="show_close_button">True</property>
+        <property name="title" translatable="yes">Tasks</property>
+        <child>
+          <object class="GtkButton" id="new_task">
+            <property name="visible">True</property>
+            <property name="sensitive">True</property>
+            <property name="label" translatable="yes">New Task</property>
+            <property name="tooltip_text" translatable="yes">Create a new task</property>
+            <property name="valign">center</property>
+            <signal handler="on_add_task" name="clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="pack_type">start</property>
+          </packing>
+          <style>
+            <class name="text-button"/>
+          </style>
+        </child>
+        <child>
+          <object class="GtkBox" id="customisation_box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="has_focus">False</property>
+            <property name="is_focus">False</property>
+            <property name="spacing">1</property>
+            <child>
+              <object class="GtkButton" id="settings">
+                <property name="visible">True</property>
+                <property name="label">Settings</property>
+                <property name="sensitive">True</property>
+                <property name="tooltip_text" translatable="yes">Settings/Preferences
+                    </property>
+                <signal handler="on_preferences_activate" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="tags">
+                <property name="visible">True</property>
+                <property name="label">Tags</property>
+                <property name="sensitive">True</property>
+                <property name="tooltip_text" translatable="yes">Tags Sidebar
+                       </property>
+                <signal handler="on_view_sidebar_toggled" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">start</property>
+          </packing>
+        </child>
+        <child type="title">
+          <object class="GtkBox" id="stack_switcher_box">
+            <property name="visible">True</property>
+            <property name="spacing">1</property>
+            <child>
+              <object class="GtkButton" id="normal_view">
+                <property name="visible">True</property>
+                <property name="label" translatable="yes">Active Tasks</property>
+                <property name="tooltip_text" translatable="yes">Normal, active tasks</property>
+                <signal handler="temp_active_view" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="work_view">
+                <property name="visible">True</property>
+                <property name="label" translatable="yes">Actionable Tasks</property>
+                <property name="tooltip_text" translatable="yes">WorkView</property>
+                <signal handler="temp_workview" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="closed_tasks">
+                <property name="visible">True</property>
+                <property name="label" translatable="yes">Closed Tasks</property>
+                <property name="tooltip_text" translatable="yes">View Closed Tasks</property>
+                <signal handler="on_view_closed_toggled" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="search">
+            <property name="visible">True</property>
+            <property name="sensitive">True</property>
+            <property name="tooltip_text" translatable="yes">Activate Search Entry</property>
+            <signal handler="temporary_search" name="clicked" swapped="no"/>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkImage" id="search_icon">
+                <property name="visible">True</property>
+                <property name="icon-name">edit-find-symbolic</property>
+                <property name="icon-size">1</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+          </packing>
+          <style>
+            <class name="image-button"/>
+          </style>
+        </child>
+        <child>
+          <object class="GtkBox" id="extras_box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="has_focus">False</property>
+            <property name="is_focus">False</property>
+            <property name="spacing">1</property>
+            <child>
+              <object class="GtkButton" id="plugins">
+                <property name="visible">True</property>
+                <property name="label">Plugins</property>
+                <property name="sensitive">True</property>
+                <property name="tooltip_text" translatable="yes">Add plugins</property>
+                <signal handler="on_edit_plugins_activate" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="synchronisation">
+                <property name="visible">True</property>
+                <property name="label">Synchronisation</property>
+                <property name="sensitive">True</property>
+                <property name="tooltip_text" translatable="yes">Synchronisation Services
+                     </property>
+                <signal handler="on_edit_backends_activate" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+              </object>
+              <style>
+                <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+          </packing>
+        </child>
+      </object>
+    </child>
     <child>
       <object class="GtkBox" id="master_vbox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkMenuBar" id="browser_menu">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkMenuItem" id="bm_task">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Tasks</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="tasks_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="new_task_mi">
-                        <property name="label" translatable="yes">New _Task</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Create a new task</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">bm_img_task</property>
-                        <property name="use_stock">False</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="activate" handler="on_add_task" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="new_subtask_mi">
-                        <property name="label" translatable="yes">New _Subtask</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">bm_img_subtask</property>
-                        <property name="use_stock">False</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="activate" handler="on_add_subtask" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="edit_mi">
-                        <property name="label">gtk-edit</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_edit_active_task" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="done_mi">
-                        <property name="label" translatable="yes">Mark as _Done</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">bm_img_done</property>
-                        <property name="use_stock">False</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="dismiss_mi">
-                        <property name="label" translatable="yes">D_ismiss</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">bm_img_dismiss</property>
-                        <property name="use_stock">False</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="delete_mi">
-                        <property name="label">gtk-delete</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_delete_task" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="file_quit">
-                        <property name="label">gtk-quit</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="gtk_main_quit" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="bm_edit">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Edit</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="edit_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="edit_undo">
-                        <property name="label">gtk-undo</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="edit_redo">
-                        <property name="label">gtk-redo</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_3">
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="plugins_mi">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">P_lugins</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_edit_plugins_activate" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="backends_mi">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">_Synchronization Services</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_edit_backends_activate" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="edit_preferences_mi">
-                        <property name="label">gtk-preferences</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_preferences_activate" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="menu_view">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_View</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="view_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="view_workview">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Work View</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_view_workview_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="view_sidebar">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Tags Sidebar</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_view_sidebar_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="view_closed">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Closed Tasks Pane</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_view_closed_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="view_toolbar">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">T_oolbar</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_view_toolbar_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="view_quickadd">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Quick Add Entry</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_view_quickadd_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="plugin_mi">
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Plugins</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="plugins_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="help_mi">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Help</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="help_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="help_contents">
-                        <property name="label">Contents</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Open GTG help</property>
-                        <property name="image">image7</property>
-                        <property name="use_stock">False</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_documentation_clicked" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_11">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="launchpad_translate">
-                        <property name="label">_Translate GTG</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Help to translate GTG into your language</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_translate_clicked" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="launchpad_report_bug">
-                        <property name="label">_Report a Problem</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Report a problem to GTG developers</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_report_bug_clicked" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator_12">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="gtk_about_mi">
-                        <property name="label">gtk-about</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
-                        <signal name="activate" handler="on_about_clicked" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="vbox_toolbars">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkToolbar" id="task_toolbar">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkToolButton" id="new_task_b">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">New Task</property>
-                    <property name="stock_id">gtk-new</property>
-                    <signal name="clicked" handler="on_add_task" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="new_subtask_b">
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">New Subtask</property>
-                    <property name="icon_name">gtk-new</property>
-                    <signal name="clicked" handler="on_add_subtask" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="edit_b">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="visible_horizontal">False</property>
-                    <property name="visible_vertical">False</property>
-                    <property name="label" translatable="yes">Edit</property>
-                    <property name="stock_id">gtk-edit</property>
-                    <signal name="clicked" handler="on_edit_active_task" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSeparatorToolItem" id="&lt;separateur&gt;">
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="Undo">
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Undo</property>
-                    <property name="stock_id">gtk-undo</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="Redo">
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Redo</property>
-                    <property name="stock_id">gtk-redo</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSeparatorToolItem" id="separator_6">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="done_b">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Mark as Done</property>
-                    <property name="stock_id">gtk-apply</property>
-                    <signal name="clicked" handler="on_mark_as_done" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="dismiss_b">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Dismiss</property>
-                    <property name="stock_id">gtk-close</property>
-                    <signal name="clicked" handler="on_dismiss_task" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton" id="delete_b">
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Delete</property>
-                    <property name="icon_name">edit-delete</property>
-                    <signal name="clicked" handler="on_delete_task" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSeparatorToolItem" id="separator_7">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToggleToolButton" id="workview_toggle">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Work View</property>
-                    <property name="stock_id">gtk-index</property>
-                    <signal name="toggled" handler="on_workview_toggled" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkPaned" id="hpaned1">
             <property name="visible">True</property>
@@ -576,7 +245,7 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="relief">none</property>
-                        <signal name="clicked" handler="on_view_sidebar_toggled" swapped="no"/>
+                        <signal handler="on_view_sidebar_toggled" name="clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="sidebar_img_close">
                             <property name="visible">True</property>
@@ -655,11 +324,12 @@
                         <property name="is_focus">True</property>
                         <property name="can_default">True</property>
                         <property name="invisible_char">●</property>
+                        <property name="tooltip_text">You can create, open or filter your tasks here</property>
                         <property name="secondary_icon_stock">gtk-clear</property>
                         <property name="primary_icon_activatable">False</property>
-                        <signal name="changed" handler="on_quickadd_field_changed" swapped="no"/>
-                        <signal name="activate" handler="on_quickadd_field_activate" swapped="no"/>
-                        <signal name="icon-press" handler="on_quickadd_field_icon_press" swapped="no"/>
+                        <signal handler="on_quickadd_field_changed" name="changed" swapped="no"/>
+                        <signal handler="on_quickadd_field_activate" name="activate" swapped="no"/>
+                        <signal handler="on_quickadd_field_icon_press" name="icon-press" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -770,8 +440,8 @@ You should have received a copy of the GNU General Public License along with Get
 Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
     <property name="logo_icon_name">gtg</property>
     <property name="wrap_license">True</property>
-    <signal name="delete-event" handler="on_about_delete" swapped="no"/>
-    <signal name="response" handler="on_about_close" swapped="no"/>
+    <signal handler="on_about_delete" name="delete-event" swapped="no"/>
+    <signal handler="on_about_close" name="response" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="about_dialog_vbox">
         <property name="visible">True</property>
@@ -830,7 +500,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
         <property name="accel_group">accelgroup1</property>
-        <signal name="activate" handler="on_edit_done_task" swapped="no"/>
+        <signal handler="on_edit_done_task" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -848,7 +518,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="image">ctcm_img_mark_not_done</property>
         <property name="use_stock">False</property>
         <property name="always_show_image">True</property>
-        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
+        <signal handler="on_mark_as_done" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -860,7 +530,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="image">tcm_img_undismiss</property>
         <property name="use_stock">True</property>
         <property name="always_show_image">True</property>
-        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
+        <signal handler="on_dismiss_task" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -871,7 +541,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
         <property name="accel_group">accelgroup1</property>
-        <signal name="activate" handler="on_delete_task" swapped="no"/>
+        <signal handler="on_delete_task" name="activate" swapped="no"/>
       </object>
     </child>
   </object>
@@ -922,7 +592,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
   </object>
   <object class="GtkEntryCompletion" id="quickadd_entrycompletion">
     <property name="popup_set_width">False</property>
-    <signal name="action-activated" handler="on_quickadd_entrycompletion_action_activated" swapped="no"/>
+    <signal handler="on_quickadd_entrycompletion_action_activated" name="action-activated" swapped="no"/>
   </object>
   <object class="GtkMenu" id="task_context_menu">
     <property name="visible">True</property>
@@ -933,10 +603,10 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="use_underline">True</property>
-	<property name="image">tcm_img_add_subtask</property>
+        <property name="image">tcm_img_add_subtask</property>
         <property name="use_stock">False</property>
         <property name="always_show_image">True</property>
-        <signal name="activate" handler="on_add_subtask" swapped="no"/>
+        <signal handler="on_add_subtask" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -947,7 +617,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
         <property name="accel_group">accelgroup1</property>
-        <signal name="activate" handler="on_edit_active_task" swapped="no"/>
+        <signal handler="on_edit_active_task" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -965,7 +635,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="image">tcm_img_mark_done</property>
         <property name="use_stock">False</property>
         <property name="always_show_image">True</property>
-        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
+        <signal handler="on_mark_as_done" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -977,7 +647,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="image">tcm_img_dismiss</property>
         <property name="use_stock">False</property>
         <property name="always_show_image">True</property>
-        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
+        <signal handler="on_dismiss_task" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -988,7 +658,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
         <property name="accel_group">accelgroup1</property>
-        <signal name="activate" handler="on_delete_task" swapped="no"/>
+        <signal handler="on_delete_task" name="activate" swapped="no"/>
       </object>
     </child>
     <child>
@@ -1015,7 +685,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_mark_as_started" swapped="no"/>
+                <signal handler="on_mark_as_started" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1025,7 +695,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_for_tomorrow" swapped="no"/>
+                <signal handler="on_start_for_tomorrow" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1035,7 +705,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_for_next_week" swapped="no"/>
+                <signal handler="on_start_for_next_week" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1045,7 +715,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_for_next_month" swapped="no"/>
+                <signal handler="on_start_for_next_month" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1055,7 +725,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_for_next_year" swapped="no"/>
+                <signal handler="on_start_for_next_year" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1065,7 +735,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_for_specific_date" swapped="no"/>
+                <signal handler="on_start_for_specific_date" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1081,7 +751,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_start_clear" swapped="no"/>
+                <signal handler="on_start_clear" name="activate" swapped="no"/>
               </object>
             </child>
           </object>
@@ -1106,7 +776,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_today" swapped="no"/>
+                <signal handler="on_set_due_today" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1116,7 +786,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_tomorrow" swapped="no"/>
+                <signal handler="on_set_due_tomorrow" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1126,7 +796,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_next_week" swapped="no"/>
+                <signal handler="on_set_due_next_week" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1136,7 +806,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_next_month" swapped="no"/>
+                <signal handler="on_set_due_next_month" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1146,7 +816,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_next_year" swapped="no"/>
+                <signal handler="on_set_due_next_year" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1156,7 +826,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_for_specific_date" swapped="no"/>
+                <signal handler="on_set_due_for_specific_date" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1172,7 +842,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_soon" swapped="no"/>
+                <signal handler="on_set_due_soon" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1182,7 +852,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_someday" swapped="no"/>
+                <signal handler="on_set_due_someday" name="activate" swapped="no"/>
               </object>
             </child>
             <child>
@@ -1198,7 +868,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
                 <property name="can_focus">False</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">False</property>
-                <signal name="activate" handler="on_set_due_clear" swapped="no"/>
+                <signal handler="on_set_due_clear" name="activate" swapped="no"/>
               </object>
             </child>
           </object>
@@ -1218,7 +888,7 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <property name="can_focus">False</property>
         <property name="image">image3</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="on_modify_tags" swapped="no"/>
+        <signal handler="on_modify_tags" name="activate" swapped="no"/>
       </object>
     </child>
   </object>


### PR DESCRIPTION
This pull request introduces HeaderBar into the GTG app.

I have included the most essential buttons and functionality which had to be removed from the menu and toolbar. Now they provide the very basic functionality so as to allow normal, comfortable use.

Other:
 - refurbished keyboard shortcuts in order to preserve the ease of use as before
 - some functions which may not be currently in use have been preserved so as to allow their use in a short period of time when I implement stack switcher or other features.
 - over the course of the upcoming months, when the design polishes, the text buttons will be probably changed by representative icons.

Please, note that the centred three buttons will be redesigned into a StackSwitcher shortly, now they are being included only as normal buttons due to the functionality constraint.

![screen shot 2015-05-26 at 21 10 41](https://cloud.githubusercontent.com/assets/2866323/7820919/b4920f92-03eb-11e5-9d10-c5234a9f6872.png)