### PR TITLE
using another unicode for recurring tasks.

### DIFF
--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -95,7 +95,7 @@ class TreeviewFactory():
         str_format = "%s"
 
         # We add the indicator when task is repeating
-        INDICATOR = "\u2B6E "
+        INDICATOR = "\u21BB "
         if node.get_recurring():
             str_format = INDICATOR + str_format
 


### PR DESCRIPTION
this is super small change, but in my ubuntu I haven't installed or changing the default fonts, 

and using `\u2B6E` I'm seeing this:
![image](https://user-images.githubusercontent.com/193027/96374696-86197700-114a-11eb-957e-458b588f7843.png)

so I try another similar unicode code `\u21BB` and it works for me
![image](https://user-images.githubusercontent.com/193027/96374732-da245b80-114a-11eb-8845-50e3698ff12d.png)


what do you think @diegogangl @zeddo123 