### PR TITLE
BackendsDialog: Declare on_help as classmethod

### DIFF
--- a/GTG/gtk/backends_dialog/__init__.py
+++ b/GTG/gtk/backends_dialog/__init__.py
@@ -210,6 +210,7 @@ class BackendsDialog(object):
 ########################################
 # EVENT HANDLING #######################
 ########################################
+    @classmethod
     def on_help(cls, widget):
         """ Open help for syncronization services """
         help.show_help("sync")


### PR DESCRIPTION
The on_help of the BackendsDialog method should be a classmethod like
the one from the PreferencesDialog.

(Found while testing out @quantifiedcode)