### PR TITLE
Proposal for schema (Redux mk. II)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ flatpak/cache
 flatpak/.flatpak-builder
 flatpak/bundles
 /.local_build/
+.idea/
 
 # src/ usually has development version of liblarch
 src/

--- a/data/schema/_elements.xsd
+++ b/data/schema/_elements.xsd
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema targetNamespace="https://wiki.gnome.org/Apps/GTG"
+           xmlns="https://wiki.gnome.org/Apps/GTG"
+           xmlns:gtgData="https://wiki.gnome.org/Apps/GTG"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 
@@ -71,6 +74,20 @@
               <xs:element name="tag" type="t_std_UUID4" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
           </xs:complexType>
+          <!--
+            This verifies that tag IDs are valid...
+          -->
+          <xs:keyref name="key_task_tags" refer="key_tag_id">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="@id"/>
+          </xs:keyref>
+          <!--
+            And this verifies that tag IDs are unique in a given task.
+          -->
+          <xs:unique name="uniq_task_tags">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="."/>
+          </xs:unique>
         </xs:element>
         <!--
           NOTE: xs:dateTime accepts several different ISO 8601 formats.
@@ -104,8 +121,11 @@
               <xs:element name="sub" type="t_std_UUID4" minOccurs="1" maxOccurs="unbounded"/>
             </xs:sequence>
           </xs:complexType>
+          <!--
+            This verifies that subtask IDs are unique in a given task.
+          -->
           <xs:unique name="uniq_task_subtasks">
-            <xs:selector xpath="sub"/>
+            <xs:selector xpath="*"/>
             <xs:field xpath="."/>
           </xs:unique>
         </xs:element>

--- a/data/schema/_elements.xsd
+++ b/data/schema/_elements.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <!--
+    Getting Things GNOME! - a personal organizer for the GNOME desktop
+    Copyright (c) 2008-2013 - Lionel Dricot & Bertrand Rousseau
+
+    This program is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with
+    this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+  <xs:include schemaLocation="_types.xsd"/>
+  <xs:include schemaLocation="http://xml.r00t2.io/schema/lib/types/std.xsd"/>
+  <xs:include schemaLocation="http://xml.r00t2.io/schema/lib/types/unix.xsd"/>
+
+  <!-- ############################################################################################################# -->
+
+  <xs:complexType name="e_gtg_tag">
+    <!--
+      If https://github.com/getting-things-gnome/gtg/issues/279#issuecomment-659198547 § "Tags" is implemented
+      (e.g. the name is switched to the text component instead of an attribute), uncomment the below and remove the
+      "name" attribute defined.
+    -->
+    <!--
+    <xs:simpleContent>
+      <xs:restriction base="t_std_UUID4"/>
+    </xs:simpleContent>
+    -->
+    <!--
+      TODO: Any restrictions on valid chars/length (min/max) for tag names?
+    -->
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="id" type="t_std_UUID4" use="required"/>
+    <!--
+      TODO: Down the line, you can set use="optional" and default="(whatever the default color's hex is)"
+            LXML can then auto-populate it at parse time, or explicitly populate it on creation based on default value
+            if one is not defined.
+    -->
+    <!--
+      TODO: Will tags currently always have a color defined explicitly?
+            If not, set use="optional".
+    -->
+    <xs:attribute name="color" type="xs:hexBinary" use="required"/>
+    <!--
+      TODO: Is this always a relative path or specific filename?
+            If always relative, change type to "t_unix_relfilepath".
+            If always a filename (i.e. no directory traversal), change type to "t_unix_portablePosixFilename".
+    -->
+    <xs:attribute name="icon" type="t_unix_anyfile" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="e_gtg_task">
+    <xs:sequence minOccurs="1" maxOccurs="5">
+      <xs:choice minOccurs="1" maxOccurs="5">
+        <xs:element name="title" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="tags" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="tag" type="t_std_UUID4" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <!--
+          NOTE: xs:dateTime accepts several different ISO 8601 formats.
+                All *fixed* (i.e. non-fuzzy) dates MUST be in the form:
+                  %Y-%m-%dT%H:%M:%SZ (e.g. 2020-07-16T02:08:00Z)
+                so that it simplifies datetime.datetime.strptime() handling.
+        -->
+        <xs:element name="dates" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence minOccurs="2" maxOccurs="5">
+              <xs:choice minOccurs="2" maxOccurs="5">
+                <xs:element name="addedDate" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="modifyDate" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="doneDate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="startDate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+                <!--
+                  NOTE: At MOST one of the below may (optionally) be specified in the task's dates.
+                -->
+                <xs:choice minOccurs="0" maxOccurs="1">
+                  <xs:element name="dueDate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="fuzzyDueDate" type="t_gtg_fuzzyDueDates" minOccurs="0" maxOccurs="1"/>
+                </xs:choice>
+              </xs:choice>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="content" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="subtasks" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="sub" type="t_std_UUID4" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:unique name="uniq_task_subtasks">
+            <xs:selector xpath="sub"/>
+            <xs:field xpath="."/>
+          </xs:unique>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="id" type="t_std_UUID4" use="required"/>
+    <xs:attribute name="status" type="t_gtg_taskStatus" use="required"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/data/schema/_types.xsd
+++ b/data/schema/_types.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <!--
+    Getting Things GNOME! - a personal organizer for the GNOME desktop
+    Copyright (c) 2008-2013 - Lionel Dricot & Bertrand Rousseau
+
+    This program is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with
+    this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+  <!-- ############################################################################################################# -->
+  <!-- CUSTOM DATATYPES -->
+
+  <xs:simpleType name="t_gtg_fuzzyDueDates">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="now"/>
+      <xs:enumeration value="soon"/>
+      <xs:enumeration value="someday"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="t_gtg_taskStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Active"/>
+      <xs:enumeration value="Dismiss"/>
+      <xs:enumeration value="Done"/>
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/data/schema/_types.xsd
+++ b/data/schema/_types.xsd
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema targetNamespace="https://wiki.gnome.org/Apps/GTG"
+           xmlns="https://wiki.gnome.org/Apps/GTG"
+           xmlns:gtgData="https://wiki.gnome.org/Apps/GTG"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 

--- a/data/schema/data.xsd
+++ b/data/schema/data.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema targetNamespace="https://wiki.gnome.org/Apps/GTG"
            xmlns="https://wiki.gnome.org/Apps/GTG"
-           xmlns:project="https://wiki.gnome.org/Apps/GTG"
+           xmlns:gtgData="https://wiki.gnome.org/Apps/GTG"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
@@ -43,6 +43,24 @@
                 <xs:element name="tag" type="e_gtg_tag" minOccurs="1" maxOccurs="unbounded"/>
               </xs:sequence>
             </xs:complexType>
+            <!--
+              This verifies and indexes tags name.
+            -->
+            <!--
+              TODO: If the name is changed to be the *content* (text()) of the tag instead of an attribute,
+                    change xs:field's path attribute to "." instead of "@name".
+            -->
+            <xs:key name="key_tag_name">
+              <xs:selector xpath="gtgData:tag"/>
+              <xs:field xpath="@name"/>
+            </xs:key>
+            <!--
+              This verifies and indexes tags' id attribute.
+            -->
+            <xs:key name="key_tag_id">
+              <xs:selector xpath="gtgData:tag"/>
+              <xs:field xpath="@id"/>
+            </xs:key>
           </xs:element>
           <xs:element name="tasklist" minOccurs="1" maxOccurs="1">
             <xs:complexType>
@@ -50,6 +68,34 @@
                 <xs:element name="task" type="e_gtg_task" minOccurs="1" maxOccurs="unbounded"/>
               </xs:sequence>
             </xs:complexType>
+            <!--
+              This verifies and indexes tasks' id attribute.
+            -->
+            <xs:key name="key_task_id">
+              <xs:selector xpath="gtgData:task"/>
+              <xs:field xpath="@id"/>
+            </xs:key>
+            <!--
+              This verifies that subtask IDs are valid.
+            -->
+            <xs:keyref name="key_task_subtasks" refer="key_task_id">
+              <xs:selector xpath="gtgData:task/gtgData:subtasks/gtgData:sub/."/>
+              <xs:field xpath="."/>
+            </xs:keyref>
+            <!--
+              This verifies that no two (or more!) tasks have the same content.
+            -->
+            <xs:unique name="uniq_task_content">
+              <xs:selector xpath="gtgData:task/gtgData:content"/>
+              <xs:field xpath="."/>
+            </xs:unique>
+            <!--
+              This verifies that no two (or more!) tasks have the same title (to avoid UX confusion).
+            -->
+            <xs:unique name="uniq_task_title">
+              <xs:selector xpath="gtgData:task/gtgData:title"/>
+              <xs:field xpath="."/>
+            </xs:unique>
           </xs:element>
         </xs:choice>
       </xs:sequence>

--- a/data/schema/data.xsd
+++ b/data/schema/data.xsd
@@ -85,10 +85,13 @@
             <!--
               This verifies that no two (or more!) tasks have the same content.
             -->
+            <!-- DISABLING BECAUSE IT WILL CHOKE ON EMPTY CONTENT ELEMENTS. -->
+            <!--
             <xs:unique name="uniq_task_content">
               <xs:selector xpath="gtgData:task/gtgData:content"/>
               <xs:field xpath="."/>
             </xs:unique>
+            -->
             <!--
               This verifies that no two (or more!) tasks have the same title (to avoid UX confusion).
             -->

--- a/data/schema/data.xsd
+++ b/data/schema/data.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema targetNamespace="https://wiki.gnome.org/Apps/GTG"
+           xmlns="https://wiki.gnome.org/Apps/GTG"
+           xmlns:project="https://wiki.gnome.org/Apps/GTG"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <!--
+  Getting Things GNOME! - a personal organizer for the GNOME desktop
+  Copyright (c) 2008-2013 - Lionel Dricot & Bertrand Rousseau
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+  <xs:include schemaLocation="_types.xsd"/>
+  <xs:include schemaLocation="_elements.xsd"/>
+
+  <!-- ############################################################################################################# -->
+
+  <xs:element name="gtgData">
+    <xs:complexType>
+      <!--
+        NOTE: We encapsulate a choice in the sequence so the order doesn't matter. (Normally, order specified in a
+              document has to match order specified in the schema if a sequence is used.)
+      -->
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element name="taglist" minOccurs="1" maxOccurs="1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="tag" type="e_gtg_tag" minOccurs="1" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="tasklist" minOccurs="1" maxOccurs="1">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="task" type="e_gtg_task" minOccurs="1" maxOccurs="unbounded"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="appVersion" type="xs:decimal" use="required"/>
+      <xs:attribute name="xmlVersion" type="xs:positiveInteger" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
_**NOTE**: This is a total redo of #431 (and #437, oops - need to stop playing with branches I have open PRs for) to match the updated example in #279 as it progresses._

---

Hey all! I'm composing some [XSDs](https://www.w3.org/TR/xmlschema-1/) for GTG.

## Why?

This, combined with the porting to LXML (#401) (LXML natively supports XSD), will let you do some REALLY nice things programmatically:

* Automatic data validation/verification
* Automatic structure validation/verification
* Automatic population of default attributes
* Address and enforce concerns in #279 as they're implemented
* *Very* easy test cases for generated XML

## Review

I'd like someone more familiar with the GTG guts to give it a look over. Please review and reference the items marked:

```xml
<!--
  TODO: ...
-->
```
for specific questions/concerns/suggestions I have.

## Outer scope changes

The `gtg_tasks.xml` (filename subject to change per #279 approval/implementation), etc. will need to have namespaces added.

e.g. for `gtg_tasks.xml`, instead of:

```xml
<?xml version="1.0" ?>
<gtgData appVersion="0.5" xmlVersion="2">
<!-- ... -->
</gtgData>
```

it'd be:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<gtgData appVersion="0.5"
         xmlVersion="2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://wiki.gnome.org/Apps/GTG"
         xsi:schemaLocation="http://SOMEDOMAIN.TLD/SOME/PATH/TO/data.xsd">
<!-- ... -->
</project>
```

This can be done programmatically, and I can provide code to convert existing documents over to the namespaced version.

## Implementation

I can provide examples of how to automatically detect, parse, fetch, and validate XSDs (and strip the namespace once the data/structure is validated/verified and defaults are applied, so the elements don't need to be referenced by namespace) with lxml, as I have direct experience with lxml in python3 and the above.

## Further Reading

It is recommended to review #279 in full and take note of the example proposed document format. This PR will attempt to stay in tandem with current proposed format per #279, and will exit draft stage and enter a review/pulling stage once the specification in #279 hits master.