### PR TITLE
Make module-level translations work

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -50,6 +50,20 @@ import gettext
 import locale
 import signal
 
+if __name__ == "__main__":
+    # Set up UI i18n so module-level translations work
+    LOCALE_DIR = '@localedir@'
+
+    try:
+        locale.bindtextdomain('gtg', LOCALE_DIR)
+        locale.textdomain('gtg')
+    except AttributeError as e:
+        # Python built without gettext support doesn't have bindtextdomain() and textdomain()
+        print("Couldn't bind the gettext translation domain. Some translations won't work.\n{}".format(e))
+
+    gettext.bindtextdomain('gtg', LOCALE_DIR)
+    gettext.textdomain('gtg')
+
 import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
@@ -96,19 +110,6 @@ if __name__ == "__main__":
         def N_(message):
             """Mark as to be translated for gettext, don't do any translation here"""
             return message
-
-        # Set up UI i18n
-        LOCALE_DIR = '@localedir@'
-
-        try:
-            locale.bindtextdomain('gtg', LOCALE_DIR)
-            locale.textdomain('gtg')
-        except AttributeError as e:
-            # Python built without gettext support doesn't have bindtextdomain() and textdomain()
-            print("Couldn't bind the gettext translation domain. Some translations won't work.\n{}".format(e))
-
-        gettext.bindtextdomain('gtg', LOCALE_DIR)
-        gettext.textdomain('gtg')
 
         application = Application('@APP_ID@')
 


### PR DESCRIPTION
I saw this being done in D-Feet:
https://gitlab.gnome.org/GNOME/d-feet/-/blob/b312c714fc01c3d14e2c6e1da6e87645674cca05/src/d-feet.in#L38-41

The problem is that some code uses gettext "at the module level", which is run when the module is being imported.
Before this change, basically all of GTG gets imported, before locale gets set up.
After this change, it gets setup before importing it, so it'll work as expected. Not sure why I haven't thought of this earlier.

I've put this in a if `__name__ == "__main__"` block, because the original code was also in such block.

Fixes #362
Fixes #378
Fixes #379

Haven't tested every string, but I did more of the for me easier tests and it works fine as expected.
![Before-After](https://user-images.githubusercontent.com/1196130/94485697-a060d480-01de-11eb-8e6e-f48c38684f04.png)
