### PR TITLE
GTM synchronization bug fix

### DIFF
--- a/GTG/backends/genericbackend.py
+++ b/GTG/backends/genericbackend.py
@@ -613,7 +613,7 @@ class GenericBackend(object):
         if ALLTASKS_TAG in attached_tags:
             return True
         for tag in task.get_tags_name():
-            if tag in attached_tags:
+            if tag[1:] in attached_tags:
                 return True
         return False
 


### PR DESCRIPTION
task.get_tags_name() do not contains '@' in tags but attached_tags do.

This is hack, and actually attached_tags should be changed, I'm not good at python and have no time to write good fix=(