### PR TITLE
Resolving the issue in #172 with out-dated style property for GtkButton

### DIFF
--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -25,9 +25,6 @@
           <packing>
             <property name="pack_type">start</property>
           </packing>
-          <style>
-            <class name="text-button"/>
-          </style>
         </child>
         <child>
           <object class="GtkBox" id="customisation_box">
@@ -45,9 +42,6 @@
                 <signal handler="on_view_sidebar_toggled" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
-              <style>
-                <class name="text-button"/>
-              </style>
               <packing>
                 <property name="pack_type">start</property>
               </packing>
@@ -67,9 +61,6 @@
                   </object>
                 </child>
               </object>
-              <style>
-                <class name="image-button"/>
-              </style>
               <packing>
                 <property name="pack_type">start</property>
               </packing>
@@ -109,9 +100,6 @@
           <packing>
             <property name="pack_type">end</property>
           </packing>
-          <style>
-            <class name="image-button"/>
-          </style>
         </child>
         <child>
           <object class="GtkBox" id="extras_box">
@@ -129,9 +117,6 @@
                 <signal handler="on_edit_plugins_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
-              <style>
-                <class name="text-button"/>
-              </style>
               <packing>
                 <property name="pack_type">start</property>
               </packing>
@@ -146,9 +131,6 @@
                 <signal handler="on_edit_backends_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
               </object>
-              <style>
-                <class name="text-button"/>
-              </style>
               <packing>
                 <property name="pack_type">start</property>
               </packing>

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -24,9 +24,6 @@
           <packing>
             <property name="pack_type">start</property>
           </packing>
-          <style>
-            <class name="text-button"/>
-          </style>
         </child>
         <child>
           <object class="GtkButton" id="mark_as_undone">
@@ -40,9 +37,6 @@
           <packing>
             <property name="pack_type">start</property>
           </packing>
-          <style>
-            <class name="text-button"/>
-          </style>
         </child>
         <child>
           <object class="GtkMenuButton" id="editor_menu">
@@ -62,9 +56,6 @@
           <packing>
             <property name="pack_type">end</property>
           </packing>
-          <style>
-            <class name="image-button"/>
-          </style>
         </child>
       </object>
     </child>
@@ -378,9 +369,6 @@
             <property name="tooltip_text">Permanently remove this task</property>
             <signal handler="delete_clicked" name="clicked" swapped="no"/>
           </object>
-          <style>
-            <class name="text-button"/>
-          </style>
         </child>
       </object>
     </child>


### PR DESCRIPTION
According to the latest standards for GNOME: 

https://developer.gnome.org/gtk3/stable/GtkButton.html#GtkButton.style-properties

no style properties distinguishing the type of the button are required, therefore this was the reason probably for fails mentioned in #172. 

I haven't tested the outcome on GNOME 3.18 yet, though, although the functionality and the design of GTG remains unchanged after these style properties were removed, therefore I think this will also enable launching on the new GNOME version. They were essentially useless and just made the code cluttered.