### PR TITLE
Hide delete tag option in context menu for saved search

### DIFF
--- a/GTG/gtk/browser/tag_context_menu.py
+++ b/GTG/gtk/browser/tag_context_menu.py
@@ -90,8 +90,8 @@ class TagContextMenu(Gtk.Menu):
     def on_mi_ctag_activate(self, widget):
         random_color = generate_tag_color()
         present_color = self.tag.get_attribute('color')
-        if(present_color is not None):
-                color_remove(present_color)
+        if present_color is not None:
+            color_remove(present_color)
         self.tag.set_attribute('color', random_color)
         color_add(random_color)
 

--- a/GTG/gtk/browser/tag_context_menu.py
+++ b/GTG/gtk/browser/tag_context_menu.py
@@ -53,22 +53,26 @@ class TagContextMenu(Gtk.Menu):
             # Color chooser FIXME: SHOULD BECOME A COLOR PICKER
             self.mi_cc = Gtk.MenuItem()
             self.mi_cc.set_label(_("Edit Tag..."))
+            self.append(self.mi_cc)
+            self.mi_cc.connect('activate', self.on_mi_cc_activate)
+
             self.mi_ctag = Gtk.MenuItem()
             self.mi_ctag.set_label(_("Generate Color"))
-            self.mi_del_tag = Gtk.MenuItem()
-            self.mi_del_tag.set_label(_("Delete Tag"))
-            self.append(self.mi_cc)
             self.append(self.mi_ctag)
-            self.append(self.mi_del_tag)
-            self.mi_del_tag.connect(
-                'activate', self.app.browser.on_delete_tag_activate)
-            self.mi_cc.connect('activate', self.on_mi_cc_activate)
             self.mi_ctag.connect('activate', self.on_mi_ctag_activate)
+
             if self.tag.is_search_tag():
                 self.mi_del = Gtk.MenuItem()
                 self.mi_del.set_label(_("Delete"))
                 self.append(self.mi_del)
                 self.mi_del.connect('activate', self.on_mi_del_activate)
+            else:
+                self.mi_del_tag = Gtk.MenuItem()
+                self.mi_del_tag.set_label(_("Delete Tag"))
+                self.append(self.mi_del_tag)
+                self.mi_del_tag.connect(
+                    'activate', self.app.browser.on_delete_tag_activate)
+
         # Make it visible
         self.show_all()
 


### PR DESCRIPTION
Deleting the tag in this case doesn't do anything since it's actually a saved search, without a '@' prepended to the text.

Fixes #283 

There is a bigger issue here, in that it doesn't seem possible to actually alter the search term(s) once the search has been saved. So having a "Edit Search..." option that just displays the same window as for editing tags is misleading. Probably the "Edit Tag..." option should not be displayed at all for saved searches. Instead there should be a window specifically for editing saved searches, which actually allows you update the saved search terms. I thought that was probably out of scope for this ticket.