### PR TITLE
Tasks column translatable

### DIFF
--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -325,7 +325,7 @@ class TreeviewFactory():
 
     def active_tasks_treeview(self, tree):
         # Build the title/label/tags columns
-        desc = self.common_desc_for_tasks(tree, "Tasks")
+        desc = self.common_desc_for_tasks(tree, _("Tasks"))
 
         # "startdate" column
         col_name = 'startdate'

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -422,7 +422,7 @@ class TreeviewFactory():
         # "label" column
         col_name = 'label'
         col = {}
-        col['title'] = _(title_label)
+        col['title'] = title_label
         render_text = Gtk.CellRendererText()
         render_text.set_property("ellipsize", Pango.EllipsizeMode.END)
         col['renderer'] = ['markup', render_text]


### PR DESCRIPTION
Note that, at least in the german version, there is existing translation for this string in an #~ "comment" (gettext complained about duplicate string when I added that string manually).
This translation may be re-used next time translations are refreshed.

Additionally, in `common_desc_for_tasks` the parameter `title_label` is getting translated again.
This is removed since callers already translate their label and has the benefit of gettext finding them.