### PR TITLE
Add translation context for the tasks view names

### DIFF
--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -480,7 +480,7 @@
                       </object>
                       <packing>
                         <property name="name">open_view</property>
-                        <property name="title" translatable="yes">Open</property>
+                        <property name="title" translatable="yes" context="tasks view name">Open</property>
                       </packing>
                     </child>
                     <child>
@@ -494,7 +494,7 @@
                       </object>
                       <packing>
                         <property name="name">actionable_view</property>
-                        <property name="title" translatable="yes">Actionable</property>
+                        <property name="title" translatable="yes" context="tasks view name">Actionable</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -509,7 +509,7 @@
                       </object>
                       <packing>
                         <property name="name">closed_view</property>
-                        <property name="title" translatable="yes">Closed</property>
+                        <property name="title" translatable="yes" context="tasks view name">Closed</property>
                         <property name="position">2</property>
                       </packing>
                     </child>


### PR DESCRIPTION
The open tasks view (to view all open tasks) is rightfully called "Open", however, it is also used as an verb (like in the Export plugin).
This is problematic for languages that has distinct words for those two situations (such as in german: "Offen" for the former one, and "Öffnen" for the latter one).
Because the latter is the more "usual" case, the name of the view names get an special gettext message context.

Note that this means translators would have to re-check the translation as it would be marked as fuzzy by gettext.
From very little testing (as I am not very familiar with the gettext tools), it did that for me, but also correctly separated the "Open" from the export plugin and the "Open" from the task view name in the main window.