### PR TITLE
Migrate Timer from dbus-python to Gio & drop dbus-python

### DIFF
--- a/GTG/core/plugins/engine.py
+++ b/GTG/core/plugins/engine.py
@@ -19,8 +19,6 @@ import imp
 import os
 import configparser
 
-import dbus
-
 from GTG.core.dirs import PLUGIN_DIRS
 from GTG.core.borg import Borg
 from GTG.core.logger import log

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Later, when you want to update to the latest development version (assuming you a
 
 * meson
 * python3
-* dbus-python
 * pycairo
 * pygobject (>= 3.20)
 * libLarch (>= 3.0)
@@ -43,9 +42,9 @@ Later, when you want to update to the latest development version (assuming you a
 You can get most of those from your distribution packages:
 
     # On Fedora
-    sudo dnf install meson python3-dbus python3-cairo python3-gobject gtk3 itstool gettext python3-lxml
+    sudo dnf install meson python3-cairo python3-gobject gtk3 itstool gettext python3-lxml
     # On Debian/Ubuntu
-    sudo apt install meson python3-dbus python3-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml
+    sudo apt install meson python3-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml
 
 liblarch may be harder to come by until distributions package the python3 version of it, alongside GTG 0.4+ itself.
 You can get it meanwhile via PIP (commonly provided by python3-pip package):


### PR DESCRIPTION
For #277

Yes, I figured the timer system bus signal not being executed thingy out. Finally!
See the commit message for more details:

> Initially, it didn't work. The reason was that system_dbus object is created on that line and when it goes out of scope, it gets destroyed and the signals get disconnected.
> 
> I assumed that the connection would stay open as part of Gio and not be created on first use (althrough it makes sense when implementing it). Also, I assumed that the signal would make it stay connected.
> 
> This took days to figure out, I even wrote a more "minimal" python version, and even a C version which let me find out the issue. See https://gitlab.gnome.org/-/snippets/1288
> 
> Thus the fix is to just keep a reference to it in the timer object itself.