### PR TITLE
Don't print errors for the same icon multiple times

### DIFF
--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -85,7 +85,7 @@ class CellRendererTags(Gtk.CellRenderer):
         self.ypad = 1
         self.PADDING = 1
         self.config = config
-
+        self._ignore_icon_error_for = set()
 
 
     def do_set_property(self, pspec, value):
@@ -154,11 +154,13 @@ class CellRendererTags(Gtk.CellRenderer):
                                                 rect_x, rect_y)
                     gdkcontext.paint()
                     count = count + 1
-                except GLib.GError:
+                except GLib.GError as e:
                     # In some rare cases an icon could not be found
                     # (e.g. wrong set icon path, missing icon)
                     # Raising an exception breaks UI and signal catcher badly
-                    log.error(f"Can't load icon '{my_tag_icon}'")
+                    if my_tag_icon not in self._ignore_icon_error_for:
+                        log.error(f"Can't load icon '{my_tag_icon}': {e}")
+                        self._ignore_icon_error_for.add(my_tag_icon)
 
             elif my_tag_color:
 


### PR DESCRIPTION
Previously, when getting an icon error while rendering tasks (such as when the user changes icon themes), it won't find the icon and prints an error.

This is fine, but it spams the terminal/console/logs with essential useless stuff, thus it is made sure only to print it once (per renderer).

I know about that possibly being dropped (see #85), but while it happens, I'd like to make it less spammy for me.