### PR TITLE
Export plugin: Make it clickable in the menu

### DIFF
--- a/GTG/plugins/export/export.py
+++ b/GTG/plugins/export/export.py
@@ -180,8 +180,9 @@ class ExportPlugin():
         """ Initialize all the GTK widgets """
         self.menu_entry = False
 
-        self.menu_item = Gtk.MenuItem(_("Export the tasks currently listed"))
-        self.menu_item.connect('activate', self.show_dialog)
+        self.menu_item = Gtk.ModelButton()
+        self.menu_item.set_label(_("Export the tasks currently listed"))
+        self.menu_item.connect('clicked', self.show_dialog)
         self.menu_item.show()
 
         builder = Gtk.Builder()


### PR DESCRIPTION
Looks like since the GTK3 Headerbar switch, the new menus use ModelButtons instead of the old MenuItems.
[Fixes the comment by nekohayo](https://github.com/getting-things-gnome/gtg/issues/299#issuecomment-638259673) in #299.

Found using the [GTK Inspector](https://developer.gnome.org/gtk3/3.24/gtk-running.html#interactive-debugging) (Ctrl+Shift+i doesn't work for some reason, I used `GTK_DEBUG=interactive ./launch.sh`: (The export plugins menu entry is called "Exportiere die aktuell gelistete Aufgaben" here)
![Image of the GTK Inspector showing the button being GtkMenuItem instead of GtkModelButton like the others](https://user-images.githubusercontent.com/1196130/85174769-4b740080-b276-11ea-9d05-7c0ba823dcaf.png)


Note that the plugin itself seems to be buggy, I couldn't export anything (to check what it really exports, like does it take into account the current filter being applied?)
When trying to export (using the open button), I just get an error message that the document couldn't be exported, and a reason is some python error, so there is still debugging to be done.
Possibly remove the plugin temporarily for the upcoming release, if there isn't enough time.

(BTW the "open" string when exporting conflicts with the "open" (view) string in the main window for the open tasks; There is an distinction in german, I would likely make an PR or Issue to mark the "open" (view) string in the main window specially, so it has its own translation)