### PR TITLE
Actually exit with the correct exit code

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         application.connect("handle-local-options", handle_local_options)
 
         signal.signal(signal.SIGTERM, lambda s, f: application.quit())
-        application.run(sys.argv)
+        sys.exit(application.run(sys.argv))
 
     except KeyboardInterrupt:
         sys.exit(1)


### PR DESCRIPTION
AFAIK doesn't really change anything, but [the return value should be used as an exit value from the documentation](https://developer.gnome.org/gio/2.64/GApplication.html#g-application-run).