### PR TITLE
Help not accessible from main window

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
     * Fixing the Tooltip for open parent, by Sagar Ghuge
     * Fix for bug #83: Closed tasks remover imposes a too low limit for the days period option, by Àlex Magaz Graça
     * Fix for bug #177 'TextTag' object has no attribute 'link', by Sagar Ghuge
+    * Fix for bug #189 Help not accessible from main window, by Sagar Ghuge
 
 2013-11-24 Getting Things GNOME! 0.3.1
     * Fix for bug #1024473: Have 'Show Main Window' in notification area, by Antonio Roquentin

--- a/GTG/gtk/browser/browser.py
+++ b/GTG/gtk/browser/browser.py
@@ -39,7 +39,7 @@ from GTG.gtk.editor.calendar import GTGCalendar
 from GTG.gtk.tag_completion import TagCompletion
 from GTG.tools.dates import Date
 from GTG.tools.logger import Log
-
+from GTG.gtk.help import add_help_shortcut
 
 class TaskBrowser(GObject.GObject):
     """ The UI for browsing open and closed tasks,
@@ -115,6 +115,9 @@ class TaskBrowser(GObject.GObject):
         self._init_accelerators()
 
         self.restore_state_from_conf()
+
+        # F1 shows help
+        add_help_shortcut(self.window, "browser")
 
         self.on_select_tag()
         self.browser_shown = False


### PR DESCRIPTION
Added shortcut key "F1" to open help

Fixes #189 
