### PR TITLE
Recurring/repeating tasks through the quickadd menu.

### DIFF
--- a/GTG/core/dates.py
+++ b/GTG/core/dates.py
@@ -489,10 +489,10 @@ class Date():
 
         # accepted date formats
         formats = {
-            'day': 0 if newtask == True else 1,
-            _('day').lower(): 0 if newtask == True else 1,
-            'other-day': 1 if newtask == True else 2,
-            _('other-day').lower(): 1 if newtask == True else 2,
+            'day': 0 if newtask else 1,
+            _('day').lower(): 0 if newtask else 1,
+            'other-day': 1 if newtask else 2,
+            _('other-day').lower(): 1 if newtask else 2,
             'week': 7,
             _('week').lower(): 7,
             'month': calendar.mdays[self.month],

--- a/GTG/core/dates.py
+++ b/GTG/core/dates.py
@@ -485,10 +485,15 @@ class Date():
         return result
     
     def _parse_text_representation_for_recurrency(self, string, newtask=False):
-        """ Match common text representation from a certain date """
+        """Match common text representation from a certain date(self)
 
+        Args:
+            string (str): text representation.
+            newtask (bool, optional): depending on the task if it is a new one or not, the offset changes
+        """
         # accepted date formats
         formats = {
+            # change the offset depending on the task.
             'day': 0 if newtask else 1,
             _('day').lower(): 0 if newtask else 1,
             'other-day': 1 if newtask else 2,

--- a/GTG/core/dates.py
+++ b/GTG/core/dates.py
@@ -473,9 +473,9 @@ class Date():
                 result = convert_datetime_to_date(da_ti)
                 if '%Y' not in fmt:
                     # If the day has passed, assume the next year
-                    if result.month > self.month or \
+                    if (result.month > self.month or 
                         (result.month == self.month and
-                         result.day >= self.day):
+                         result.day >= self.day)):
                         year = self.year
                     else:
                         year = self.year + 1

--- a/GTG/core/firstrun_tasks.py
+++ b/GTG/core/firstrun_tasks.py
@@ -304,9 +304,13 @@ def generate() -> etree.Element:
         task_tag.attrib['id'] = task['id']
         task_tag.attrib['status'] = 'Active'
         task_tag.attrib['tags'] = ','.join(tags)
+        task_tag.attrib['recurring'] = 'False'
 
         title = etree.SubElement(task_tag, 'title')
         title.text = task['title']
+
+        recurring_term = etree.SubElement(task_tag, 'recurring_term')
+        recurring_term.text = 'None'
 
         for sub in task['subtasks']:
             subtask = etree.SubElement(task_tag, 'subtask')

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -420,18 +420,18 @@ class Task(TreeNode):
         today = date.today()
         if today < self.start_date or self.start_date <= today and today <= self.due_date:
             try:
-                nextdate = self.due_date.parse_from_date(self.recurring_term, newtask)
+                nextdate = self.due_date.parse_from_date(self.recurring_term)
                 while nextdate <= self.due_date:
                     nextdate.day += 1
-                    nextdate = nextdate.parse_from_date(self.recurring_term, newtask)
+                    nextdate = nextdate.parse_from_date(self.recurring_term)
                 return nextdate
             except:
                 raise ValueError(f'Invalid recurring term {self.recurring_term}')
         elif today > self.due_date:
             try:
-                next_date = self.due_date.parse_from_date(self.recurring_term, newtask)
+                next_date = self.due_date.parse_from_date(self.recurring_term)
                 while next_date < date.today():
-                    next_date = next_date.parse_from_date(self.recurring_term, newtask)
+                    next_date = next_date.parse_from_date(self.recurring_term)
                 return next_date
             except:
                 raise ValueError(f'Invalid recurring term {self.recurring_term}')

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -149,10 +149,7 @@ class Task(TreeNode):
     def duplicate(self):
         """ Duplicates a task with a new ID """
         copy = self.req.ds.new_task()
-        # TODO: change the title so that it is more obvious that 
-        # the task is recurring and has been duplicated
-        # proposition: Name of the task (occurred 3)
-        copy.set_title(f"{self.title}")
+        copy.set_title(self.title)
         copy.content = self.content
         copy.tags = self.tags
         return copy
@@ -162,7 +159,6 @@ class Task(TreeNode):
         newtask = self.duplicate()
         newtask.set_recurring(True, self.recurring_term)
         nextdate = self.get_next_occurrence()
-        newtask.set_start_date(nextdate)
         newtask.set_due_date(nextdate)
 
         if self.has_child():
@@ -227,13 +223,10 @@ class Task(TreeNode):
                         due_date = Date.parse(args)
                     except:
                         valid_attribute = False
-                # NOTE: Should the recurring task repeat on the due date, the start date, or both?
-                # The current implementation sets the recurring date as the start and the due date.
+
                 elif attribute.lower() == "every" or \
                         attribute.lower() == _("every"):
                     try:
-                        # NOTE: for now the repeating task will highjack the due_date as well as the defer_date (SHOULD IT BE CHANGED?)
-                        # Should there be a separate date for the recurring tasks?
                         Date(self.added_date).parse_from_date(args)
                         recurring = True
                         recurring_term = args
@@ -361,7 +354,6 @@ class Task(TreeNode):
                 self.recurring_term = recurring_term
                 if newtask:
                     self.set_due_date(date)
-                    self.set_start_date(date)
             except:
                 if recurring_term == None:
                     self.recurring_term = None
@@ -391,7 +383,6 @@ class Task(TreeNode):
                 if par.get_recurring() and par.is_loaded():
                     self.set_recurring(True, par.get_recurring_term())
                     self.set_due_date(par.due_date)
-                    self.set_start_date(par.start_date)
         else:
             self.set_recurring(False)
 

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -160,16 +160,17 @@ class Task(TreeNode):
     def duplicate_recursively(self):
         """ Duplicates recursively all the task itself and its children while keeping the relationship"""
         newtask = self.duplicate()
+        newtask.set_recurring(True, self.recurring_term)
+        nextdate = self.get_next_occurrence()
+        newtask.set_start_date(nextdate)
+        newtask.set_due_date(nextdate)
+
         if self.has_child():
             for c_tid in self.get_children():
                 child = self.req.get_task(c_tid)
                 if child.is_loaded():
                     newtask.add_child(child.duplicate_recursively())
-        
-        newtask.set_recurring(True, self.recurring_term)
-        nextdate = self.get_next_occurrence()
-        newtask.set_start_date(nextdate)
-        newtask.set_due_date(nextdate)
+                    
         newtask.sync()
         return newtask.tid
 
@@ -374,7 +375,7 @@ class Task(TreeNode):
                 child = self.req.get_task(c_tid)
                 if child.is_loaded() and child.get_status() in\
                     (self.STA_ACTIVE):
-                    child.set_recurring(recurring, recurring_term)
+                    child.set_recurring(recurring, recurring_term, newtask)
 
     def get_recurring(self):
         return self.recurring
@@ -389,6 +390,8 @@ class Task(TreeNode):
                 par = self.req.get_task(p_tid)
                 if par.get_recurring() and par.is_loaded():
                     self.set_recurring(True, par.get_recurring_term())
+                    self.set_due_date(par.due_date)
+                    self.set_start_date(par.start_date)
         else:
             self.set_recurring(False)
 

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -277,8 +277,8 @@ class Task(TreeNode):
                     if self.has_parent():
                         for p_tid in self.get_parents():
                             par = self.req.get_task(p_tid)
-                            if par.is_loaded() and par.get_status() in\
-                                (self.STA_ACTIVE):
+                            if (par.is_loaded() and par.get_status() in
+                                (self.STA_ACTIVE)):
                                 par.add_child(nexttask_tid)
 
             # If we mark a task as Active and that some parent are not
@@ -376,8 +376,8 @@ class Task(TreeNode):
         if self.has_child() and self.recurring:
             for c_tid in self.get_children():
                 child = self.req.get_task(c_tid)
-                if child.is_loaded() and child.get_status() in\
-                    (self.STA_ACTIVE):
+                if (child.is_loaded() and child.get_status() in
+                    (self.STA_ACTIVE)):
                     child.set_recurring(recurring, recurring_term, newtask)
 
     def get_recurring(self):
@@ -440,8 +440,8 @@ class Task(TreeNode):
         if self.has_parent():
             for p_tid in self.get_parents():
                 p = self.req.get_task(p_tid)
-                if p.is_loaded() and p.get_status() in\
-                    (self.STA_ACTIVE) and p.get_recurring():
+                if (p.is_loaded() and p.get_status() in
+                    (self.STA_ACTIVE) and p.get_recurring()):
                     return True
         return False
 

--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -72,6 +72,14 @@ def task_from_element(task, element: etree.Element):
     except (AttributeError, TypeError):
         pass
 
+    # Recurring tasks
+    try:
+        recurring = element.attrib['recurring']
+        recurring_term = element.find('recurring_term').text
+        task.set_recurring(recurring == 'True', None if recurring_term == 'None' else recurring_term)
+    except AttributeError:
+        pass
+
     # Task Tags
     tags = element.get('tags')
     tags = [t for t in tags.split(',') if t.strip() != '']
@@ -105,6 +113,7 @@ def task_to_element(task) -> etree.Element:
     element.set('id', task.get_id())
     element.set('status', task.get_status())
     element.set('uuid', task.get_uuid())
+    element.set('recurring', str(task.get_recurring()))
 
     tags = [saxutils.escape(str(t)) for t in task.get_tags_name()]
     element.set('tags', ','.join(tags))
@@ -126,6 +135,9 @@ def task_to_element(task) -> etree.Element:
 
     done_date = etree.SubElement(element, 'donedate')
     done_date.text = task.get_closed_date().xml_str()
+
+    recurring_term = etree.SubElement(element, 'recurring_term')
+    recurring_term.text = str(task.get_recurring_term())
 
     for subtask_id in task.get_children():
         sub = etree.SubElement(element, 'subtask')

--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -74,7 +74,7 @@ def task_from_element(task, element: etree.Element):
 
     # Recurring tasks
     try:
-        recurring = element.attrib['recurring']
+        recurring = element.get('recurring')
         recurring_term = element.find('recurring_term').text
         task.set_recurring(recurring == 'True', None if recurring_term == 'None' else recurring_term)
     except AttributeError:

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -948,6 +948,10 @@ class MainWindow(Gtk.ApplicationWindow):
             task = self.req.new_task(tags=tags, newtask=True)
             # task.add_parent(uid)
             zetask.add_child(task.get_id())
+
+            # if the parent task is recurring, its child must be also.
+            task.inherit_recursion()
+            
             self.app.open_task(task.get_id(), new=True)
 
     def on_edit_active_task(self, widget=None, row=None, col=None):


### PR DESCRIPTION
By putting **every: day**, other-day or any valid date in the **quick add menu**, the task is set to recurring with a recurring_term being day, other-day,...
Furthermore, depending on the date on which the task has been set to done or dismiss, we calculate the next closest occurrence.

With this implementation, all subtasks of the recurring task are recurring.
When a recurring subtask is marked as done, its next occurrence will only appear after the parent has been set to done.

Further information:
When we first create a recurring task, there are some adjustments for calculating the date that we have to deal with. For instance,
the first time every: day adds 0 to the delta-time while in the next occurrences it adds 1. Also, the date parser calculates the date since the current date, whereas in repeating tasks we need the next occurrence from the old due date.
That is why I need new date methods.

Ref #169
Ref #455

On branch master

 Changes to be committed:
	modified:   GTG/core/dates.py
	modified:   GTG/core/firstrun_tasks.py
	modified:   GTG/core/task.py
	modified:   GTG/core/xml.py
	modified:   GTG/gtk/browser/main_window.py
PS: first pull