### PR TITLE
Add tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp
 .pydevproject
 .project
 .settings
+.tox
 **/**.glade.h
 **/**.gladep
 **/**.gladep.bak

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-PEP8=pep8
+PEP8=pycodestyle
 PYFLAKES=pyflakes
 
 check: tests pep8 pyflakes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ spec
 pyxdg
 pyflakes
 pep8
+pycodestyle
 mock
 -e git+http://github.com/getting-things-gnome/liblarch.git#egg=liblarch
 dbus-python

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py37,pep8
+sitepackages=True
+
+[testenv]
+sitepackages=True
+deps=-rrequirements.txt
+commands=make tests
+whitelist_externals=/usr/bin/make
+
+[testenv:pep8]
+commands=make pep8


### PR DESCRIPTION
Tox is a widely spread testing automation tool for python projects,
it still uses the Makefile under the hood, but tox will take care
of managing virtualenvs and running the tests inside of them.