### PR TITLE
Update meson to 0.51.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gtg',
   version: '0.4.0',
-  meson_version: '>= 0.50.0'
+  meson_version: '>= 0.51.0'
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
Because I was getting the following warning:

    WARNING: Project targeting '>= 0.50.0' but tried to use feature introduced in '0.51.0': args arg in i18n.merge_file

Because I used the args argument in #457 to set what keys gettext should translate.