### PR TITLE
Remove GtkImageMenuItem occurence

### DIFF
--- a/GTG/plugins/geolocalized_tasks/geolocalized_tasks.py
+++ b/GTG/plugins/geolocalized_tasks/geolocalized_tasks.py
@@ -79,8 +79,7 @@ class GeolocalizedTasks(object):
         image_assign_location.show()
 
         # the menu intem for the tag context
-        self.context_item = Gtk.ImageMenuItem("Assign a location to this tag")
-        self.context_item.set_image(image_assign_location)
+        self.context_item = Gtk.MenuItem("Assign a location to this tag")
         # TODO: add a short cut to the menu
 
         self.context_item.connect('activate',


### PR DESCRIPTION
**This PR solves #92**

I'm removing a left-behind ImageMenuItem widget and putting MenuItem instead.
It would be complicated to keep there the image. If you look at the documentation of ImageMenuItem it suggests creating a MenuItem, placing a Box inside and within that box place a Lable and an Image which would be a real mess to do in code!
