### PR TITLE
Fix Untouched Task timer upper limit

### DIFF
--- a/GTG/plugins/untouched_tasks/untouchedTasks.ui
+++ b/GTG/plugins/untouched_tasks/untouchedTasks.ui
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">1</property>
-    <property name="upper">100</property>
+    <property name="upper">999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>


### PR DESCRIPTION
Current upper limit in Untouched Task timer is 100 days, which seems
arbitrary and might confuse users.

Since the Entry widget for the timer is limited to show up to 3 digits,
it seems more reasonable to set this upper limit to 999 days.

Closes #412