### PR TITLE
Export plugin: Fix file chooser & exporting

### DIFF
--- a/GTG/plugins/export/export.py
+++ b/GTG/plugins/export/export.py
@@ -267,19 +267,18 @@ class ExportPlugin():
 
     def choose_file(self):
         """ Let user choose a file to save and return its path """
-        chooser = Gtk.NativeFileChooser(
-            title=_("Choose where to save your list"),
-            parent=self.export_dialog,
-            action=Gtk.FileChooserAction.SAVE,
-            buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                     Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+        chooser = Gtk.FileChooserNative.new(
+            _("Choose where to save your list"),
+            self.export_dialog,
+            Gtk.FileChooserAction.SAVE,
+            None,
+            None)
         chooser.set_do_overwrite_confirmation(True)
-        chooser.set_default_response(Gtk.ResponseType.OK)
         chooser.set_current_folder(get_desktop_dir())
         response = chooser.run()
         filename = chooser.get_filename()
         chooser.destroy()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             return filename
         else:
             return None

--- a/GTG/plugins/export/export.py
+++ b/GTG/plugins/export/export.py
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 import webbrowser
 
-from gi.repository import GObject, Gtk, GdkPixbuf
+from gi.repository import GObject, Gtk, GdkPixbuf, GLib
 
 from gettext import gettext as _
 from GTG.core.logger import log

--- a/GTG/plugins/export/templates.py
+++ b/GTG/plugins/export/templates.py
@@ -123,7 +123,7 @@ class Template():
 
         suffix = ".%s" % self._get_suffix()
         output = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-        output.write(str(document))
+        output.write(str(document).encode('utf-8'))
         self._document_path = output.name
         output.close()
 


### PR DESCRIPTION
Fix the file chooser, import the `GLib` library and convert to a bytes object when exporting because python wants a bytes object not an string.
Only tested with the "status" export.