### PR TITLE
meson: Explicitly install python sources to purelib path

### DIFF
--- a/GTG/backends/meson.build
+++ b/GTG/backends/meson.build
@@ -7,4 +7,4 @@ gtg_backend_sources = [
   'sync_engine.py',
 ]
 
-python3.install_sources(gtg_backend_sources, subdir: 'GTG' / 'backends')
+python3.install_sources(gtg_backend_sources, subdir: 'GTG' / 'backends', pure: true)

--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -31,5 +31,5 @@ gtg_core_plugin_sources = [
   'plugins/engine.py',
 ]
 
-python3.install_sources(gtg_core_sources, subdir: 'GTG' / 'core')
-python3.install_sources(gtg_core_plugin_sources, subdir: 'GTG' / 'core' / 'plugins')
+python3.install_sources(gtg_core_sources, subdir: 'GTG' / 'core', pure: true)
+python3.install_sources(gtg_core_plugin_sources, subdir: 'GTG' / 'core' / 'plugins', pure: true)

--- a/GTG/gtk/meson.build
+++ b/GTG/gtk/meson.build
@@ -62,9 +62,9 @@ gtg_editor_sources = [
   'editor/taskview.py',
 ]
 
-python3.install_sources(gtg_gtk_sources, subdir: 'GTG' / 'gtk')
-python3.install_sources(gtg_backend_sources, subdir: 'GTG' / 'gtk' / 'backends')
-python3.install_sources(gtg_backend_parameters_ui_sources, subdir: 'GTG' / 'gtk' / 'backends' / 'parameters_ui')
-python3.install_sources(gtg_browser_sources, subdir: 'GTG' / 'gtk' / 'browser')
-python3.install_sources(gtg_data_sources, subdir: 'GTG' / 'gtk' / 'data')
-python3.install_sources(gtg_editor_sources, subdir: 'GTG' / 'gtk' / 'editor')
+python3.install_sources(gtg_gtk_sources, subdir: 'GTG' / 'gtk', pure: true)
+python3.install_sources(gtg_backend_sources, subdir: 'GTG' / 'gtk' / 'backends', pure: true)
+python3.install_sources(gtg_backend_parameters_ui_sources, subdir: 'GTG' / 'gtk' / 'backends' / 'parameters_ui', pure: true)
+python3.install_sources(gtg_browser_sources, subdir: 'GTG' / 'gtk' / 'browser', pure: true)
+python3.install_sources(gtg_data_sources, subdir: 'GTG' / 'gtk' / 'data', pure: true)
+python3.install_sources(gtg_editor_sources, subdir: 'GTG' / 'gtk' / 'editor', pure: true)

--- a/GTG/meson.build
+++ b/GTG/meson.build
@@ -2,7 +2,10 @@ gtg_sources = [
   '__init__.py'
 ]
 
-python3.install_sources(gtg_sources, subdir: 'GTG')
+# The explicit `pure: true` can go away here and other files once we rely
+# on new enough meson to guarantee the default is pure as documented
+# https://github.com/mesonbuild/meson/pull/6848
+python3.install_sources(gtg_sources, subdir: 'GTG', pure: true)
 
 configure_file(
   input: 'gtg.in',

--- a/GTG/plugins/export/meson.build
+++ b/GTG/plugins/export/meson.build
@@ -26,5 +26,5 @@ gtg_plugin_export_template_sources = [
   'export_templates/thumbnail_textual.png',
 ]
 
-python3.install_sources(gtg_plugin_export_sources, subdir: 'GTG' / 'plugins' / 'export')
-python3.install_sources(gtg_plugin_export_template_sources, subdir: 'GTG' / 'plugins' / 'export' / 'export_templates')
+python3.install_sources(gtg_plugin_export_sources, subdir: 'GTG' / 'plugins' / 'export', pure: true)
+python3.install_sources(gtg_plugin_export_template_sources, subdir: 'GTG' / 'plugins' / 'export' / 'export_templates', pure: true)

--- a/GTG/plugins/meson.build
+++ b/GTG/plugins/meson.build
@@ -6,7 +6,7 @@ gtg_plugin_sources = [
   'urgency-color.gtg-plugin',
 ]
 
-python3.install_sources(gtg_plugin_sources, subdir: 'GTG' / 'plugins')
+python3.install_sources(gtg_plugin_sources, subdir: 'GTG' / 'plugins', pure: true)
 subdir('export')
 subdir('send_email')
 subdir('untouched_tasks')

--- a/GTG/plugins/send_email/meson.build
+++ b/GTG/plugins/send_email/meson.build
@@ -3,4 +3,4 @@ gtg_plugin_send_email_sources = [
   'sendEmail.py',
 ]
 
-python3.install_sources(gtg_plugin_send_email_sources, subdir: 'GTG' / 'plugins' / 'send_email')
+python3.install_sources(gtg_plugin_send_email_sources, subdir: 'GTG' / 'plugins' / 'send_email', pure: true)

--- a/GTG/plugins/untouched_tasks/meson.build
+++ b/GTG/plugins/untouched_tasks/meson.build
@@ -4,4 +4,4 @@ gtg_plugin_untouched_tasks_sources = [
   'untouchedTasks.ui',
 ]
 
-python3.install_sources(gtg_plugin_untouched_tasks_sources, subdir: 'GTG' / 'plugins' / 'untouched_tasks')
+python3.install_sources(gtg_plugin_untouched_tasks_sources, subdir: 'GTG' / 'plugins' / 'untouched_tasks', pure: true)

--- a/GTG/plugins/urgency_color/meson.build
+++ b/GTG/plugins/urgency_color/meson.build
@@ -4,4 +4,4 @@ gtg_plugin_urgency_color_sources = [
   'urgency_color.py',
 ]
 
-python3.install_sources(gtg_plugin_urgency_color_sources, subdir: 'GTG' / 'plugins' / 'urgency_color')
+python3.install_sources(gtg_plugin_urgency_color_sources, subdir: 'GTG' / 'plugins' / 'urgency_color', pure: true)

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ local_config.set('localedir', meson.source_root() / 'po')
 
 # Wrapper to launch gtg with non-/usr prefix install PYTHONPATH
 wrapper_config = configuration_data()
-wrapper_config.set('python_installdir', python3.get_install_dir())
+wrapper_config.set('python_installdir', python3.get_install_dir(pure: true))
 configure_file(
   input: 'prefix-gtg.sh.in',
   output: 'prefix-gtg.sh',


### PR DESCRIPTION
Despite the documentation stating that it's done by default, it wasn't
doing that until very recently. However it was in the case of
get_install_dir, so they were inconsistent and breaking gtg.sh usage
on systems where purelib and platlib differ for the used python.
Request pure explicitly to workaround the meson issue that was fixed
by https://github.com/mesonbuild/meson/pull/6848 in meson.