### PR TITLE
Fix ImportError: No module named 'GTG.core.tools'

### DIFF
--- a/GTG/plugins/notification_area/notification_area.py
+++ b/GTG/plugins/notification_area/notification_area.py
@@ -24,7 +24,7 @@ try:
 except:
     pass
 
-from GTG.core.tools import ICONS_DIR
+from GTG.core.dirs import ICONS_DIR
 from GTG.core.translations import _
 from GTG.tools.borg import Borg
 from GTG.tools.dates import Date


### PR DESCRIPTION
This was introduced in 44fb77d with the reorganization of GTG.core.dirs.