### PR TITLE
Implement the stack switcher into the GTG app

### DIFF
--- a/GTG/core/requester.py
+++ b/GTG/core/requester.py
@@ -58,14 +58,20 @@ class Requester(GObject.GObject):
     def get_basetree(self):
         return self.__basetree
 
-    # this method also update the viewcount of tags
     def apply_global_filter(self, tree, filtername):
+        """
+        This method also update the viewcount of tags
+        TODO(jakubbrindza): Evaluate if this is used somewhere before release
+        """
         tree.apply_filter(filtername)
         for t in self.get_all_tags():
             ta = self.get_tag(t)
             ta.apply_filter(filtername)
 
     def unapply_global_filter(self, tree, filtername):
+        """
+        TODO(jakubbrindza): Evaluate if this is used somewhere before release
+        """
         tree.unapply_filter(filtername)
         for t in self.get_all_tags():
             ta = self.get_tag(t)

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -37,22 +37,6 @@
             <property name="is_focus">False</property>
             <property name="spacing">1</property>
             <child>
-              <object class="GtkButton" id="settings">
-                <property name="visible">True</property>
-                <property name="label">Settings</property>
-                <property name="sensitive">True</property>
-                <property name="tooltip_text" translatable="yes">Settings/Preferences</property>
-                <signal handler="on_preferences_activate" name="clicked" swapped="no"/>
-                <property name="valign">center</property>
-              </object>
-              <style>
-                <class name="text-button"/>
-              </style>
-              <packing>
-                <property name="pack_type">start</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkToggleButton" id="tags">
                 <property name="visible">True</property>
                 <property name="label">Tags</property>
@@ -63,6 +47,28 @@
               </object>
               <style>
                 <class name="text-button"/>
+              </style>
+              <packing>
+                <property name="pack_type">start</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="settings">
+                <property name="visible">True</property>
+                <property name="sensitive">True</property>
+                <property name="tooltip_text" translatable="yes">Preferences</property>
+                <signal handler="on_preferences_activate" name="clicked" swapped="no"/>
+                <property name="valign">center</property>
+                <child>
+                  <object class="GtkImage" id="settings_icon">
+                    <property name="visible">True</property>
+                    <property name="icon-name">preferences-system-symbolic</property>
+                    <property name="icon-size">1</property>
+                  </object>
+                </child>
+              </object>
+              <style>
+                <class name="image-button"/>
               </style>
               <packing>
                 <property name="pack_type">start</property>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -41,8 +41,7 @@
                 <property name="visible">True</property>
                 <property name="label">Settings</property>
                 <property name="sensitive">True</property>
-                <property name="tooltip_text" translatable="yes">Settings/Preferences
-                    </property>
+                <property name="tooltip_text" translatable="yes">Settings/Preferences</property>
                 <signal handler="on_preferences_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
@@ -58,8 +57,7 @@
                 <property name="visible">True</property>
                 <property name="label">Tags</property>
                 <property name="sensitive">True</property>
-                <property name="tooltip_text" translatable="yes">Tags Sidebar
-                       </property>
+                <property name="tooltip_text" translatable="yes">Tags Sidebar</property>
                 <signal handler="on_view_sidebar_toggled" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
@@ -80,49 +78,10 @@
             <property name="visible">True</property>
             <property name="spacing">1</property>
             <child>
-              <object class="GtkButton" id="normal_view">
+              <object class="GtkStackSwitcher" id="stack_switcher">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Active Tasks</property>
-                <property name="tooltip_text" translatable="yes">Normal, active tasks</property>
-                <signal handler="temp_active_view" name="clicked" swapped="no"/>
-                <property name="valign">center</property>
+                <property name="stack">stack</property>
               </object>
-              <style>
-                <class name="text-button"/>
-              </style>
-              <packing>
-                <property name="pack_type">start</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="work_view">
-                <property name="visible">True</property>
-                <property name="label" translatable="yes">Actionable Tasks</property>
-                <property name="tooltip_text" translatable="yes">WorkView</property>
-                <signal handler="temp_workview" name="clicked" swapped="no"/>
-                <property name="valign">center</property>
-              </object>
-              <style>
-                <class name="text-button"/>
-              </style>
-              <packing>
-                <property name="pack_type">start</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToggleButton" id="closed_tasks">
-                <property name="visible">True</property>
-                <property name="label" translatable="yes">Closed Tasks</property>
-                <property name="tooltip_text" translatable="yes">View Closed Tasks</property>
-                <signal handler="on_view_closed_toggled" name="clicked" swapped="no"/>
-                <property name="valign">center</property>
-              </object>
-              <style>
-                <class name="text-button"/>
-              </style>
-              <packing>
-                <property name="pack_type">start</property>
-              </packing>
             </child>
           </object>
         </child>
@@ -351,11 +310,9 @@
                     <property name="can_focus">True</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkNotebook" id="main_notebook">
+                      <object class="GtkStack" id="stack">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tab_pos">bottom</property>
-                        <property name="show_tabs">False</property>
+                        <property name="transition-type">crossfade</property>
                         <child>
                           <object class="GtkScrolledWindow" id="main_pane">
                             <property name="visible">True</property>
@@ -365,36 +322,40 @@
                               <placeholder/>
                             </child>
                           </object>
+                          <packing>
+                            <property name="name">active_view</property>
+                            <property name="title">Active Tasks</property>
+                          </packing>
                         </child>
-                        <child type="tab">
-                          <object class="GtkLabel" id="tasks_tab_label">
+                        <child>
+                          <object class="GtkScrolledWindow" id="workview_pane">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Tasks</property>
+                            <property name="can_focus">True</property>
+                            <property name="hscrollbar_policy">never</property>
+                            <child>
+                              <placeholder/>
+                            </child>
                           </object>
                           <packing>
-                            <property name="tab_fill">False</property>
+                            <property name="name">work_view</property>
+                            <property name="title">Workview Tasks</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScrolledWindow" id="closed_pane">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hscrollbar_policy">never</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">closed_view</property>
+                            <property name="title">Closed Tasks</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="resize">True</property>
-                        <property name="shrink">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkNotebook" id="accessory_notebook">
-                        <property name="can_focus">True</property>
-                        <property name="tab_pos">bottom</property>
-                        <property name="show_tabs">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="resize">True</property>
-                        <property name="shrink">False</property>
-                      </packing>
                     </child>
                   </object>
                   <packing>


### PR DESCRIPTION
In this commit, I am implementing GtkStack in order to enable switching between task views in a more
coherent way. The transition is set at 'crossfade' as of now, as I found that one quite elegant and simplistic.
Introduction of this cool feature included:

* Removing old GtkNotebook elements and using GtkStack instead
* Creation of new widgets and minor code cleaning in order to remove all the unused functions.
* I left one TODO note next to _add_accelerator_for_widget function, as I could not get the feature to work in this new code. Please either help or comment on how to do it, I'll give a separate PR.
* EXTRA: I used an icon instead of the label "Settings", in order to make the headerbar a bit nicer and not so cluttered.

Note: right-click menu in closed tasks does not work 100% correct. I will figure this out and deliver a fix shortly in a separate PR.

*System used: Ubuntu GNOME.*

#### SNEAK PEEK
![screen shot 2015-05-29 at 19 40 04](https://cloud.githubusercontent.com/assets/2866323/7888687/863d3260-063a-11e5-9e5f-9178f25d3a7f.png)
![screen shot 2015-05-29 at 19 42 05](https://cloud.githubusercontent.com/assets/2866323/7888719/db02ddae-063a-11e5-8d45-51b232e574bb.png)
![screen shot 2015-05-29 at 19 42 17](https://cloud.githubusercontent.com/assets/2866323/7888718/db00d7e8-063a-11e5-9952-3e04c34ca64a.png)
