### PR TITLE
Disabled "ctrl+del" on text focus #352 

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -48,6 +48,7 @@ PANE_STACK_NAMES_MAP = {
 }
 PANE_STACK_NAMES_MAP_INVERTED = {v: k for k, v in PANE_STACK_NAMES_MAP.items()}
 
+
 class MainWindow(Gtk.ApplicationWindow):
     """ The UI for browsing open and closed tasks,
     and listing tags in a tree """
@@ -156,7 +157,6 @@ class MainWindow(Gtk.ApplicationWindow):
         self.open_menu = Gtk.Menu.new_from_model(open_menu_model)
         self.open_menu.attach_to_widget(self.main_box)
 
-
     def _set_actions(self):
         """Setup actions."""
 
@@ -246,7 +246,6 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.tagpopup = TagContextMenu(self.req, self.app)
 
-
     def _init_ui_widget(self):
         """ Sets the main pane with three trees for active tasks,
         actionable tasks (workview), closed tasks and creates
@@ -304,7 +303,6 @@ class MainWindow(Gtk.ApplicationWindow):
         # expanding search tag does not work automatically, request it
         self.expand_search_tag()
 
-
     def _init_about_dialog(self):
         """
         Show the about dialog
@@ -354,6 +352,8 @@ class MainWindow(Gtk.ApplicationWindow):
             "on_add_subtask": self.on_add_subtask,
             "on_tagcontext_deactivate": self.on_tagcontext_deactivate,
             "on_quickadd_field_activate": self.on_quickadd_activate,
+            "on_quickadd_field_focus_in": self.on_quickadd_focus_in,
+            "on_quickadd_field_focus_out": self.on_quickadd_focus_out,
             "on_about_delete": self.on_about_close,
             "on_about_close": self.on_about_close,
             "on_search": self.on_search,
@@ -735,6 +735,19 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.quickadd_entry.grab_focus()
 
+    def on_quickadd_focus_in(self, widget, event):
+        self.toggle_delete_accel(False)
+
+    def on_quickadd_focus_out(self, widget, event):
+        self.toggle_delete_accel(True)
+
+    def toggle_delete_accel(self, enable_delete_accel):
+        """
+        enable/disabled delete task shortcut.
+        """
+        accels = ['<ctrl>Delete'] if enable_delete_accel else []
+        self.app.set_accels_for_action('win.delete_task', accels)
+
     def on_quickadd_activate(self, widget):
         """ Add a new task from quickadd toolbar """
         text = str(self.quickadd_entry.get_text())
@@ -992,7 +1005,6 @@ class MainWindow(Gtk.ApplicationWindow):
                  for uid in self.get_selected_tasks()
                  if uid is not None]
 
-
         next_day = Date.today() + datetime.timedelta(days=day_number)
 
         for task in tasks:
@@ -1234,7 +1246,6 @@ class MainWindow(Gtk.ApplicationWindow):
         current = self.stack_switcher.get_stack().get_visible_child_name()
 
         return PANE_STACK_NAMES_MAP[current]
-
 
     def get_selected_task(self, tv=None):
         """

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -547,6 +547,8 @@
                     <property name="input_hints">GTK_INPUT_HINT_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
                     <property name="show_emoji_icon">True</property>
                     <signal name="activate" handler="on_quickadd_field_activate" swapped="no"/>
+                    <signal name="focus-in-event" handler="on_quickadd_field_focus_in" swapped="no"/>
+                    <signal name="focus-out-event" handler="on_quickadd_field_focus_out" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -91,7 +91,6 @@ class TaskEditor():
         self.due_entry = self.builder.get_object("duedate_entry")
         self.due_calendar = self.builder.get_object("calendar_due")
 
-
         # Create our dictionary and connect it
         dic = {
             "on_tags_popover": self.open_tags_popover,
@@ -180,6 +179,8 @@ class TaskEditor():
         self.textview.set_add_tag_callback(task.add_tag)
         self.textview.set_remove_tag_callback(task.remove_tag)
         self.textview.save_task_callback(self.light_save)
+        self.textview.connect('focus-in-event', self.on_textview_focus_in)
+        self.textview.connect('focus-out-event', self.on_textview_focus_out)
 
         texte = self.task.get_text()
         title = self.task.get_title()
@@ -521,7 +522,6 @@ class TaskEditor():
 
             self.refresh_editor()
 
-
     def calendar_to_datetime(self, calendar):
         """
         Gtk.Calendar uses a 0-based convention for counting months.
@@ -566,8 +566,6 @@ class TaskEditor():
         elif kind == GTGCalendar.DATE_KIND_CLOSED:
             self.task.set_closed_date(Date(date))
             self.closed_entry.set_text(str(Date(date)))
-
-
 
     def on_date_changed(self, calendar):
         date, date_kind = calendar.get_selected_date()
@@ -720,6 +718,12 @@ class TaskEditor():
 
         self.config.set('position', list(self.window.get_position()))
         self.config.set('size', list(self.window.get_size()))
+
+    def on_textview_focus_in(self, widget, event):
+        self.app.browser.toggle_delete_accel(False)
+
+    def on_textview_focus_out(self, widget, event):
+        self.app.browser.toggle_delete_accel(True)
 
     # We define dummy variable for when close is called from a callback
     def close(self, action=None, param=None):


### PR DESCRIPTION
Disable delete task shortcut when focus is in quick entry or task editor.
why someone could want to use `Ctrl+Delete` in an editor? Because that's the standard way to delete the word that is after the text cursor (the opposite of Ctrl+Backspace)

To do it we add a signal to catch event on focus in and focus out to remove `ctrl+del` accelerator or add it respectively.

