### PR TITLE
Untouched Plugin: Make main menu entry translatable

### DIFF
--- a/GTG/plugins/untouched_tasks/untouchedTasks.py
+++ b/GTG/plugins/untouched_tasks/untouchedTasks.py
@@ -17,6 +17,7 @@
 from threading import Timer
 import datetime
 import os
+from gettext import gettext as _
 
 from gi.repository import Gtk
 
@@ -60,7 +61,7 @@ class UntouchedTasksPlugin():
 
         self.builder.connect_signals(SIGNAL_CONNECTIONS_DIC)
         self.menu_item = Gtk.ModelButton.new()
-        self.menu_item.set_label("Add @untouched tag")
+        self.menu_item.set_label(_("Add @untouched tag"))
         self.menu_item.connect("clicked", self.add_untouched_tag)
 
     def activate(self, plugin_api):


### PR DESCRIPTION
Not tested whenever xgettext picks up when generating the PO file (but I can't think why it shouldn't), but adding it manually works.