### PR TITLE
Implement open_parent feature

### DIFF
--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -166,7 +166,6 @@
                     <child>
                       <object class="GtkButton" id="parent">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
                         <property name="tooltip_text">Open the parent task</property>
                         <signal handler="on_parent_select" name="clicked" swapped="yes"/>
                         <child>


### PR DESCRIPTION
This PR is a follow-up of #146. Finally opening a parent from the task editor is fully functional.

If a task has one parent, it is opened immediately. If it has more immediate parents, a popover shows with the option to choose the one user wants.
##### The parent selection is viewed in a popover
![screen shot 2015-07-16 at 16 51 19](https://cloud.githubusercontent.com/assets/2866323/8726715/3488df56-2bdc-11e5-9fb9-c27ac4961d44.png)

##### You decide which parent to open and open it from the popover
![screen shot 2015-07-16 at 16 51 25](https://cloud.githubusercontent.com/assets/2866323/8726509/fa0996dc-2bda-11e5-98a7-57572afa9a7c.png)

