### PR TITLE
Add missing dependent packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pyflakes
 pep8
 mock
 -e git+http://github.com/getting-things-gnome/liblarch.git#egg=liblarch
+dbus-python
+PyGObject


### PR DESCRIPTION
These two packages are required when trying to run GTG from a local
virtual environment by executing script gtg.sh

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>