### PR TITLE
Remove editor new features

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -283,7 +283,7 @@ class TaskEditor(object):
                 alphabetically
                 '''
 
-    def on_tag_toggled(self, widget, path):
+    def on_tag_toggled(self, widget, path, column):
         """We toggle by tag_row variable. tag_row is
         meant to be a tuple (is_used, tagname)"""
         tag_row = self.tag_store[path]

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkPopover" id="closed_popover">
     <property name="can_focus">False</property>
     <child>

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -29,7 +29,10 @@
       <object class="GtkBox" id="menu_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">8</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkModelButton" id="dismiss">

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -442,11 +442,12 @@
         <property name="border_width">8</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkEntry" id="tags_entry">
+          <object class="GtkSearchEntry">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="has_focus">True</property>
-            <property name="is_focus">True</property>
+            <property name="primary_icon_name">edit-find-symbolic</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="primary_icon_sensitive">False</property>
             <property name="placeholder_text" translatable="yes">Search / Add</property>
           </object>
           <packing>

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -462,22 +462,10 @@
             <property name="model">tag_store</property>
             <property name="headers_visible">False</property>
             <property name="show_expanders">False</property>
+            <property name="activate_on_single_click">True</property>
+            <signal name="row-activated" handler="on_tag_toggled" swapped="no"/>
             <child internal-child="selection">
               <object class="GtkTreeSelection"/>
-            </child>
-            <child>
-              <object class="GtkTreeViewColumn" id="bool_column">
-                <property name="title">Toggle</property>
-                <property name="sort_column_id">0</property>
-                <child>
-                  <object class="GtkCellRendererToggle" id="renderer_toggle">
-                    <signal name="toggled" handler="on_tag_toggled" swapped="no"/>
-                  </object>
-                  <attributes>
-                    <attribute name="active">0</attribute>
-                  </attributes>
-                </child>
-              </object>
             </child>
             <child>
               <object class="GtkTreeViewColumn" id="tagname_column">

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -153,7 +153,7 @@
               <object class="GtkImage" id="menu-icon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">open-menu-symbolic</property>
+                <property name="icon_name">view-more-symbolic</property>
                 <property name="icon_size">1</property>
               </object>
             </child>

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -1,6 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkPopover" id="closed_popover">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox" id="closeddate_box">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkCalendar" id="calendar_closed">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopoverMenu" id="editor_menu_popover">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox" id="menu_box">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">8</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkModelButton" id="dismiss">
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text">Mark this task as not to be done anymore</property>
+            <property name="text" translatable="yes">Dismiss Task</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_dismiss" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="undismiss">
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text">Mark this task as to be done</property>
+            <property name="text" translatable="yes">Undismiss Task</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="on_dismiss" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparatorMenuItem">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="delete">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text">Permanently remove this task</property>
+            <property name="text" translatable="yes">Delete Task</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="delete_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">main</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkListStore" id="tag_store">
+    <columns>
+      <!-- column-name gboolean -->
+      <column type="gboolean"/>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkWindow" id="TaskEditor">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Task</property>
@@ -10,51 +112,52 @@
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
-        <property name="show_close_button">True</property>
+        <property name="can_focus">False</property>
         <property name="title" translatable="yes">Task</property>
+        <property name="show_close_button">True</property>
         <child>
           <object class="GtkButton" id="mark_as_done">
-            <property name="visible">False</property>
-            <property name="sensitive">True</property>
             <property name="label" translatable="yes">Mark as Done</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="tooltip_text" translatable="yes">Mark the task as done</property>
             <property name="valign">center</property>
-            <signal handler="on_mark_as_done" name="clicked" swapped="no"/>
+            <signal name="clicked" handler="on_mark_as_done" swapped="no"/>
           </object>
-          <packing>
-            <property name="pack_type">start</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="mark_as_undone">
-            <property name="visible">False</property>
-            <property name="sensitive">True</property>
             <property name="label" translatable="yes">Mark as not Done</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="tooltip_text" translatable="yes">Mark the task as to be done</property>
             <property name="valign">center</property>
-            <signal handler="on_mark_as_done" name="clicked" swapped="no"/>
+            <signal name="clicked" handler="on_mark_as_done" swapped="no"/>
           </object>
           <packing>
-            <property name="pack_type">start</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkMenuButton" id="editor_menu">
             <property name="visible">True</property>
-            <property name="sensitive">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="tooltip_text" translatable="yes">Task action menu</property>
             <property name="valign">center</property>
             <property name="popover">editor_menu_popover</property>
             <child>
               <object class="GtkImage" id="menu-icon">
                 <property name="visible">True</property>
-                <property name="icon-name">open-menu-symbolic</property>
-                <property name="icon-size">1</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">open-menu-symbolic</property>
+                <property name="icon_size">1</property>
               </object>
             </child>
           </object>
           <packing>
             <property name="pack_type">end</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -66,110 +169,94 @@
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="margin">3</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkBox" id="task_toolbar_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">5</property>
                 <child>
-                  <object class="GtkBox" id="text_formatting">
-                    <property name="visible">True</property>
-                    <style>
-                      <class name="linked"/>
-                    </style>
-                    <child>
-                      <object class="GtkButton" id="bold">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text">Bold</property>
-                        <child>
-                          <object class="GtkImage" id="bold_image">
-                            <property name="visible">True</property>
-                            <property name="icon-name">format-text-bold-symbolic</property>
-                            <property name="icon-size">2</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="italic">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text">Italic</property>
-                        <child>
-                          <object class="GtkImage" id="italic_image">
-                            <property name="visible">True</property>
-                            <property name="icon-name">format-text-italic-symbolic</property>
-                            <property name="icon-size">2</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-                <child>
                   <object class="GtkBox" id="task_options">
                     <property name="visible">True</property>
-                    <style>
-                      <class name="linked"/>
-                    </style>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkButton" id="add_subtask">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="receives_default">False</property>
                         <property name="tooltip_text">Add subtask to current task</property>
-                        <signal handler="on_insert_subtask_clicked" name="clicked" swapped="no"/>
+                        <signal name="clicked" handler="on_insert_subtask_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="subtask_image">
                             <property name="visible">True</property>
-                            <property name="icon-name">format-indent-more-symbolic</property>
-                            <property name="icon-size">2</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">format-indent-more-symbolic</property>
+                            <property name="icon_size">2</property>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
                     <child>
                       <object class="GtkMenuButton" id="tags">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="receives_default">False</property>
                         <property name="tooltip_text">Add tags to the task</property>
                         <property name="popover">tags_popover</property>
-                        <signal handler="on_tags_popover" name="clicked" swapped="no"/>
+                        <signal name="clicked" handler="on_tags_popover" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="tags_image">
                             <property name="visible">True</property>
-                            <property name="icon-name">user-bookmarks-symbolic</property>
-                            <property name="icon-size">2</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">user-bookmarks-symbolic</property>
+                            <property name="icon_size">2</property>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="parent">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="receives_default">False</property>
                         <property name="tooltip_text">Open the parent task</property>
-                        <signal handler="on_parent_select" name="clicked" swapped="yes"/>
+                        <signal name="clicked" handler="on_parent_select" swapped="yes"/>
                         <child>
                           <object class="GtkImage" id="parent_image">
                             <property name="visible">True</property>
-                            <property name="icon-name">go-up-symbolic</property>
-                            <property name="icon-size">2</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">go-up-symbolic</property>
+                            <property name="icon_size">2</property>
                           </object>
                         </child>
                       </object>
-                    </child> 
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <style>
+                      <class name="linked"/>
+                    </style>
                   </object>
-                </child>                 
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
                 <child>
                   <object class="GtkBox" id="start_box">
                     <property name="visible">True</property>
@@ -178,8 +265,8 @@
                       <object class="GtkLabel" id="start_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Starts on</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -197,8 +284,8 @@
                         <property name="can_focus">True</property>
                         <property name="width_chars">10</property>
                         <signal name="changed" handler="startingdate_changed" swapped="no"/>
-                        <signal name="focus-out-event" handler="startdate_focus_out" swapped="no"/>
                         <signal name="focus-in-event" handler="show_popover_start" swapped="no"/>
+                        <signal name="focus-out-event" handler="startdate_focus_out" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -207,6 +294,11 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="end_box">
@@ -216,8 +308,8 @@
                       <object class="GtkLabel" id="end_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Due on</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -235,8 +327,8 @@
                         <property name="can_focus">True</property>
                         <property name="width_chars">10</property>
                         <signal name="changed" handler="duedate_changed" swapped="no"/>
-                        <signal name="focus-out-event" handler="duedate_focus_out" swapped="no"/>
                         <signal name="focus-in-event" handler="show_popover_due" swapped="no"/>
+                        <signal name="focus-out-event" handler="duedate_focus_out" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -245,6 +337,11 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="closed_box">
@@ -254,8 +351,8 @@
                       <object class="GtkLabel" id="closed_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Closed on</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -273,8 +370,8 @@
                         <property name="can_focus">True</property>
                         <property name="width_chars">10</property>
                         <signal name="changed" handler="closeddate_changed" swapped="no"/>
-                        <signal name="focus-out-event" handler="closeddate_focus_out" swapped="no"/>
                         <signal name="focus-in-event" handler="show_popover_closed" swapped="no"/>
+                        <signal name="focus-out-event" handler="closeddate_focus_out" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -283,6 +380,11 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
                 </child>
               </object>
               <packing>
@@ -292,6 +394,11 @@
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkScrolledWindow" id="scrolledtask">
@@ -318,92 +425,46 @@
       </object>
     </child>
   </object>
-  <object class="GtkPopover" id="closed_popover">
-    <child>
-      <object class="GtkBox" id="closeddate_box">
-        <property name="visible">True</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkCalendar" id="calendar_closed">
-            <property name="visible">True</property>
-          </object>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkPopoverMenu" id="editor_menu_popover">
-    <child>
-      <object class="GtkBox" id="menu_box">
-        <property name="border-width">8</property>
-        <property name="visible">True</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkModelButton" id="dismiss">
-            <property name="visible">False</property>
-            <property name="centered">True</property>
-            <property name="text" translatable="yes">Dismiss Task</property>
-            <property name="tooltip_text">Mark this task as not to be done anymore</property>
-            <signal handler="on_dismiss" name="clicked" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="undismiss">
-            <property name="visible">False</property>
-            <property name="centered">True</property>
-            <property name="text" translatable="yes">Undismiss Task</property>
-            <property name="tooltip_text">Mark this task as to be done</property>
-            <signal handler="on_dismiss" name="clicked" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSeparatorMenuItem">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="delete">
-            <property name="visible">True</property>
-            <property name="centered">True</property>
-            <property name="text" translatable="yes">Delete Task</property>
-            <property name="tooltip_text">Permanently remove this task</property>
-            <signal handler="delete_clicked" name="clicked" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-  </object>
   <object class="GtkPopoverMenu" id="tags_popover">
-    <property name="relative-to">tags</property>
+    <property name="can_focus">False</property>
+    <property name="relative_to">tags</property>
     <child>
       <object class="GtkBox" id="tags_box">
-        <property name="border-width">8</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkEntry" id="tags_entry">
             <property name="visible">True</property>
-            <property name="has_focus">True</property>
             <property name="can_focus">True</property>
+            <property name="has_focus">True</property>
             <property name="is_focus">True</property>
-            <property name="max-width-chars">-1</property>
-            <property name="placeholder-text" translatable="yes">Search / Add</property>
+            <property name="placeholder_text" translatable="yes">Search / Add</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkTreeView" id="tags_tree">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="headers-visible">False</property>
-            <property name="show-expanders">False</property>
             <property name="model">tag_store</property>
+            <property name="headers_visible">False</property>
+            <property name="show_expanders">False</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection"/>
+            </child>
             <child>
               <object class="GtkTreeViewColumn" id="bool_column">
                 <property name="title">Toggle</property>
                 <property name="sort_column_id">0</property>
                 <child>
                   <object class="GtkCellRendererToggle" id="renderer_toggle">
-                    <signal handler="on_tag_toggled" name="toggled"/>
+                    <signal name="toggled" handler="on_tag_toggled" swapped="no"/>
                   </object>
                   <attributes>
                     <attribute name="active">0</attribute>
@@ -424,14 +485,17 @@
               </object>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
       </object>
+      <packing>
+        <property name="submenu">main</property>
+        <property name="position">1</property>
+      </packing>
     </child>
-  </object>
-  <object class="GtkListStore" id="tag_store">
-    <columns>
-      <column type="gboolean"/>
-      <column type="gchararray"/>      
-    </columns>
   </object>
 </interface>

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -175,6 +175,10 @@
               <object class="GtkBox" id="task_toolbar_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">10</property>
+                <property name="margin_right">10</property>
+                <property name="margin_top">5</property>
+                <property name="margin_bottom">5</property>
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkBox" id="task_options">

--- a/GTG/gtk/ui/taskeditor.ui
+++ b/GTG/gtk/ui/taskeditor.ui
@@ -439,12 +439,16 @@
       <object class="GtkBox" id="tags_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">8</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkSearchEntry">
+          <object class="GtkSearchEntry" id="tags_entry">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="margin_bottom">10</property>
             <property name="primary_icon_name">edit-find-symbolic</property>
             <property name="primary_icon_activatable">False</property>
             <property name="primary_icon_sensitive">False</property>
@@ -463,6 +467,7 @@
             <property name="model">tag_store</property>
             <property name="headers_visible">False</property>
             <property name="show_expanders">False</property>
+            <property name="enable_grid_lines">horizontal</property>
             <property name="activate_on_single_click">True</property>
             <signal name="row-activated" handler="on_tag_toggled" swapped="no"/>
             <child internal-child="selection">
@@ -470,6 +475,7 @@
             </child>
             <child>
               <object class="GtkTreeViewColumn" id="tagname_column">
+                <property name="sizing">autosize</property>
                 <property name="title">Toggle</property>
                 <property name="sort_column_id">1</property>
                 <child>


### PR DESCRIPTION
This PR removes the bold/italic buttons (they can be brought back when they are implemented). It also adds padding to a bunch of popups and fixes the icon menu for the task editor.

It also removes the checkbox from the tags popup and adds tags just by clicking their name.
This is closer to the old gtg behaviour. The checkbox was added so that tags could also be removed from the menu, but since that's not implemented unchecking the the checkbox did nothing (which is kind of weird for the user).