### PR TITLE
Port commandline parsing to using GLib Application

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -54,6 +54,8 @@ import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 
+from gi.repository import GLib
+
 _LOCAL = @local_build@
 
 if _LOCAL:
@@ -63,40 +65,37 @@ from GTG.core import info
 from GTG.gtk.application import Application
 
 
-def parse_args():
-    """Parse arguments from the command line."""
+def handle_local_options(application, options):
+    """
+    Handle local options passed to the application, such as --version, --debug
+    and --title.
+    This is called by the Application object via the handle_local_options signal
+    """
+    version = options.lookup_value("version", None)
+    if version is not None and version:
+        print("GTG (Getting Things GNOME!)", info.VERSION)
+        print("Using python", sys.version)
+        print("For more information:", info.URL)
+        return 0 # Exit successfully
 
-    parser = argparse.ArgumentParser()
+    debug = options.lookup_value("debug", None)
+    if debug is not None:
+        debug = debug.unpack()
+    application.set_debug_flag(bool(debug))
 
-    parser.add_argument('-v', '--version', help='Show program version',
-                        action="store_true")
+    title = options.lookup_value("title", None)
+    if title is not None:
+        info.NAME = str(title.unpack())
 
-    parser.add_argument('-d', '--debug', help='Enable debug output',
-                        action='store_true')
-
-    parser.add_argument('-t', '--title',
-                        help='Use special title for windows\' title')
-
-    parser.add_argument('task_uri', default='', nargs='*', type=str,
-                        help='Open a specific task via URI')
-
-    return parser.parse_args()
-
+    return -1 # Continue parsing
 
 if __name__ == "__main__":
     if _LOCAL:
         print("Running from source tree")
     try:
-        args = parse_args()
-
-        if args.version:
-            print("GTG (Getting Things GNOME!)", info.VERSION)
-            print()
-            print("For more information:", info.URL)
-            sys.exit(0)
-
-        if args.title is not None:
-            info.NAME = args.title
+        def N_(message):
+            """Mark as to be translated for gettext, don't do any translation here"""
+            return message
 
         # Set up UI i18n
         LOCALE_DIR = '@localedir@'
@@ -111,12 +110,37 @@ if __name__ == "__main__":
         gettext.bindtextdomain('gtg', LOCALE_DIR)
         gettext.textdomain('gtg')
 
-        # Run the application
-        application = Application('@APP_ID@', args.debug)
-        application.uri_list = args.task_uri
+        application = Application('@APP_ID@')
+
+        application.add_main_option(
+                "version", ord('v'),
+                GLib.OptionFlags.IN_MAIN,
+                GLib.OptionArg.NONE,
+                # Translators: -v --version cli argument description
+                N_("Show program version"),
+                None
+            )
+        application.add_main_option(
+                "debug", ord('d'),
+                GLib.OptionFlags.NONE,
+                GLib.OptionArg.NONE,
+                # Translators: -d --debug cli argument description
+                N_("Enable debug output"),
+                None
+            )
+        application.add_main_option(
+                "title", ord('t'),
+                GLib.OptionFlags.NONE,
+                GLib.OptionArg.STRING,
+                # Translators: -t --title=TITLE cli argument description
+                N_("Use special title for windows\' title"),
+                # Translators: -t --title=TITLE cli argument placeholder
+                N_("TITLE")
+            )
+        application.connect("handle-local-options", handle_local_options)
 
         signal.signal(signal.SIGTERM, lambda s, f: application.quit())
-        application.run()
+        application.run(sys.argv)
 
     except KeyboardInterrupt:
         sys.exit(1)

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -115,6 +115,7 @@ class Application(Gtk.Application):
         """Callback when launched from the desktop."""
 
         self.init_shared()
+        self.browser.present()
 
         log.debug("Application activation finished")
 

--- a/prefix-gtg.sh.in
+++ b/prefix-gtg.sh.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-PYTHONPATH='@python_installdir@' $@
+PYTHONPATH='@python_installdir@' "$@"

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -22,10 +22,12 @@ do  case "$o" in
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG";;
-    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-n]"
+    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-n] (-- args passed to gtg)"
          exit 1;;
     esac
 done
+args_array=("${@}")
+extra_args=("${args_array[@]:$((OPTIND-1))}")
 
 # Copy dataset
 if [[  "$dataset" != "default" && ! -d "./tmp/$dataset" ]]; then
@@ -56,5 +58,5 @@ if [[ "$norun" -eq 0 ]]; then
     ninja -C .local_build install
     # double quoting args seems to prevent python script from picking up flag arguments correctly
     # shellcheck disable=SC2086
-    ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} -t "$title"
+    ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} -t "$title" "${extra_args[@]}"
 fi


### PR DESCRIPTION
Done a bit more than I would've liked, but it is a step closer to being DBus-Activatable (#183).

More testing appreciated. An current bug I've found is that when opening an task via cli (`gtg://....`), closing the task (and thus the application) and open GTG normally, it would reopen the task. I am not sure whenever this happens with the old implementation, but it might be worth investigating later.

I tried to explain in the commits, but there you go if you're lazy:

---

Use GLibs cli parser and use application.open

The primarily goal was to use the GApplication command line parser, so
that an user can also access gtk and GLibs command line arguments.

However, the opening tasks part made this much bigger, since it is done
from the activate-signal, which is usually reserved to open without any
files. With the new system, the open-signal is used to open files, so it
had to be ported to over there.

Initializing the browser window wasn't possible in the startup-signal
(it crashes, and it seems you aren't supposed to do that), so this is
done by both activate- and open-signals.

An weird oddity I've found is that in "the" documentation for python,
the do_open just accepts 2 arguments: files and hint. However, I was
getting argument mismatch errors, and I've noticed that I got a number
as the second parameter, and by looking at the C docs, the second
parameter is the number of files.
Since files is a python list, this isn't needed, but checked anyway,
just in case.
https://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application.do_open
https://developer.gnome.org/gio/2.66/GApplication.html#GApplication-open

The files in the open-signal are GFiles, which seem to change the URI a
tiny bit by adding a final slash (gtg://a → gtg://a/). Because of this,
the old code wouldn't find the task, so I went ahead and parsed the URI
completely using urllib.parse.
GLib also has URI parsing, but it seems they aren't exposed to python.

Also, GLib also translates the help strings if they are translated.
However, I needed to put GTG/gtg.in manually in po/POTFILES.in, but even
then, xgettext defaulted to using C instead of python (rightfully).
An workaround would be creating an symlink gtg.py.in and inputting that
to xgettext, but I didn't wanted to deal more with this, so I didn't
bother to continue.

---

scripts/debug.sh: Support passing directly to gtg

Useful to input custom arguments or tasks directly to gtg.
Note that from what I understand, it would get the options up to the
last non-option and pass it to gtg, but I think it isn't too bad for a
debug script.

---

prefix-gtg.sh.in: Properly "escape" arguments

Previously, the launch.sh (scripts/debug.sh) script would pass a title
like -t "Dev GTG", but gtg would read it as ["-t", "Dev", "GTG"].
This commit fixes this.

From `man bash`:
>      @      Expands  to the positional parameters, starting from one.
>             When the expansion  occurs  within  double  quotes,  each
>             parameter  expands  to a separate word.  That is, "$@" is
>             equivalent to "$1" "$2" ...  If the double-quoted  expan‐
>             sion  occurs  within  a  word, the expansion of the first
>             parameter is joined with the beginning part of the origi‐
>             nal  word,  and  the  expansion  of the last parameter is
>             joined with the last part of  the  original  word.   When
>             there are no positional parameters, "$@" and $@ expand to
>             nothing (i.e., they are removed).

---

Try to quit when just opening files

A side effect of moving to Gtk.Application with the current MainWindow
dependency is that detecting whenever to quit the application is
harder.

Assigning an application to an window keeps the application open when
the window exists. So by not assigning it, and when just tasks were
open, upon closing them quits the application as expected.
However, when activated, it sets the application and continues as
normal.

I don't really like this solution, but is pretty easy to read (and
hopefully to understand).
I hope that this doesn't cause bugs around quitting application when all
windows are closed.