### PR TITLE
debug.sh: Drop -l from usage help as it is not a valid option anymore

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -22,7 +22,7 @@ do  case "$o" in
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG";;
-    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-l] [-n]"
+    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-n]"
          exit 1;;
     esac
 done


### PR DESCRIPTION
The option is gone from main gtg binary since commit 5131f6fae6c4efed,
where it was also dropped from debug.sh script, but appears it was
forgotten to be dropped from the usage help string.