### PR TITLE
Move from application constructor to starup signal

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -80,11 +80,19 @@ class Application(Gtk.Application):
         super().__init__(application_id=app_id,
                          flags=Gio.ApplicationFlags.HANDLES_OPEN)
 
+    # --------------------------------------------------------------------------
+    # INIT
+    # --------------------------------------------------------------------------
+
+    def do_startup(self):
+        """Callback when primary instance should initialize"""
+        Gtk.Application.do_startup(self)
+
         # Register backends
         datastore = DataStore()
 
-        [datastore.register_backend(backend_dic)
-         for backend_dic in BackendFactory().get_saved_backends_list()]
+        for backend_dic in BackendFactory().get_saved_backends_list():
+            datastore.register_backend(backend_dic)
 
         # Save the backends directly to be sure projects.xml is written
         datastore.save(quit=False)
@@ -106,10 +114,6 @@ class Application(Gtk.Application):
             self.toggle_darkmode()
 
         self.init_style()
-
-    # --------------------------------------------------------------------------
-    # INIT
-    # --------------------------------------------------------------------------
 
     def do_activate(self):
         """Callback when launched from the desktop."""

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -517,6 +517,9 @@ class Application(Gtk.Application):
     def save_plugin_settings(self):
         """Save plugin settings to configuration."""
 
+        if self.plugin_engine is None:
+            return # Can't save when none has been loaded
+
         if self.plugin_engine.plugins:
             self.config_plugins.set(
                 'disabled',
@@ -545,8 +548,9 @@ class Application(Gtk.Application):
 
         self.save_plugin_settings()
 
-        # Save data and shutdown datastore backends
-        self.req.save_datastore(quit=True)
+        if self.req is not None:
+            # Save data and shutdown datastore backends
+            self.req.save_datastore(quit=True)
 
         Gtk.Application.do_shutdown(self)
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -21,4 +21,16 @@ i18n.merge_file(
   type: 'desktop'
 )
 
+service_config = configuration_data()
+service_config.set('APP_ID', application_id)
+service_config.set('bindir', bindir)
+
+configure_file(
+  input: rdnn_name + '.service.in',
+  output: application_id + '.service',
+  configuration: service_config,
+  install: true,
+  install_dir: dbusservicedir
+)
+
 subdir('icons')

--- a/data/org.gnome.GTG.desktop.in.in
+++ b/data/org.gnome.GTG.desktop.in.in
@@ -13,3 +13,4 @@ Categories=Office;ProjectManagement;
 Keywords=Organizer;Task;Tasks;Projects;Activities;Productivity;Plan;Planning;Planner;Time;Management;Scheduling;GTD;gtg;Todo;
 MimeType=x-scheme-handler/gtg;
 StartupNotify=true
+DBusActivatable=true

--- a/data/org.gnome.GTG.service.in
+++ b/data/org.gnome.GTG.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@APP_ID@
+Exec=@bindir@/gtg --gapplication-service

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ datadir = prefix / get_option('datadir')
 
 appdatadir = datadir / 'metainfo'
 desktopdir = datadir / 'applications'
+dbusservicedir = datadir / 'dbus-1' / 'services'
 icondir = datadir / 'icons'
 pythondir = python3.get_path('purelib')
 rdnn_name = 'org.gnome.GTG'
@@ -33,6 +34,7 @@ bin_config.set('local_build', 'False')
 bin_config.set('pythondir', pythondir)
 bin_config.set('localedir', datadir / 'locale')
 bin_config.set('APP_ID', application_id)
+bin_config.set('bindir', bindir)
 
 local_config = configuration_data()
 local_config.set('local_build', 'True')


### PR DESCRIPTION
Previously, a bit of stuff was done in the constructor, which (likely) hurts being D-Bus activate-able, since the "remote" instance (aka when trying to execute GTG again which then would hand off to the existing instance) would re-initialize only to not use that stuff.

Also changed from using an list-comprehension `[x for y in z]` to an "normal" for-loop, since it is two lines anyway and the result isn't used.

~~One step closer to being DBus-Activatable (#183).~~

Edit: Now also fixes #183