### PR TITLE
Implement search to a separate search entry and modify quickadd

### DIFF
--- a/GTG/core/requester.py
+++ b/GTG/core/requester.py
@@ -172,17 +172,41 @@ class Requester(GObject.GObject):
         """
         return self.ds.new_tag(tagname)
 
-    def new_search_tag(self, name, query):
+    def new_search_tag(self, query):
         """
         Create a new search tag from search query
 
         Note: this modifies the datastore.
 
-        @param name:  name of the new search tag
         @param query: Query will be parsed using search parser
-        @return:      new tag
+        @return:      tag_id
         """
-        return self.ds.new_search_tag(name, query)
+        # ! at the beginning is reserved keyword for liblarch
+        if query.startswith('!'):
+            label = '_' + query
+        else:
+            label = query
+
+        # find possible name collisions
+        name, number = label, 1
+        already_search = False
+        while True:
+            tag = self.get_tag(name)
+            if tag is None:
+                break
+
+            if tag.is_search_tag() and tag.get_attribute("query") == query:
+                already_search = True
+                break
+
+            # this name is used, adding number
+            number += 1
+            name = label + ' ' + str(number)
+
+        if not already_search:
+            tag = self.ds.new_search_tag(name, query)
+
+        return name
 
     def remove_tag(self, name):
         """ calls datastore to remove a given tag """

--- a/GTG/core/search.py
+++ b/GTG/core/search.py
@@ -105,14 +105,6 @@ for key in KEYWORDS:
         possible_words = [key.lower()]
     KEYWORDS[key] = possible_words
 
-# Generate list of possible commands
-SEARCH_COMMANDS = []
-for key in KEYWORDS:
-    for key_command in KEYWORDS[key]:
-        key_command = '!' + key_command
-        if key_command not in SEARCH_COMMANDS:
-            SEARCH_COMMANDS.append(key_command)
-
 
 class InvalidQuery(Exception):
     """ Exception which is raised during parsing of

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -92,11 +92,11 @@
           </object>
         </child>
         <child>
-          <object class="GtkButton" id="search">
+          <object class="GtkToggleButton" id="search_button">
             <property name="visible">True</property>
             <property name="sensitive">True</property>
             <property name="tooltip_text" translatable="yes">Activate Search Entry</property>
-            <signal handler="temporary_search" name="clicked" swapped="no"/>
+            <signal handler="on_search_activate" name="clicked" swapped="no"/>
             <property name="valign">center</property>
             <child>
               <object class="GtkImage" id="search_icon">
@@ -142,7 +142,7 @@
                 <property name="label">Synchronisation</property>
                 <property name="sensitive">True</property>
                 <property name="tooltip_text" translatable="yes">Synchronisation Services
-                     </property>
+                </property>
                 <signal handler="on_edit_backends_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
@@ -241,36 +241,55 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="quickadd_pane">
+                  <object class="GtkSearchBar" id="searchbar">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="has_focus">True</property>
+                    <property name="is_focus">True</property>
+                    <property name="search-mode-enabled">False</property>
+                    <property name="show_close_button">False</property>
+                    <property name="valign">center</property>
                     <child>
-                      <object class="GtkEntry" id="quickadd_field">
+                      <object class="GtkBox" id="searchbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="has_focus">True</property>
-                        <property name="is_focus">True</property>
-                        <property name="can_default">True</property>
-                        <property name="tooltip_text">You can create, open or filter your tasks here</property>
-                        <property name="secondary_icon_name">edit-clear</property>
-                        <property name="secondary_icon_sensitive">True</property>
-                        <property name="secondary_icon_activatable">True</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <signal handler="on_quickadd_field_changed" name="changed" swapped="no"/>
-                        <signal handler="on_quickadd_field_activate" name="activate" swapped="no"/>
-                        <signal handler="on_quickadd_field_icon_press" name="icon-press" swapped="no"/>
+                        <property name="can_focus">False</property>
+                        <property name="has_focus">False</property>
+                        <property name="is_focus">False</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkSearchEntry" id="search_entry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="has_focus">True</property>
+                            <property name="is_focus">True</property>
+                            <property name="can_default">True</property>
+                            <property name="max-width-chars">40</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="placeholder-text">Search here</property>
+                            <signal handler="on_search" name="key-release-event" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="save_search">
+                            <property name="visible">True</property>
+                            <property name="label">Save Search</property>
+                            <signal handler="on_save_search" name="clicked" swapped="no"/>
+                          </object>
+                        </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="padding">2</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">2</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -334,6 +353,37 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="quickadd_pane">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkEntry" id="quickadd_field">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="has_focus">True</property>
+                        <property name="is_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="placeholder-text">Quickly create tasks here</property>
+                        <property name="tooltip_text">You can create your tasks here</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <signal handler="on_quickadd_field_activate" name="activate" swapped="no"/>
+                        <signal handler="on_quickadd_field_icon_press" name="icon-press" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="padding">2</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="resize">True</property>
@@ -344,7 +394,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -360,15 +410,15 @@
     <property name="program_name">Getting Things GNOME!</property>
     <property name="copyright" translatable="yes">Copyright © 2008-2013 Lionel Dricot, Bertrand Rousseau</property>
     <property name="comments" translatable="yes">GTG is a personal tasks and TODO-list items
-organizer for the GNOME desktop environment.</property>
+    organizer for the GNOME desktop environment.</property>
     <property name="website_label" translatable="yes">GTG website</property>
     <property name="license" translatable="yes">Getting Things GNOME! is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
-Getting Things GNOME! is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+    Getting Things GNOME! is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with Getting Things GNOME!; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</property>
+    You should have received a copy of the GNU General Public License along with Getting Things GNOME!; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</property>
     <property name="authors">Lionel Dricot (ploum@ploum.net),
-Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
+    Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
     <property name="logo_icon_name">gtg</property>
     <property name="wrap_license">True</property>
     <signal handler="on_about_delete" name="delete-event" swapped="no"/>
@@ -439,10 +489,6 @@ Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
         <signal handler="on_delete_task" name="activate" swapped="no"/>
       </object>
     </child>
-  </object>
-  <object class="GtkEntryCompletion" id="quickadd_entrycompletion">
-    <property name="popup_set_width">False</property>
-    <signal handler="on_quickadd_entrycompletion_action_activated" name="action-activated" swapped="no"/>
   </object>
   <object class="GtkMenu" id="task_context_menu">
     <property name="visible">True</property>


### PR DESCRIPTION
This commit aims to clarify the distinction between search and quickadd. Search is now accessible from the headerbar and offers immediate, automatic searching after each key stroke. This made the search more conveninet, however the functionality is not very fluent or fast yet.

Search tags are now not saved automatically, but only after the user decides to do so using the "Save search" button. Such a search tag can then be, as before, re-accessed from the tag sidebar.

As for the quickadd, it has been moved to the bottom of the GTG window and features only adding and opening of tasks.

![screen shot 2015-06-15 at 14 40 19](https://cloud.githubusercontent.com/assets/2866323/8160105/2c9ec99a-136d-11e5-806e-24fb33c91f7e.png)
