### PR TITLE
Add translator notes primarily around parsing code

### DIFF
--- a/GTG/core/dates.py
+++ b/GTG/core/dates.py
@@ -41,20 +41,27 @@ ENGLISH_STRINGS = {
 }
 
 STRINGS = {
+    # Translators: Used for display
     NOW: _('now'),
+    # Translators: Used for display
     SOON: _('soon'),
+    # Translators: Used for display
     SOMEDAY: _('someday'),
     NODATE: '',
 }
 
 LOOKUP = {
     'now': NOW,
+    # Translators: Used in parsing, made lowercased in code
     _('now').lower(): NOW,
     'soon': SOON,
+    # Translators: Used in parsing, made lowercased in code
     _('soon').lower(): SOON,
     'later': SOMEDAY,
+    # Translators: Used in parsing, made lowercased in code
     _('later').lower(): SOMEDAY,
     'someday': SOMEDAY,
+    # Translators: Used in parsing, made lowercased in code
     _('someday').lower(): SOMEDAY,
     '': NODATE,
 }
@@ -368,14 +375,19 @@ class Date():
         # accepted date formats
         formats = {
             'today': 0,
+            # Translators: Used in parsing, made lowercased in code
             _('today').lower(): 0,
             'tomorrow': 1,
+            # Translators: Used in parsing, made lowercased in code
             _('tomorrow').lower(): 1,
             'next week': 7,
+            # Translators: Used in parsing, made lowercased in code
             _('next week').lower(): 7,
             'next month': calendar.mdays[today.month],
+            # Translators: Used in parsing, made lowercased in code
             _('next month').lower(): calendar.mdays[today.month],
             'next year': 365 + int(calendar.isleap(today.year)),
+            # Translators: Used in parsing, made lowercased in code
             _('next year').lower(): 365 + int(calendar.isleap(today.year)),
         }
 
@@ -496,14 +508,19 @@ class Date():
         formats = {
             # change the offset depending on the task.
             'day': 0 if newtask else 1,
+            # Translators: Used in recurring parsing, made lowercased in code
             _('day').lower(): 0 if newtask else 1,
             'other-day': 0 if newtask else 2,
+            # Translators: Used in recurring parsing, made lowercased in code
             _('other-day').lower(): 0 if newtask else 2,
             'week': 0 if newtask else 7,
+            # Translators: Used in recurring parsing, made lowercased in code
             _('week').lower(): 0 if newtask else 7,
             'month': 0 if newtask else calendar.mdays[self.month],
+            # Translators: Used in recurring parsing, made lowercased in code
             _('month').lower(): 0 if newtask else calendar.mdays[self.month],
             'year': 0 if newtask else 365 + int(calendar.isleap(self.year)),
+            # Translators: Used in recurring parsing, made lowercased in code
             _('year').lower(): 0 if newtask else 365 + int(calendar.isleap(self.year)),
         }
 

--- a/GTG/core/search.py
+++ b/GTG/core/search.py
@@ -83,16 +83,27 @@ from GTG.core.dates import Date
 # Generate keywords and their possible translations
 # They must be listed because of gettext
 KEYWORDS = {
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "not": _("not"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "or": _("or"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "after": _("after"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "before": _("before"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "today": _("today"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "tomorrow": _("tomorrow"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "nodate": _("nodate"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "now": _("now"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "soon": _("soon"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "someday": _("someday"),
+    # Translators: Used in search parsing, no spaces, lowercased in code
     "notag": _("notag"),
 }
 

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -200,6 +200,25 @@ class Task(TreeNode):
         defer_date = Date.no_date()
         recurring = False
         recurring_term = None
+
+        match_tags = [
+            "tags",
+            "tag",
+            # Translators: Used in parsing, no spaces, lowercased in code
+            _("tags").lower(),
+            # Translators: Used in parsing, no spaces, lowercased in code
+            _("tag").lower(),
+        ]
+        match_defer = [
+            "defer",
+            "start",
+            # Translators: Used in parsing, no spaces, lowercased in code
+            _("defer").lower(),
+            # Translators: Used in parsing, no spaces, lowercased in code
+            _("start").lower(),
+        ]
+
+
         if text:
             # Get tags in the title
             for match in extract_tags_from_text(text):
@@ -209,27 +228,26 @@ class Task(TreeNode):
             matches = re.findall(regexp, text, re.UNICODE)
             for spaces, attribute, args in matches:
                 valid_attribute = True
-                if attribute.lower() in ["tags", _("tags"), "tag", _("tag")]:
+                if attribute.lower() in match_tags:
                     for tag in args.split(","):
                         if not tag.strip() == "@" and not tag.strip() == "":
                             if not tag.startswith("@"):
                                 tag = "@" + tag
                             tags.append(tag)
-                elif attribute.lower() in ["defer", _("defer"), "start",
-                                           _("start")]:
+                elif attribute.lower() in match_defer:
                     try:
                         defer_date = Date.parse(args)
                     except ValueError:
                         valid_attribute = False
-                elif attribute.lower() == "due" or \
-                        attribute.lower() == _("due"):
+                # Translators: Used in parsing, no spaces, lowercased in code
+                elif attribute.lower() in ["due", _("due").lower()]:
                     try:
                         due_date = Date.parse(args)
                     except:
                         valid_attribute = False
 
-                elif attribute.lower() == "every" or \
-                        attribute.lower() == _("every"):
+                # Translators: Used in parsing, no spaces, lowercased in code
+                elif attribute.lower() in ["every", _("every").lower()]:
                     try:
                         Date(self.added_date).parse_from_date(args)
                         recurring = True

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -342,11 +342,13 @@ class TreeviewFactory():
 
     def active_tasks_treeview(self, tree):
         # Build the title/label/tags columns
+        # Translators: Column name, containing the task titles
         desc = self.common_desc_for_tasks(tree, _("Tasks"))
 
         # "startdate" column
         col_name = 'startdate'
         col = {}
+        # Translators: Column name, containing the start date
         col['title'] = _("Start Date")
         col['expandable'] = False
         col['resizable'] = False
@@ -358,6 +360,7 @@ class TreeviewFactory():
         # 'duedate' column
         col_name = 'duedate'
         col = {}
+        # Translators: Column name, containing the due date
         col['title'] = _("Due")
         col['expandable'] = False
         col['resizable'] = False
@@ -373,11 +376,13 @@ class TreeviewFactory():
 
     def closed_tasks_treeview(self, tree):
         # Build the title/label/tags columns
+        # Translators: Column name, containing the task titles
         desc = self.common_desc_for_tasks(tree, _("Closed Tasks"))
 
         # "startdate" column
         col_name = 'closeddate'
         col = {}
+        # Translators: Column name, containing the closed date
         col['title'] = _("Closed Date")
         col['expandable'] = False
         col['resizable'] = False

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -474,8 +474,10 @@ class TaskEditor():
 
         # Refreshing the parent button
         if self.task.has_parent():
+            # Translators: Button label to open the parent task
             self.parent_button.set_label(_('Open Parent'))
         else:
+            # Translators: Button label to add an new parent task
             self.parent_button.set_label(_('Add Parent'))
 
         # Refreshing the status bar labels and date boxes

--- a/GTG/gtk/editor/recurring_menu.py
+++ b/GTG/gtk/editor/recurring_menu.py
@@ -93,9 +93,11 @@ class RecurringMenu():
         if self.is_term_set():
             if self.selected_recurring_term.isdigit():
                 if len(self.selected_recurring_term) <= 2 : # Recurring monthly from selected date
+                    # Translators: Recurring monthly
                     self.title.set_markup(_('Every <b>{month_day} of the month</b>').format(month_day=datetime.strptime(f'{self.selected_recurring_term}', '%d').strftime('%d')))
                 else: # Recurring yearly from selected date
                     date = datetime.strptime(f'{self.selected_recurring_term[:2:]}-{self.selected_recurring_term[2::]}', '%m-%d')
+                    # Translators: Recurring yearly
                     self.title.set_markup(_('Every <b>{month} {day}</b>').format(month=date.strftime('%B'), day=date.strftime('%d')))
             elif self.selected_recurring_term == 'day': # Recurring daily
                 self.title.set_markup(_('Every <b>day</b>'))


### PR DESCRIPTION
To better signify what those strings and their restrictions are.

In `GTG/core/task.py` I had outsourced 2 lists to an new variable so it isn't that crammed in there to make "proper" comments.

Shouldn't make any functionality changes.