### PR TITLE
Update translation doc (with plugins and additional option)

### DIFF
--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -73,5 +73,8 @@ Make sure to this AFTER COMMITING YOUR CHANGES!
 * During launching, it might complain about certain files not being found in [`po/POTFILES.in`][POTFILES.IN].
   It is safe to remove the lines from that file and re-run until it works.
   It would be useful to comment about that if you're submitting your translation, just in case.
+* Plugin related strings don't update after updating the translation.
+  The cause is unknown, but you can delete the plugin files to re-generate
+  them using the new translations: `rm -f .local_build/GTG/plugins/*.gtg-plugin`
 
 [POTFILES.IN]: ../../po/POTFILES.in

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -24,9 +24,9 @@ After that, you can then use the updated translation files and translate the mis
 
 Testing the changes is useful since you can then see your translation in action and see potentially mistranslation due to missing context.
 
-[Setup the environment][readme] and then simply run `LC_ALL=<lang>.UTF-8 ./launch.sh` in the repository root to compile the translations and run GTG with the `<lang>` language.
-For example, `LC_ALL=de_DE.UTF-8 ./launch.sh` would run GTG with the German translation.
-You don't need the `LC_ALL=<lang>.UTF-8` part if you run the system in the destination language anyway.
+[Setup the environment][readme] and then simply run `LC_ALL=<lang>.UTF-8 LANGUAGE=<lang>.UTF-8 ./launch.sh` in the repository root to compile the translations and run GTG with the `<lang>` language.
+For example, `LC_ALL=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 ./launch.sh` would run GTG with the German translation.
+You don't need the `LC_ALL=<lang>.UTF-8 LANGUAGE=<lang>.UTF-8` part if you run the system in the destination language anyway.
 
 # Submitting
 

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -27,6 +27,7 @@ Testing the changes is useful since you can then see your translation in action 
 [Setup the environment][readme] and then simply run `LC_ALL=<lang>.UTF-8 LANGUAGE=<lang>.UTF-8 ./launch.sh` in the repository root to compile the translations and run GTG with the `<lang>` language.
 For example, `LC_ALL=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 ./launch.sh` would run GTG with the German translation.
 You don't need the `LC_ALL=<lang>.UTF-8 LANGUAGE=<lang>.UTF-8` part if you run the system in the destination language anyway.
+You can use the `C` language to run without any translations: `LC_ALL=C.UTF-8 LANGUAGE=C.UTF-8 ./launch.sh`
 
 # Submitting
 


### PR DESCRIPTION
See commit messages

The plugin workaround is already known, see #457, not entirely sure why this is happening. (I would think it uses the symlink last updated which doesn't update when the file it points to updates)