### PR TITLE
core/task: Support for 'Added date'

### DIFF
--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -794,11 +794,9 @@ class Task(TreeNode):
         return toreturn
 
     def __str__(self):
-        s = ""
-        s = s + "Task Object\n"
-        s = s + "Title:  " + self.title + "\n"
-        s = s + "Id:     " + self.tid + "\n"
-        s = s + "Status: " + self.status + "\n"
-        s = s + "Tags:   " + str(self.tags) + "\n"
-        s = s + "Added date: " + str(self.added_date)
-        return s
+        return '<Task title="%s" id="%s" status="%s" tags="%s" added="%s">' % (
+                self.title,
+                self.tid,
+                self.status,
+                str(self.tags),
+                str(self.added_date))

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -55,6 +55,10 @@ class Task(TreeNode):
         self.title = _("My new task")
         # available status are: Active - Done - Dismiss - Note
         self.status = self.STA_ACTIVE
+        self.added_date = Date.no_date()
+        if newtask:
+            self.added_date = datetime.now()
+
         self.closed_date = Date.no_date()
         self.due_date = Date.no_date()
         self.start_date = Date.no_date()
@@ -70,6 +74,18 @@ class Task(TreeNode):
 #            self.req._task_loaded(self.tid)
         self.attributes = {}
         self._modified_update()
+
+    def get_added_date(self):
+        return self.added_date
+
+    def get_added_date_string(self):
+        return self.added_date.strftime("%Y-%m-%dT%H:%M:%S")
+
+    def get_added_date_simple(self):
+        return self.added_date.strftime("%Y/%m/%d") if self.added_date else ""
+
+    def set_added_date(self, date):
+        self.added_date = date
 
     def is_loaded(self):
         return self.loaded
@@ -783,5 +799,6 @@ class Task(TreeNode):
         s = s + "Title:  " + self.title + "\n"
         s = s + "Id:     " + self.tid + "\n"
         s = s + "Status: " + self.status + "\n"
-        s = s + "Tags:   " + str(self.tags)
+        s = s + "Tags:   " + str(self.tags) + "\n"
+        s = s + "Added date: " + str(self.added_date)
         return s

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -18,6 +18,7 @@
 # -----------------------------------------------------------------------------
 
 import locale
+from datetime import datetime
 import xml.sax.saxutils as saxutils
 
 from gi.repository import GObject, Gtk, Pango
@@ -31,8 +32,6 @@ from GTG.gtk.browser.CellRendererTags import CellRendererTags
 from GTG.tools.dates import Date
 from liblarch_gtk import TreeView
 
-
-from datetime import datetime
 
 class TreeviewFactory():
 

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -32,6 +32,8 @@ from GTG.tools.dates import Date
 from liblarch_gtk import TreeView
 
 
+from datetime import datetime
+
 class TreeviewFactory():
 
     def __init__(self, requester, config):
@@ -183,6 +185,14 @@ class TreeviewFactory():
             elif para == 'added':
                 t1 = task1.get_added_date()
                 t2 = task2.get_added_date()
+
+                # Convert both times to datetimes (accurate comparison)
+                if isinstance(t1, Date):
+                    d = t1.date()
+                    t1 = datetime(year=d.year, month=d.month, day=d.day)
+                if isinstance(t2, Date):
+                    d = t2.date()
+                    t2 = datetime(year=d.year, month=d.month, day=d.day)
             else:
                 raise ValueError(
                     'invalid date comparison parameter: %s') % para

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -126,6 +126,9 @@ class TreeviewFactory():
     def task_sdate_column(self, node):
         return node.get_start_date().to_readable_string()
 
+    def task_adate_column(self, node):
+        return node.get_added_date_simple()
+
     def task_duedate_column(self, node):
         # We show the most constraining due date for task with no due dates.
         if node.get_due_date() == Date.no_date():
@@ -139,6 +142,10 @@ class TreeviewFactory():
 
     def start_date_sorting(self, task1, task2, order):
         sort = self.__date_comp(task1, task2, 'start', order)
+        return sort
+
+    def added_date_sorting(self, task1, task2, order):
+        sort = self.__date_comp(task1, task2, 'added', order)
         return sort
 
     def due_date_sorting(self, task1, task2, order):
@@ -173,6 +180,9 @@ class TreeviewFactory():
             elif para == 'closed':
                 t1 = task1.get_closed_date()
                 t2 = task2.get_closed_date()
+            elif para == 'added':
+                t1 = task1.get_added_date()
+                t2 = task2.get_added_date()
             else:
                 raise ValueError(
                     'invalid date comparison parameter: %s') % para
@@ -318,6 +328,17 @@ class TreeviewFactory():
     def active_tasks_treeview(self, tree):
         # Build the title/label/tags columns
         desc = self.common_desc_for_tasks(tree, "Tasks")
+
+        # "startdate" column
+        col_name = 'Added'
+        col = {}
+        col['title'] = _("Added date")
+        col['expandable'] = False
+        col['resizable'] = True
+        col['value'] = [str, self.task_adate_column]
+        col['order'] = 3
+        col['sorting_func'] = self.added_date_sorting
+        desc[col_name] = col
 
         # "startdate" column
         col_name = 'startdate'

--- a/GTG/plugins/export/task_str.py
+++ b/GTG/plugins/export/task_str.py
@@ -30,6 +30,7 @@ class TaskStr(object):
         self.text = str(task.get_text())
         self.status = task.get_status()
         self.modified = str(task.get_modified_string())
+        self.added_date = str(task.get_added_date())
         self.due_date = str(task.get_due_date())
         self.closed_date = str(task.get_closed_date())
         self.start_date = str(task.get_start_date())

--- a/GTG/tools/taskxml.py
+++ b/GTG/tools/taskxml.py
@@ -55,7 +55,6 @@ def task_from_xml(task, xmlnode):
     donedate = Date.parse(read_node(xmlnode, "donedate"))
     task.set_status(status, donedate=donedate)
 
-
     duedate = Date(read_node(xmlnode, "duedate"))
     task.set_due_date(duedate)
 

--- a/GTG/tools/taskxml.py
+++ b/GTG/tools/taskxml.py
@@ -43,6 +43,7 @@ def read_node(xmlnode, name):
 
 # Take an empty task, an XML node and return a Task.
 
+# FIXME: This should use reflection to figure out the fields
 def task_from_xml(task, xmlnode):
     # print "********************************"
     # print xmlnode.toprettyxml()
@@ -54,6 +55,7 @@ def task_from_xml(task, xmlnode):
     donedate = Date.parse(read_node(xmlnode, "donedate"))
     task.set_status(status, donedate=donedate)
 
+
     duedate = Date(read_node(xmlnode, "duedate"))
     task.set_due_date(duedate)
 
@@ -64,6 +66,11 @@ def task_from_xml(task, xmlnode):
     if modified != "":
         modified = datetime.strptime(modified, "%Y-%m-%dT%H:%M:%S")
         task.set_modified(modified)
+
+    added = read_node(xmlnode, "addeddate")
+    if added:
+        added = datetime.strptime(added, "%Y-%m-%dT%H:%M:%S")
+        task.set_added_date(added)
 
     tags = xmlnode.getAttribute("tags").replace(' ', '')
     tags = (tag for tag in tags.split(',') if tag.strip() != "")
@@ -120,6 +127,7 @@ def task_to_xml(doc, task):
         tags_str = tags_str + saxutils.escape(str(tag)) + ","
     t_xml.setAttribute("tags", tags_str[:-1])
     cleanxml.addTextNode(doc, t_xml, "title", task.get_title())
+    cleanxml.addTextNode(doc, t_xml, "addeddate", task.get_added_date_string())
     cleanxml.addTextNode(doc, t_xml, "duedate", task.get_due_date().xml_str())
     cleanxml.addTextNode(doc, t_xml, "modified", task.get_modified_string())
     cleanxml.addTextNode(doc, t_xml, "startdate",


### PR DESCRIPTION
I found it pretty annoying that subtasks are ordered alphabetically by default. I wanted to see the subtasks in the order I entered them, and there's no support for this in GTG.

I also felt that an "added date" field was missing, and this is a good way to sort the tasks in the order they were entered.

In the future, someone should add support for user-customisable ordering (and being able to reorder via drag and drop).
