### PR TITLE
UI Polish / Improvements

### DIFF
--- a/GTG/core/treefactory.py
+++ b/GTG/core/treefactory.py
@@ -73,7 +73,7 @@ class TreeFactory(object):
         # Build the "all tasks tag"
         alltag = tag.Tag(tag.ALLTASKS_TAG, req=req)
         alltag.set_attribute("special", "all")
-        alltag.set_attribute("label", "<span weight='bold'>%s</span>"
+        alltag.set_attribute("label", "%s"
                              % _("All tasks"))
         alltag.set_attribute("icon", "gtg-tags-all")
         alltag.set_attribute("order", 0)
@@ -84,7 +84,7 @@ class TreeFactory(object):
         # Build the "without tag tag"
         notag_tag = tag.Tag(tag.NOTAG_TAG, req=req)
         notag_tag.set_attribute("special", "notag")
-        notag_tag.set_attribute("label", "<span weight='bold'>%s</span>"
+        notag_tag.set_attribute("label", "%s"
                                 % _("Tasks with no tags"))
         notag_tag.set_attribute("icon", "gtg-tags-none")
         notag_tag.set_attribute("order", 2)
@@ -97,7 +97,7 @@ class TreeFactory(object):
         search_tag = tag.Tag(tag.SEARCH_TAG, req=req)
         search_tag.set_attribute("special", "search")
         search_tag.set_attribute("label",
-                                 "<span weight='bold'>%s</span>" % _("Search"))
+                                 "%s" % _("Search"))
         search_tag.set_attribute("icon", "search")
         search_tag.set_attribute("order", 1)
         tagtree.add_node(search_tag)

--- a/GTG/core/treefactory.py
+++ b/GTG/core/treefactory.py
@@ -75,7 +75,7 @@ class TreeFactory(object):
         alltag.set_attribute("special", "all")
         alltag.set_attribute("label", "%s"
                              % _("All tasks"))
-        alltag.set_attribute("icon", "gtg-tags-all")
+        alltag.set_attribute("icon", "emblem-documents-symbolic")
         alltag.set_attribute("order", 0)
         tagtree.add_node(alltag)
         p = {}
@@ -86,7 +86,7 @@ class TreeFactory(object):
         notag_tag.set_attribute("special", "notag")
         notag_tag.set_attribute("label", "%s"
                                 % _("Tasks with no tags"))
-        notag_tag.set_attribute("icon", "gtg-tags-none")
+        notag_tag.set_attribute("icon", "task-past-due-symbolic")
         notag_tag.set_attribute("order", 2)
         tagtree.add_node(notag_tag)
         p = {}
@@ -98,7 +98,7 @@ class TreeFactory(object):
         search_tag.set_attribute("special", "search")
         search_tag.set_attribute("label",
                                  "%s" % _("Search"))
-        search_tag.set_attribute("icon", "search")
+        search_tag.set_attribute("icon", "system-search-symbolic")
         search_tag.set_attribute("order", 1)
         tagtree.add_node(search_tag)
         p = {}

--- a/GTG/gtk/browser/browser.py
+++ b/GTG/gtk/browser/browser.py
@@ -525,10 +525,8 @@ class TaskBrowser(GObject.GObject):
 
         tag_pane = self.config.get("tag_pane")
         if not tag_pane:
-            self.builder.get_object("tags").set_active(False)
             self.sidebar.hide()
         else:
-            self.builder.get_object("tags").set_active(True)
             if not self.tagtreeview:
                 self.init_tags_sidebar()
             self.sidebar.show()
@@ -626,11 +624,9 @@ class TaskBrowser(GObject.GObject):
     def on_sidebar_toggled(self, widget):
         tags = self.builder.get_object("tags")
         if self.sidebar.get_property("visible"):
-            tags.set_active(False)
             self.config.set("tag_pane", False)
             self.sidebar.hide()
         else:
-            tags.set_active(True)
             if not self.tagtreeview:
                 self.init_tags_sidebar()
             self.sidebar.show()

--- a/GTG/gtk/browser/browser.py
+++ b/GTG/gtk/browser/browser.py
@@ -114,6 +114,9 @@ class TaskBrowser(GObject.GObject):
         # Define accelerator keys
         self._init_accelerators()
 
+        # Initalize custom CSS
+        self._init_css()
+
         self.restore_state_from_conf()
 
         self.on_select_tag()
@@ -656,6 +659,21 @@ class TaskBrowser(GObject.GObject):
         # expand if the node was not stored as collapsed
         if tid not in colt:
             self.vtree_panes['active'].expand_row(path, False)
+
+    def _init_css(self):
+        style_provider = Gtk.CssProvider()
+
+        css = b"""
+        #main_menu GtkModelButton {
+            padding: 10 5;
+        }
+        """
+
+        style_provider.load_from_data(css);
+
+        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
+                                                 style_provider,
+                                                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
     def on_task_expanded(self, sender, tid):
         colt = self.config.get("collapsed_tasks")

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -97,13 +97,14 @@
     </child>
   </object>
   <object class="GtkPopoverMenu" id="main_menu">
+    <property name="name">main_menu</property>
     <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">12</property>
-        <property name="margin_right">12</property>
+        <property name="margin_left">14</property>
+        <property name="margin_right">14</property>
         <property name="margin_top">8</property>
         <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
@@ -125,6 +126,8 @@
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -164,6 +167,8 @@
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -316,6 +316,8 @@
                   <object class="GtkNotebook" id="sidebar_notebook">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="margin_top">10</property>
+                    <property name="margin_bottom">10</property>
                     <property name="tab_pos">bottom</property>
                     <property name="show_tabs">False</property>
                     <property name="show_border">False</property>
@@ -326,6 +328,9 @@
                         <child>
                           <placeholder/>
                         </child>
+                        <style>
+                          <class name="sidebar"/>
+                        </style>
                       </object>
                     </child>
                     <child type="tab">
@@ -345,6 +350,9 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <style>
+                  <class name="sidebar"/>
+                </style>
               </object>
               <packing>
                 <property name="resize">False</property>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -2,6 +2,223 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAboutDialog" id="about_dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">About GTG!</property>
+    <property name="resizable">False</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="type_hint">dialog</property>
+    <property name="program_name">Getting Things GNOME!</property>
+    <property name="copyright" translatable="yes">Copyright © 2008-2013 Lionel Dricot, Bertrand Rousseau</property>
+    <property name="comments" translatable="yes">GTG is a personal tasks and TODO-list items
+    organizer for the GNOME desktop environment.</property>
+    <property name="website_label" translatable="yes">GTG website</property>
+    <property name="license" translatable="yes">Getting Things GNOME! is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
+
+    Getting Things GNOME! is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with Getting Things GNOME!; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</property>
+    <property name="authors">Lionel Dricot (ploum@ploum.net),
+    Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
+    <property name="logo_icon_name">gtg</property>
+    <property name="wrap_license">True</property>
+    <signal name="delete-event" handler="on_about_delete" swapped="no"/>
+    <signal name="response" handler="on_about_close" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="about_dialog_vbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkMenu" id="closed_task_context_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkMenuItem" id="ctcm_edit">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label">Edit</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_edit_done_task" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkSeparatorMenuItem" id="separator_1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="ctcm_mark_as_not_done">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Mark as Not Done</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="ctcm_undismiss">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Und_ismiss</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="ctcm_delete">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label">Delete</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_delete_task" swapped="no"/>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopoverMenu" id="main_menu">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkModelButton" id="tags">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">Tags sidebar</property>
+            <signal name="clicked" handler="on_view_sidebar_toggled" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="plugins">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">Plugins</property>
+            <signal name="clicked" handler="on_edit_plugins_activate" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="synchronization">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">Synchronization</property>
+            <signal name="clicked" handler="on_edit_backends_activate" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="preferences">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">Preferences</property>
+            <signal name="clicked" handler="on_preferences_activate" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="help">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">Help</property>
+            <signal name="clicked" handler="on_documentation_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="about">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="text" translatable="yes">About GTG</property>
+            <signal name="clicked" handler="on_about_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">8</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">main</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkWindow" id="MainWindow">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Getting Things GNOME!</property>
@@ -13,7 +230,6 @@
       <object class="GtkHeaderBar" id="browser_headerbar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="title" translatable="yes">Tasks</property>
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkButton" id="new_task">
@@ -26,73 +242,31 @@
             <signal name="clicked" handler="on_add_task" swapped="no"/>
           </object>
         </child>
-        <child>
-          <object class="GtkBox" id="customisation_box">
+        <child type="title">
+          <object class="GtkStackSwitcher" id="stack_switcher">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">1</property>
+            <property name="stack">stack</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="main_menu_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="popover">main_menu</property>
             <child>
-              <object class="GtkToggleButton" id="tags">
-                <property name="label">Tags</property>
+              <object class="GtkImage" id="main_menu_icon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Tags Sidebar</property>
-                <property name="valign">center</property>
-                <signal name="clicked" handler="on_view_sidebar_toggled" swapped="no"/>
+                <property name="icon_name">open-menu-symbolic</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="settings">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Preferences</property>
-                <property name="valign">center</property>
-                <signal name="clicked" handler="on_preferences_activate" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="settings_icon">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">preferences-system-symbolic</property>
-                    <property name="icon_size">2</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
+            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
-        </child>
-        <child type="title">
-          <object class="GtkBox" id="stack_switcher_box">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">1</property>
-            <child>
-              <object class="GtkStackSwitcher" id="stack_switcher">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="stack">stack</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
         </child>
         <child>
           <object class="GtkToggleButton" id="search_button">
@@ -109,50 +283,6 @@
                 <property name="icon_name">edit-find-symbolic</property>
                 <property name="icon_size">1</property>
               </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="extras_box">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">1</property>
-            <child>
-              <object class="GtkButton" id="plugins">
-                <property name="label">Plugins</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Add plugins</property>
-                <property name="valign">center</property>
-                <signal name="clicked" handler="on_edit_plugins_activate" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="synchronisation">
-                <property name="label">Synchronisation</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Synchronisation Services
-                </property>
-                <property name="valign">center</property>
-                <signal name="clicked" handler="on_edit_backends_activate" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
@@ -387,100 +517,6 @@
             <property name="position">1</property>
           </packing>
         </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkAboutDialog" id="about_dialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">About GTG!</property>
-    <property name="resizable">False</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
-    <property name="program_name">Getting Things GNOME!</property>
-    <property name="copyright" translatable="yes">Copyright © 2008-2013 Lionel Dricot, Bertrand Rousseau</property>
-    <property name="comments" translatable="yes">GTG is a personal tasks and TODO-list items
-    organizer for the GNOME desktop environment.</property>
-    <property name="website_label" translatable="yes">GTG website</property>
-    <property name="license" translatable="yes">Getting Things GNOME! is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
-
-    Getting Things GNOME! is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along with Getting Things GNOME!; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</property>
-    <property name="authors">Lionel Dricot (ploum@ploum.net),
-    Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
-    <property name="logo_icon_name">gtg</property>
-    <property name="wrap_license">True</property>
-    <signal name="delete-event" handler="on_about_delete" swapped="no"/>
-    <signal name="response" handler="on_about_close" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="about_dialog_vbox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkMenu" id="closed_task_context_menu">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkMenuItem" id="ctcm_edit">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label">Edit</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="on_edit_done_task" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkSeparatorMenuItem" id="separator_1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="ctcm_mark_as_not_done">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Mark as Not Done</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="ctcm_undismiss">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Und_ismiss</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="ctcm_delete">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label">Delete</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="on_delete_task" swapped="no"/>
       </object>
     </child>
   </object>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -482,6 +482,10 @@
                         <property name="is_focus">True</property>
                         <property name="can_default">True</property>
                         <property name="tooltip_text">You can create your tasks here</property>
+                        <property name="margin_left">10</property>
+                        <property name="margin_right">10</property>
+                        <property name="margin_top">7</property>
+                        <property name="margin_bottom">7</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="placeholder_text">Quickly create tasks here</property>
                         <property name="input_hints">GTK_INPUT_HINT_SPELLCHECK | GTK_INPUT_HINT_NONE</property>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -110,9 +110,9 @@
         <child>
           <object class="GtkModelButton" id="tags">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
-            <property name="text" translatable="yes">Tags sidebar</property>
+            <property name="text" translatable="yes">Show Sidebar</property>
             <signal name="clicked" handler="on_view_sidebar_toggled" swapped="no"/>
           </object>
           <packing>
@@ -135,7 +135,7 @@
         <child>
           <object class="GtkModelButton" id="plugins">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="text" translatable="yes">Plugins</property>
             <signal name="clicked" handler="on_edit_plugins_activate" swapped="no"/>
@@ -149,7 +149,7 @@
         <child>
           <object class="GtkModelButton" id="synchronization">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="text" translatable="yes">Synchronization</property>
             <signal name="clicked" handler="on_edit_backends_activate" swapped="no"/>
@@ -174,7 +174,7 @@
         <child>
           <object class="GtkModelButton" id="preferences">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="text" translatable="yes">Preferences</property>
             <signal name="clicked" handler="on_preferences_activate" swapped="no"/>
@@ -188,7 +188,7 @@
         <child>
           <object class="GtkModelButton" id="help">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="text" translatable="yes">Help</property>
             <signal name="clicked" handler="on_documentation_clicked" swapped="no"/>
@@ -202,7 +202,7 @@
         <child>
           <object class="GtkModelButton" id="about">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="text" translatable="yes">About GTG</property>
             <signal name="clicked" handler="on_about_clicked" swapped="no"/>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -425,7 +425,7 @@
                           </object>
                           <packing>
                             <property name="name">active_view</property>
-                            <property name="title">Active Tasks</property>
+                            <property name="title">Active</property>
                           </packing>
                         </child>
                         <child>
@@ -439,7 +439,7 @@
                           </object>
                           <packing>
                             <property name="name">work_view</property>
-                            <property name="title">Workview Tasks</property>
+                            <property name="title">Workview</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
@@ -454,7 +454,7 @@
                           </object>
                           <packing>
                             <property name="name">closed_view</property>
-                            <property name="title">Closed Tasks</property>
+                            <property name="title">Closed</property>
                             <property name="position">2</property>
                           </packing>
                         </child>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -216,6 +216,7 @@
       </object>
       <packing>
         <property name="submenu">main</property>
+        <property name="position">1</property>
       </packing>
     </child>
   </object>
@@ -252,7 +253,7 @@
         <child>
           <object class="GtkMenuButton" id="main_menu_btn">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <property name="receives_default">True</property>
             <property name="popover">main_menu</property>
             <child>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -1,143 +1,163 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkWindow" id="MainWindow">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Getting Things GNOME!</property>
     <property name="default_width">700</property>
     <property name="default_height">550</property>
-    <signal handler="on_move" name="configure-event" swapped="no"/>
-    <signal handler="on_size_allocate" name="size-allocate" swapped="no"/>
+    <signal name="configure-event" handler="on_move" swapped="no"/>
+    <signal name="size-allocate" handler="on_size_allocate" swapped="no"/>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="browser_headerbar">
         <property name="visible">True</property>
-        <property name="show_close_button">True</property>
+        <property name="can_focus">False</property>
         <property name="title" translatable="yes">Tasks</property>
+        <property name="show_close_button">True</property>
         <child>
           <object class="GtkButton" id="new_task">
-            <property name="visible">True</property>
-            <property name="sensitive">True</property>
             <property name="label" translatable="yes">New Task</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="tooltip_text" translatable="yes">Create a new task</property>
             <property name="valign">center</property>
-            <signal handler="on_add_task" name="clicked" swapped="no"/>
+            <signal name="clicked" handler="on_add_task" swapped="no"/>
           </object>
-          <packing>
-            <property name="pack_type">start</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox" id="customisation_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="has_focus">False</property>
-            <property name="is_focus">False</property>
             <property name="spacing">1</property>
             <child>
               <object class="GtkToggleButton" id="tags">
-                <property name="visible">True</property>
                 <property name="label">Tags</property>
-                <property name="sensitive">True</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Tags Sidebar</property>
-                <signal handler="on_view_sidebar_toggled" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
+                <signal name="clicked" handler="on_view_sidebar_toggled" swapped="no"/>
               </object>
               <packing>
-                <property name="pack_type">start</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="settings">
                 <property name="visible">True</property>
-                <property name="sensitive">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Preferences</property>
-                <signal handler="on_preferences_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
+                <signal name="clicked" handler="on_preferences_activate" swapped="no"/>
                 <child>
                   <object class="GtkImage" id="settings_icon">
                     <property name="visible">True</property>
-                    <property name="icon-name">preferences-system-symbolic</property>
-                    <property name="icon-size">2</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">preferences-system-symbolic</property>
+                    <property name="icon_size">2</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="pack_type">start</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="pack_type">start</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child type="title">
           <object class="GtkBox" id="stack_switcher_box">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">1</property>
             <child>
               <object class="GtkStackSwitcher" id="stack_switcher">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="stack">stack</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
           </object>
         </child>
         <child>
           <object class="GtkToggleButton" id="search_button">
             <property name="visible">True</property>
-            <property name="sensitive">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="tooltip_text" translatable="yes">Activate Search Entry</property>
-            <signal handler="on_search_activate" name="clicked" swapped="no"/>
             <property name="valign">center</property>
+            <signal name="clicked" handler="on_search_activate" swapped="no"/>
             <child>
               <object class="GtkImage" id="search_icon">
                 <property name="visible">True</property>
-                <property name="icon-name">edit-find-symbolic</property>
-                <property name="icon-size">1</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">edit-find-symbolic</property>
+                <property name="icon_size">1</property>
               </object>
             </child>
           </object>
           <packing>
             <property name="pack_type">end</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="extras_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="has_focus">False</property>
-            <property name="is_focus">False</property>
             <property name="spacing">1</property>
             <child>
               <object class="GtkButton" id="plugins">
-                <property name="visible">True</property>
                 <property name="label">Plugins</property>
-                <property name="sensitive">True</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Add plugins</property>
-                <signal handler="on_edit_plugins_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
+                <signal name="clicked" handler="on_edit_plugins_activate" swapped="no"/>
               </object>
               <packing>
-                <property name="pack_type">start</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="synchronisation">
-                <property name="visible">True</property>
                 <property name="label">Synchronisation</property>
-                <property name="sensitive">True</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Synchronisation Services
                 </property>
-                <signal handler="on_edit_backends_activate" name="clicked" swapped="no"/>
                 <property name="valign">center</property>
+                <signal name="clicked" handler="on_edit_backends_activate" swapped="no"/>
               </object>
               <packing>
-                <property name="pack_type">start</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="pack_type">end</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
@@ -176,6 +196,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
@@ -228,15 +249,11 @@
                     <property name="can_focus">True</property>
                     <property name="has_focus">True</property>
                     <property name="is_focus">True</property>
-                    <property name="search-mode-enabled">False</property>
-                    <property name="show_close_button">False</property>
                     <property name="valign">center</property>
                     <child>
                       <object class="GtkBox" id="searchbox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="has_focus">False</property>
-                        <property name="is_focus">False</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkSearchEntry" id="search_entry">
@@ -245,33 +262,37 @@
                             <property name="has_focus">True</property>
                             <property name="is_focus">True</property>
                             <property name="can_default">True</property>
-                            <property name="max-width-chars">40</property>
+                            <property name="max_width_chars">40</property>
                             <property name="primary_icon_activatable">False</property>
-                            <property name="placeholder-text">Search here</property>
-                            <signal handler="on_search" name="key-release-event" swapped="no"/>
+                            <property name="placeholder_text">Search here</property>
+                            <signal name="key-release-event" handler="on_search" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkButton" id="save_search">
-                            <property name="visible">True</property>
                             <property name="label">Save Search</property>
-                            <signal handler="on_save_search" name="clicked" swapped="no"/>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="receives_default">False</property>
+                            <signal name="clicked" handler="on_save_search" swapped="no"/>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="padding">2</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -283,7 +304,8 @@
                     <child>
                       <object class="GtkStack" id="stack">
                         <property name="visible">True</property>
-                        <property name="transition-type">crossfade</property>
+                        <property name="can_focus">False</property>
+                        <property name="transition_type">crossfade</property>
                         <child>
                           <object class="GtkScrolledWindow" id="main_pane">
                             <property name="visible">True</property>
@@ -310,6 +332,7 @@
                           <packing>
                             <property name="name">work_view</property>
                             <property name="title">Workview Tasks</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                         <child>
@@ -324,9 +347,14 @@
                           <packing>
                             <property name="name">closed_view</property>
                             <property name="title">Closed Tasks</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="resize">False</property>
+                        <property name="shrink">True</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -346,11 +374,14 @@
                         <property name="has_focus">True</property>
                         <property name="is_focus">True</property>
                         <property name="can_default">True</property>
-                        <property name="placeholder-text">Quickly create tasks here</property>
                         <property name="tooltip_text">You can create your tasks here</property>
                         <property name="primary_icon_activatable">False</property>
-                        <signal handler="on_quickadd_field_activate" name="activate" swapped="no"/>
-                        <signal handler="on_quickadd_field_icon_press" name="icon-press" swapped="no"/>
+                        <property name="placeholder_text">Quickly create tasks here</property>
+                        <property name="input_hints">GTK_INPUT_HINT_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
+                        <property name="show_emoji_icon">True</property>
+                        <property name="enable_emoji_completion">True</property>
+                        <signal name="activate" handler="on_quickadd_field_activate" swapped="no"/>
+                        <signal name="icon-press" handler="on_quickadd_field_icon_press" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -403,8 +434,11 @@
     Bertrand Rousseau (bertrand.rousseau@gmail.com)</property>
     <property name="logo_icon_name">gtg</property>
     <property name="wrap_license">True</property>
-    <signal handler="on_about_delete" name="delete-event" swapped="no"/>
-    <signal handler="on_about_close" name="response" swapped="no"/>
+    <signal name="delete-event" handler="on_about_delete" swapped="no"/>
+    <signal name="response" handler="on_about_close" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="about_dialog_vbox">
         <property name="visible">True</property>
@@ -432,11 +466,11 @@
     <property name="can_focus">False</property>
     <child>
       <object class="GtkMenuItem" id="ctcm_edit">
-        <property name="label">Edit</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label">Edit</property>
         <property name="use_underline">True</property>
-        <signal handler="on_edit_done_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_edit_done_task" swapped="no"/>
       </object>
     </child>
     <child>
@@ -447,28 +481,29 @@
     </child>
     <child>
       <object class="GtkMenuItem" id="ctcm_mark_as_not_done">
-        <property name="label" translatable="yes">Mark as Not Done</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Mark as Not Done</property>
         <property name="use_underline">True</property>
-        <signal handler="on_mark_as_done" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="ctcm_undismiss">
-        <property name="label" translatable="yes">Und_ismiss</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Und_ismiss</property>
         <property name="use_underline">True</property>
-        <signal handler="on_dismiss_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="ctcm_delete">
-        <property name="label">Delete</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label">Delete</property>
         <property name="use_underline">True</property>
-        <signal handler="on_delete_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_delete_task" swapped="no"/>
       </object>
     </child>
   </object>
@@ -477,20 +512,20 @@
     <property name="can_focus">False</property>
     <child>
       <object class="GtkMenuItem" id="tcm_add_subtask">
-        <property name="label" translatable="yes">Add a subtask</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Add a subtask</property>
         <property name="use_underline">True</property>
-        <signal handler="on_add_subtask" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_add_subtask" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_edit">
-        <property name="label">Edit</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label">Edit</property>
         <property name="use_underline">True</property>
-        <signal handler="on_edit_active_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_edit_active_task" swapped="no"/>
       </object>
     </child>
     <child>
@@ -501,29 +536,29 @@
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_mark_as_done">
-        <property name="label" translatable="yes">Mark as _Done</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Mark as _Done</property>
         <property name="use_underline">True</property>
-        <signal handler="on_mark_as_done" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_mark_as_done" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_dismiss">
-        <property name="label" translatable="yes">D_ismiss</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">D_ismiss</property>
         <property name="use_underline">True</property>
-        <signal handler="on_dismiss_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_dismiss_task" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_delete">
-        <property name="label">Delete</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label">Delete</property>
         <property name="use_underline">True</property>
-        <signal handler="on_delete_task" name="activate" swapped="no"/>
+        <signal name="activate" handler="on_delete_task" swapped="no"/>
       </object>
     </child>
     <child>
@@ -534,9 +569,9 @@
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_start_menu">
-        <property name="label" translatable="yes">_Set Start Date</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">_Set Start Date</property>
         <property name="use_underline">True</property>
         <child type="submenu">
           <object class="GtkMenu" id="start_for_context_menu">
@@ -544,56 +579,56 @@
             <property name="can_focus">False</property>
             <child>
               <object class="GtkMenuItem" id="tcm_mark_as_started">
-                <property name="label" translatable="yes">T_oday</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">T_oday</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_mark_as_started" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_mark_as_started" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_for_tomorrow">
-                <property name="label" translatable="yes">_Tomorrow</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Tomorrow</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_for_tomorrow" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_for_tomorrow" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_for_next_week">
-                <property name="label" translatable="yes">Next _Week</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Week</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_for_next_week" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_for_next_week" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_for_next_month">
-                <property name="label" translatable="yes">Next _Month</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Month</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_for_next_month" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_for_next_month" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_for_next_year">
-                <property name="label" translatable="yes">Next _Year</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Year</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_for_next_year" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_for_next_year" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_for_specific_date">
-                <property name="label" translatable="yes">Pick a date...</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Pick a date...</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_for_specific_date" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_for_specific_date" swapped="no"/>
               </object>
             </child>
             <child>
@@ -604,11 +639,11 @@
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_start_clear">
-                <property name="label" translatable="yes">_Clear Start Date</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Clear Start Date</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_start_clear" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_start_clear" swapped="no"/>
               </object>
             </child>
           </object>
@@ -617,9 +652,9 @@
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_due_menu">
-        <property name="label" translatable="yes">Set Due Date</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Set Due Date</property>
         <property name="use_underline">True</property>
         <child type="submenu">
           <object class="GtkMenu" id="due_context_menu">
@@ -627,56 +662,56 @@
             <property name="can_focus">False</property>
             <child>
               <object class="GtkMenuItem" id="tcm_due_today">
-                <property name="label" translatable="yes">T_oday</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">T_oday</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_today" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_today" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_tomorrow">
-                <property name="label" translatable="yes">_Tomorrow</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Tomorrow</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_tomorrow" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_tomorrow" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_next_week">
-                <property name="label" translatable="yes">Next _Week</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Week</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_next_week" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_next_week" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_next_month">
-                <property name="label" translatable="yes">Next _Month</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Month</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_next_month" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_next_month" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_next_year">
-                <property name="label" translatable="yes">Next _Year</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Next _Year</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_next_year" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_next_year" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_specific_date">
-                <property name="label" translatable="yes">Pick a date...</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Pick a date...</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_for_specific_date" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_for_specific_date" swapped="no"/>
               </object>
             </child>
             <child>
@@ -687,20 +722,20 @@
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_soon">
-                <property name="label" translatable="yes">_Soon</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Soon</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_soon" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_soon" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_someday">
-                <property name="label" translatable="yes">_Someday</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Someday</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_someday" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_someday" swapped="no"/>
               </object>
             </child>
             <child>
@@ -711,11 +746,11 @@
             </child>
             <child>
               <object class="GtkMenuItem" id="tcm_due_clear">
-                <property name="label" translatable="yes">_Clear Due Date</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Clear Due Date</property>
                 <property name="use_underline">True</property>
-                <signal handler="on_set_due_clear" name="activate" swapped="no"/>
+                <signal name="activate" handler="on_set_due_clear" swapped="no"/>
               </object>
             </child>
           </object>
@@ -730,10 +765,10 @@
     </child>
     <child>
       <object class="GtkMenuItem" id="tcm_modifytags">
-        <property name="label" translatable="yes">Modify Tags...</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <signal handler="on_modify_tags" name="activate" swapped="no"/>
+        <property name="label" translatable="yes">Modify Tags...</property>
+        <signal name="activate" handler="on_modify_tags" swapped="no"/>
       </object>
     </child>
   </object>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -177,29 +177,6 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="tags_box">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="tags_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Tags Sidebar</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkNotebook" id="sidebar_notebook">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>

--- a/GTG/gtk/browser/taskbrowser.ui
+++ b/GTG/gtk/browser/taskbrowser.ui
@@ -312,11 +312,11 @@
                     <property name="can_focus">True</property>
                     <property name="tab_pos">bottom</property>
                     <property name="show_tabs">False</property>
+                    <property name="show_border">False</property>
                     <child>
                       <object class="GtkScrolledWindow" id="sidebar-scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="shadow_type">in</property>
                         <child>
                           <placeholder/>
                         </child>

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -278,7 +278,7 @@ class TreeviewFactory(object):
         col_name = 'color'
         col = {}
         render_tags = CellRendererTags()
-        render_tags.set_property('ypad', 3)
+        render_tags.set_property('ypad', 4)
         col['title'] = _("Tags")
         col['renderer'] = ['tag', render_tags]
         col['value'] = [GObject.TYPE_PYOBJECT, lambda node: node]
@@ -291,7 +291,7 @@ class TreeviewFactory(object):
         col_name = 'tagname'
         col = {}
         render_text = Gtk.CellRendererText()
-        render_text.set_property('ypad', 3)
+        render_text.set_property('ypad', 4)
         col['renderer'] = ['markup', render_text]
         col['value'] = [str, self.tag_name]
         col['expandable'] = True
@@ -303,8 +303,8 @@ class TreeviewFactory(object):
         col_name = 'tagcount'
         col = {}
         render_text = Gtk.CellRendererText()
-        render_text.set_property('xpad', 3)
-        render_text.set_property('ypad', 3)
+        render_text.set_property('xpad', 16)
+        render_text.set_property('ypad', 4)
         render_text.set_property('xalign', 1)
         col['renderer'] = ['markup', render_text]
         col['value'] = [str, self.get_tag_count]

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -278,7 +278,7 @@ class TreeviewFactory(object):
         col_name = 'color'
         col = {}
         render_tags = CellRendererTags()
-        render_tags.set_property('ypad', 4)
+        render_tags.set_property('ypad', 5)
         col['title'] = _("Tags")
         col['renderer'] = ['tag', render_tags]
         col['value'] = [GObject.TYPE_PYOBJECT, lambda node: node]
@@ -291,7 +291,7 @@ class TreeviewFactory(object):
         col_name = 'tagname'
         col = {}
         render_text = Gtk.CellRendererText()
-        render_text.set_property('ypad', 4)
+        render_text.set_property('ypad', 5)
         col['renderer'] = ['markup', render_text]
         col['value'] = [str, self.tag_name]
         col['expandable'] = True
@@ -303,8 +303,8 @@ class TreeviewFactory(object):
         col_name = 'tagcount'
         col = {}
         render_text = Gtk.CellRendererText()
-        render_text.set_property('xpad', 16)
-        render_text.set_property('ypad', 4)
+        render_text.set_property('xpad', 17)
+        render_text.set_property('ypad', 5)
         render_text.set_property('xalign', 1)
         col['renderer'] = ['markup', render_text]
         col['value'] = [str, self.get_tag_count]


### PR DESCRIPTION
Hi guys, this PR includes a few changes to the UI to bring it more in line with the current HIG and general UI style.

- Moved tags, synchronization, plugins and preferences to a main (burger) menu
- Brought back About and Help which were probably lost in the app menu
- Removed "tasks" from the names of the tabs to avoid repetition
- Added emoji input and button to quick entry. (I don't know if the button is really needed TBH, but it does look nice)
- Removed double borders in the sidebar
- Added some padding to the quick entry to avoid double edges there too
- Improved the padding in the sidebar
- Used symbolic icons for sidebar

There are two issues:
- The F9 shortcut only works if the main menu popup is open. I couldn't figure out how to fix this. Maybe we need to add a custom signal to the window or something like that instead?
- I wanted to add the `.sidebar` class to make the sidebar look more like Nautilus', but the tree widget is doing something to the styling of the cells and I couldn't figure out how to change it.

Mandatory Screen:
![Screenshot from 2019-11-23 21-34-04](https://user-images.githubusercontent.com/264829/69487458-10713200-0e39-11ea-8186-5fdabf0d032c.png)

