### PR TITLE
Translatable plugin file (.gtg-plugin) strings

### DIFF
--- a/GTG/core/plugins/engine.py
+++ b/GTG/core/plugins/engine.py
@@ -17,7 +17,7 @@
 # -----------------------------------------------------------------------------
 import imp
 import os
-import configparser
+from gi.repository import GLib
 
 from GTG.core.dirs import PLUGIN_DIRS
 from GTG.core.borg import Borg
@@ -147,9 +147,10 @@ class PluginEngine(Borg):
             for f in os.listdir(path):
                 info_file = os.path.join(path, f)
                 if os.path.isfile(info_file) and f.endswith('.gtg-plugin'):
-                    info = configparser.ConfigParser()
-                    info.read(info_file)
-                    info = dict(info.items("GTG Plugin", True))
+                    parser = GLib.KeyFile.new()
+                    parser.load_from_file(info_file, GLib.KeyFileFlags.NONE)
+                    keys = parser.get_keys("GTG Plugin")[0] # The list of keys
+                    info = {key: parser.get_locale_string("GTG Plugin", key, None) for key in keys}
                     p = Plugin(info, PLUGIN_DIRS)
                     self.plugins[p.module_name] = p
 

--- a/GTG/plugins/export.gtg-plugin
+++ b/GTG/plugins/export.gtg-plugin
@@ -2,9 +2,7 @@
 module=export
 name=Export and print
 short-description=Exports the tasks in the current view into a variety of formats.
-description=Exports the tasks in the current view into
-    a variety of formats. You can also personalize the format
-    of your tasks by writing your own template
+description=Exports the tasks in the current view into a variety of formats. You can also personalize the format of your tasks by writing your own template.
 authors=Luca Invernizzi <invernizzi.l@gmail.com>, Izidor Matušov <izidor.matusov@gmail.com>
 version=0.2
 enabled=False

--- a/GTG/plugins/export.gtg-plugin.desktop
+++ b/GTG/plugins/export.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+export.gtg-plugin

--- a/GTG/plugins/hamster.gtg-plugin
+++ b/GTG/plugins/hamster.gtg-plugin
@@ -1,9 +1,9 @@
 [GTG Plugin]
-Module=hamster
-Name=Hamster Time Tracker Integration
-Short-description=Track time of GTG task with Hamster applet.
-Description=Adds the ability to send a task to the Hamster time tracking applet
-Authors=Kevin Mehall <km@kevinmehall.net>, Francisco Lavin <fcolavin@gmail.com>
-Version=0.3
-Dbus-dependencies=org.gnome.Hamster:/org/gnome/Hamster
-Enabled=False
+module=hamster
+name=Hamster Time Tracker Integration
+short-description=Track time of GTG task with Hamster applet.
+description=Adds the ability to send a task to the Hamster time tracking applet
+authors=Kevin Mehall <km@kevinmehall.net>, Francisco Lavin <fcolavin@gmail.com>
+version=0.3
+dbus-dependencies=org.gnome.Hamster:/org/gnome/Hamster
+enabled=False

--- a/GTG/plugins/hamster.gtg-plugin.desktop
+++ b/GTG/plugins/hamster.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+hamster.gtg-plugin

--- a/GTG/plugins/meson.build
+++ b/GTG/plugins/meson.build
@@ -1,15 +1,27 @@
 gtg_plugin_sources = [
   '__init__.py',
-  'export.gtg-plugin',
-  'send-email.gtg-plugin',
-  'untouched-tasks.gtg-plugin',
-  'urgency-color.gtg-plugin',
-  'hamster.gtg-plugin',
 ]
 
 python3.install_sources(gtg_plugin_sources, subdir: 'GTG' / 'plugins', pure: true)
-subdir('export')
-subdir('send_email')
-subdir('untouched_tasks')
-subdir('urgency_color')
-subdir('hamster')
+plugin_install_dir = python3.get_install_dir(subdir: 'GTG' / 'plugins', pure: true)
+
+gtg_plugins = [
+  'export',
+  'send-email',
+  'untouched-tasks',
+  'urgency-color',
+  'hamster',
+]
+
+foreach plugin : gtg_plugins
+  i18n.merge_file(
+    input: plugin + '.gtg-plugin.desktop', # Big hack to make xgettext detect
+    output: plugin + '.gtg-plugin',
+    po_dir: meson.source_root() / 'po',
+    install: true,
+    install_dir: plugin_install_dir,
+    type: 'desktop',
+    args: ['--keyword=name', '--keyword=short-description', '--keyword=description']
+  )
+  subdir(plugin.underscorify())
+endforeach

--- a/GTG/plugins/send-email.gtg-plugin
+++ b/GTG/plugins/send-email.gtg-plugin
@@ -2,8 +2,7 @@
 module=send_email
 name=Send task via email
 short-description=Easily send a task via email.
-description=Adds a button on the toolbar to send
-    easily a task via email, also sends status, due_dates, tags and subtasks.
+description=Adds a button on the toolbar to send easily a task via email, also sends status, due_dates, tags and subtasks.
 authors=Luca Invernizzi <invernizzi.l@gmail.com>, Thibault Févry <ThibaultFevry@gmail.com>
 version=0.2.0
 enabled=False

--- a/GTG/plugins/send-email.gtg-plugin.desktop
+++ b/GTG/plugins/send-email.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+send-email.gtg-plugin

--- a/GTG/plugins/unmaintained/bugzilla.gtg-plugin
+++ b/GTG/plugins/unmaintained/bugzilla.gtg-plugin
@@ -2,11 +2,7 @@
 module=bugzilla
 name=Bugzilla
 short-description=Allow to link a task with a bugzilla ticket.
-description=Allow to link a task with a bugzilla ticket
-    Just paste the URL of the ticket in the quick add entry
-    and a new task will be created for this bug.
-    At the moment the GNOME, Mozilla and Freedesktop.org
-    bugzillas are supported.
+description=Allow to link a task with a bugzilla ticket.\nJust paste the URL of the ticket in the quick add entry and a new task will be created for this bug. At the moment the GNOME, Mozilla and Freedesktop.org bugzillas are supported.
 authors=Guillaume Desmottes <gdesmott@gnome.org>
 version=0.0.1
 enabled=False

--- a/GTG/plugins/unmaintained/geolocalized-tasks.gtg-plugin
+++ b/GTG/plugins/unmaintained/geolocalized-tasks.gtg-plugin
@@ -2,8 +2,7 @@
 module=geolocalized_tasks
 name=Geolocalized Tasks
 short-description=This plugin adds geolocalized tasks to GTG!.
-description=This plugin adds geolocalized tasks to GTG!.
-    WARNING: This plugin is still under heavy development.
+description=This plugin adds geolocalized tasks to GTG!.\nWARNING: This plugin is still under heavy development.
 authors=Paulo Cabido <paulo.cabido@gmail.com>
 version=0.1.1
 dependencies=Geoclue,clutter,cluttergtk,champlain,champlaingtk

--- a/GTG/plugins/unmaintained/notification-area.gtg-plugin
+++ b/GTG/plugins/unmaintained/notification-area.gtg-plugin
@@ -2,10 +2,7 @@
 module=notification_area
 name=Notification area
 short-description=Adds a GTG icon to the notification area.
-description=Adds a GTG icon to the notification area,
-    that keeps the list of the currently workable tasks.
-    To start GTG minimized,  click on the 'Configure Plugin' button
-    at the bottom of this window.
+description=Adds a GTG icon to the notification area, that keeps the list of the currently workable tasks. To start GTG minimized, click on the 'Configure Plugin' button at the bottom of this window.
 authors="Paulo Cabido <paulo.cabido@gmail.com>, Luca Invernizzi <invernizzi.l@gmail.com>, Jono Bacon <jono@ubuntu.com>, Izidor Matušov <izidor.matusov@gmail.com>, Antonio Roquentin <antonio.roquentin@sfr.fr>"
 version=0.95
 enabled=False

--- a/GTG/plugins/unmaintained/tomboy.gtg-plugin
+++ b/GTG/plugins/unmaintained/tomboy.gtg-plugin
@@ -2,8 +2,7 @@
 module=tomboy
 name=Tomboy/Gnote plugin
 short-description=Enable linking to Tomboy/GNote notes.
-description=This plugin lets you add a link to a Tomboy (or Gnote)
-    note in your tasks, or create a new one
+description=This plugin lets you add a link to a Tomboy (or Gnote) note in your tasks, or create a new one.
 authors=Luca Invernizzi <invernizzi.l@gmail.com>
 version=0.1.9
 enabled=False

--- a/GTG/plugins/untouched-tasks.gtg-plugin.desktop
+++ b/GTG/plugins/untouched-tasks.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+untouched-tasks.gtg-plugin

--- a/GTG/plugins/urgency-color.gtg-plugin
+++ b/GTG/plugins/urgency-color.gtg-plugin
@@ -2,14 +2,7 @@
 module=urgency_color
 name=Urgency Color
 short-description=Task urgency color-coding
-description=This plugin will calculate the urgency status of every of your currently active tasks and color-code it accordingly.
-
-    Color code
-
-    Assuming your settings are default:
-    Red means you are within the last 30% of days between the start-date and due-date, or your task is overdue.
-    Yellow means your task's start-date has passed.
-    Green means your task's start-date is oncoming.
+description=This plugin will calculate the urgency status of every of your currently active tasks and color-code it accordingly.\n\nColor code\n\nAssuming your settings are default:\nRed means you are within the last 30% of days between the start-date and due-date, or your task is overdue.\nYellow means your task's start-date has passed.\nGreen means your task's start-date is oncoming.
 authors=Wolter Hellmund <wolterh6@gmail.com>
 version=0.1
 enabled=False

--- a/GTG/plugins/urgency-color.gtg-plugin.desktop
+++ b/GTG/plugins/urgency-color.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+urgency-color.gtg-plugin

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,6 +2,12 @@
 data/org.gnome.GTG.appdata.xml.in.in
 data/org.gnome.GTG.desktop.in.in
 
+GTG/plugins/export.gtg-plugin.desktop
+GTG/plugins/send-email.gtg-plugin.desktop
+GTG/plugins/untouched-tasks.gtg-plugin.desktop
+GTG/plugins/urgency-color.gtg-plugin.desktop
+GTG/plugins/hamster.gtg-plugin.desktop
+
 GTG/gtk/data/backends.ui
 GTG/gtk/data/calendar.ui
 GTG/gtk/data/context_menus.ui

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -9,6 +9,11 @@ GTG/backends/unmaintained/backend_tomboy.py
 GTG/backends/unmaintained/generictomboy.py
 GTG/backends/unmaintained/rtm/__init__.py
 GTG/backends/unmaintained/rtm/rtm.py
+GTG/plugins/export.gtg-plugin
+GTG/plugins/hamster.gtg-plugin
+GTG/plugins/send-email.gtg-plugin
+GTG/plugins/untouched-tasks.gtg-plugin
+GTG/plugins/urgency-color.gtg-plugin
 GTG/plugins/unmaintained/bugzilla/bug.py
 GTG/plugins/unmaintained/bugzilla/bugzilla.py
 GTG/plugins/unmaintained/bugzilla/__init__.py

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,7 @@
-i18n.gettext('gtg', preset: 'glib')
+i18n.gettext('gtg',
+  preset: 'glib',
+  args: [
+    # Used by gtg-plugin
+    '--keyword=name', '--keyword=short-description', '--keyword=description'
+    ]
+  )


### PR DESCRIPTION
Make the `.gtg-plugin` files use the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys), so that  [GLib Key-value file parser](https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html) can be used to pull localized strings.
It technically breaks the format since the GLib parser doesn't support most of pythons ConfigParser features.
This is unfortunate, but this was the easiest way to get this working, especially with gettext integration.

The probably biggest hack would be introducing `.gtg-plugin.desktop` files, which are just used so that xgettext (which is run by `ninja gtg-pot`) uses the Desktop-language on them, so the appear in the .pot and .po files correctly.

A current issue is that when translation is being updated, a re-launch (via launch.sh) doesn't regenerate the files. To force regenerating the files, run `rm -f .local_build/GTG/plugins/*.gtg-plugin`.

It has been tested and works (at least for german, the translation is temporary for testing):
![Screenshot of the translated plugins list](https://user-images.githubusercontent.com/1196130/92310515-87824c00-efaf-11ea-9126-2463f520538f.png)
(Plugins in order are: Untouched Tasks; Export and print; Urgency color; Send per email)

Note that I had to comment out `GTG/core/cleanxml.py` and `GTG/core/taskxml.py` lines in `po/POTFILES.in` to make it work; This change isn't in this PR, but I'll let you know anyway when you try this PR.