### PR TITLE
Fix test_falls_back_when_there_is_config_error

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -46,7 +46,7 @@ class TestOpenConfigFile(TestCase):
         self.mock_parser.side_effect = configparser.Error()
         open_config_file('gtg.conf')
         self.mock_parser.assert_called_once_with('gtg.conf')
-        mock_log.warning.assert_called()
+        self.assertTrue(mock_log.warning.called)
 
     def test_creates_config_folder_when_missing(self):
         self.mock_path.exists.return_value = False


### PR DESCRIPTION
Trivial fix, but now all the tests pass!

Signed-off-by: Olivier Mehani shtrom@ssji.net
