### PR TITLE
Use _("...").format instead of _(f"...")

### DIFF
--- a/GTG/gtk/backends/__init__.py
+++ b/GTG/gtk/backends/__init__.py
@@ -65,7 +65,8 @@ class BackendsDialog():
         builder = Gtk.Builder()
         self._load_widgets_from_builder(builder)
         # Load and setup other widgets
-        self.dialog.set_title(_(f"Synchronization Services - {info.NAME}"))
+        dialog_title = _("Synchronization Services - {name}")
+        self.dialog.set_title(dialog_title.format(name=info.NAME))
         self._create_widgets_for_add_panel()
         self._create_widgets_for_conf_panel()
         self._setup_signal_connections(builder)

--- a/GTG/gtk/browser/delete_task.py
+++ b/GTG/gtk/browser/delete_task.py
@@ -106,7 +106,8 @@ class DeletionUI():
 
         if missing_titles_count >= 2:
             tasks = tasklist[: self.MAXIMUM_TIDS_TO_SHOW]
-            titles_suffix = _(f"\nAnd {missing_titles_count:d} more tasks")
+            titles_suffix = _("\nAnd {missing_titles_count:d} more tasks")
+            titles_suffix = titles_suffix.format(missing_titles_count= missing_titles_count)
         else:
             tasks = tasklist
             titles_suffix = ""


### PR DESCRIPTION
The latter would format the string first before translating, and having an translation for every possible combination is basically impossible.

I am using .format() specifically because diegogangl commented about having to drop it for .format(), so I am using that.

I tried to not modify the original string to not break existing translations, but I only was half-successful.

Fixes #380
Couldn't test the string about Synchronization Services because there aren't any (active) plugins for that.