### PR TITLE
Gamify, a plugin to gamify your GTG workflow

### DIFF
--- a/GTG/core/plugins/api.py
+++ b/GTG/core/plugins/api.py
@@ -120,6 +120,10 @@ class PluginAPI():
         """Return the headerbar of the mainwindow"""
         return self.__builder.get_object('browser_headerbar')
 
+    def get_quickadd_pane(self):
+        """Return the quickadd pane"""
+        return self.__builder.get_object('quickadd_pane')
+
     def get_selected(self):
         """
         Returns the selected tasks in the browser or the task ID if the editor

--- a/GTG/core/plugins/api.py
+++ b/GTG/core/plugins/api.py
@@ -116,6 +116,10 @@ class PluginAPI():
         """
         return self.__builder.get_object('main_menu')
 
+    def get_header(self):
+        """Return the headerbar of the mainwindow"""
+        return self.__builder.get_object('browser_headerbar')
+
     def get_selected(self):
         """
         Returns the selected tasks in the browser or the task ID if the editor

--- a/GTG/core/plugins/api.py
+++ b/GTG/core/plugins/api.py
@@ -110,6 +110,12 @@ class PluginAPI():
         """
         return self.__view_manager.browser
 
+    def get_menu(self):
+        """
+        Return the menu entry to the menu of the Task Browser or Task Editor.
+        """
+        return self.__builder.get_object('main_menu')
+
     def get_selected(self):
         """
         Returns the selected tasks in the browser or the task ID if the editor

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -58,6 +58,7 @@ class MainWindow(Gtk.ApplicationWindow):
     __string_signal__ = (GObject.SignalFlags.RUN_FIRST, None, (str, ))
     __none_signal__ = (GObject.SignalFlags.RUN_FIRST, None, tuple())
     __gsignals__ = {'task-added-via-quick-add': __string_signal__,
+                    'task-marked-as-done': __string_signal__,
                     'visibility-toggled': __none_signal__,
                     }
 
@@ -1287,6 +1288,7 @@ class MainWindow(Gtk.ApplicationWindow):
             else:
                 task.set_status(Task.STA_DONE)
                 self.close_all_task_editors(uid)
+                GObject.idle_add(self.emit, "task-marked-as-done", task.get_id())
 
     def on_dismiss_task(self, widget=None):
         tasks_uid = [uid for uid in self.get_selected_tasks()

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -59,6 +59,7 @@ class MainWindow(Gtk.ApplicationWindow):
     __none_signal__ = (GObject.SignalFlags.RUN_FIRST, None, tuple())
     __gsignals__ = {'task-added-via-quick-add': __string_signal__,
                     'task-marked-as-done': __string_signal__,
+                    'task-marked-as-not-done': __string_signal__,
                     'visibility-toggled': __none_signal__,
                     }
 
@@ -1280,6 +1281,7 @@ class MainWindow(Gtk.ApplicationWindow):
             if status == Task.STA_DONE:
                 # Marking as undone
                 task.set_status(Task.STA_ACTIVE)
+                GObject.idle_add(self.emit, "task-marked-as-not-done", task.get_id())
                 # Parents of that task must be updated - not to be shown
                 # in workview, update children count, etc.
                 for parent_id in task.get_parents():

--- a/GTG/plugins/gamify.gtg-plugin
+++ b/GTG/plugins/gamify.gtg-plugin
@@ -1,0 +1,8 @@
+[GTG Plugin]
+module=gamify
+name=Gamify
+short-description=Gamify adds a game aspect to your GTG workflow.
+description=tracks how many tasks you have done during the day.
+authors=Zeddo123 <m.drissi@protonmail.com>
+version=0.0.1
+enabled=False

--- a/GTG/plugins/gamify.gtg-plugin.desktop
+++ b/GTG/plugins/gamify.gtg-plugin.desktop
@@ -1,0 +1,1 @@
+gamify.gtg-plugin

--- a/GTG/plugins/gamify/__init__.py
+++ b/GTG/plugins/gamify/__init__.py
@@ -1,0 +1,2 @@
+from GTG.plugins.gamify.gamify import Gamify
+assert Gamify

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -156,9 +156,6 @@ class Gamify:
             return 3
         return 1
 
-    def OnTaskOpened(self, plugin_api):
-        pass
-
     def is_full(self):
         """Return True if ui type is FULL"""
         return self.preferences['ui_type'] == 'FULL'

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -61,34 +61,21 @@ class Gamify:
         }
         self.builder.connect_signals(SIGNALS) 
 
-    def add_submenu(self):
-        self.menu = self.plugin_api.get_menu()
-        self.stack = self.menu.get_child()
-        self.submenu = self.builder.get_object('submenu-popover')
+    def add_headerbar_button(self):
         self.headerbar_button = self.builder.get_object('gamify-headerbar')
 
-        self.stack.add_named(self.submenu, 'gamify')
         self.headerbar = self.plugin_api.get_header()
         self.headerbar.add(self.headerbar_button)
 
-    def remove_submenu(self):
-        self.stack.remove(self.submenu)
+    def remove_headerbar_button(self):
         self.headerbar.remove(self.headerbar_button)
-
-    def add_menu_enty(self):
-        self.menu_item = self.builder.get_object('gamify-entry')
-        self.plugin_api.add_menu_item(self.menu_item)
-
-    def remove_menu_entry(self):
-        self.plugin_api.remove_menu_item(self.menu_item)
 
     def activate(self, plugin_api):
         self.plugin_api = plugin_api
         self.browser = plugin_api.get_browser()
 
         # Settings up the menu 
-        self.add_submenu()
-        self.add_menu_enty()
+        self.add_headerbar_button()
 
         # Init the preference dialog
         try:
@@ -106,7 +93,6 @@ class Gamify:
         self.update_streak()
         self.analitics_save()
         self.update_widget()
-        print(self.data)
 
     def on_marked_as_done(self, sender, task_id):
         log.debug('a task has been marked as done')
@@ -123,7 +109,6 @@ class Gamify:
         self.data['score'] += self.get_points_for_task(task_id)
         self.analitics_save()
         self.update_widget()
-        print(self.data)
 
     def get_points_for_task(self, task_id):
         """Returns the number of point for doing a perticular task
@@ -213,6 +198,9 @@ class Gamify:
     def get_number_of_tasks(self):
         return self.data['last_task_number']
 
+    def get_streak(self):
+        return self.data['streak']
+
     def update_score(self):
         score_label = self.builder.get_object('score_label')
         score_label.set_markup(_("<b>{current_level}</b>").format(current_level=self.get_current_level()))
@@ -236,7 +224,7 @@ class Gamify:
             emoji = ["\U0001F60E", "\U0001F920", "\U0001F640"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Good Job!\nYou have achieved your goal."))
-        elif tasks_done > 1:
+        elif tasks_done >= 1:
             emoji = ["\U0001F600", "\U0001F60C"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Only a few tasks to go!"))
@@ -248,9 +236,20 @@ class Gamify:
         levelbar.set_max_value(self.preferences['target'])
         levelbar.set_value(self.get_number_of_tasks())
 
+    def update_streak_widget(self):
+        streak_number = self.builder.get_object('streak_number')
+        streak_emoji = self.builder.get_object('streak_emoji')
+        if self.get_streak() > 0:
+            streak_emoji.set_markup("\U0001F525")
+        else:
+            streak_emoji.set_markup("\U0001F9CA")
+        streak_number.set_markup(_("You've completed your goal {streak} day in a row.").format(streak=self.get_streak()))
+
+
     def update_widget(self):
         self.update_score()
         self.update_goal()
+        self.update_streak_widget()
 
     def configure_dialog(self, manager_dialog):
         if not self.configureable:

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -23,14 +23,14 @@ class Gamify:
         "ui_type": "FULL"
     }
     LEVELS = {
-        100: 'Beginner',
-        1000: 'Novice',
-        2000: 'prefessional',
-        4000: 'Expert',
-        9000: 'Master',
-        13000: 'Master II',
-        19000: 'Grand Master',
-        25000: 'Productivity Lord'
+        100: _('Beginner'),
+        1000: _('Novice'),
+        2000: _('prefessional'),
+        4000: _('Expert'),
+        9000: _('Master'),
+        13000: _('Master II'),
+        19000: _('Grand Master'),
+        25000: _('Productivity Lord')
     }
 
     def __init__(self):

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -19,7 +19,7 @@ class Gamify:
         "score": 0
     }
     DEFAULT_PREFERENCES = {
-        "target": 3
+        "goal": 3
     }
     LEVELS = {
         100: 'Beginner',
@@ -103,7 +103,7 @@ class Gamify:
         self.update_date()
 
         # Increase the number of tasks done and update the streak
-        # if the target number of tasks was achieved
+        # if the goal number of tasks was achieved
         self.data['last_task_number'] += 1
         self.update_streak()
         self.data['score'] += self.get_points_for_task(task_id)
@@ -175,7 +175,7 @@ class Gamify:
         )
 
     def update_streak(self):
-        if self.data['last_task_number'] >= self.preferences['target']:
+        if self.data['last_task_number'] >= self.preferences['goal']:
             if not self.data['goal_achieved']:
                 self.data['goal_achieved'] = True
                 self.data['streak'] += 1
@@ -183,7 +183,7 @@ class Gamify:
     def update_date(self):
         today = date.today()
         if self.data['last_task_date'] != today:
-            if self.data['last_task_number'] < self.preferences['target']:
+            if self.data['last_task_number'] < self.preferences['goal']:
                 self.data['streak'] = 0
             self.data['goal_achieved'] = False
             self.data['last_task_number'] = 0
@@ -208,19 +208,16 @@ class Gamify:
         score_value.set_markup(_('You have: <b>{score}</b> points').format(score=self.get_score()))
 
     def update_goal(self):
-        goal_label = self.builder.get_object('goal_label')
         headerbar_label_button = self.builder.get_object('headerbar-label-button')
         headerbar_label = self.builder.get_object('headerbar-label')
         headerbar_msg = self.builder.get_object('headerbar-msg')
-        levelbar = self.builder.get_object('gamify-level-bar')
 
         tasks_done = self.get_number_of_tasks()
-        target = self.preferences['target']
-        goal_label.set_markup(_("<b>{tasks_done} tasks out of {goal}</b>").format(tasks_done=tasks_done, goal=target))
-        headerbar_label_button.set_markup("{tasks_done}/{goal}".format(tasks_done=tasks_done, goal=target))
+        goal = self.preferences['goal']
+        headerbar_label_button.set_markup("{tasks_done}/{goal}".format(tasks_done=tasks_done, goal=goal))
 
         # Select a msg and emojo depending on the number of tasks done.
-        if tasks_done >= target:
+        if tasks_done >= goal:
             emoji = ["\U0001F60E", "\U0001F920", "\U0001F640"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Good Job!\nYou have achieved your goal."))
@@ -232,9 +229,6 @@ class Gamify:
             emoji = ["\U0001F643", "\U0001F648"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Get Down to Business\nYou haven't achieved any tasks today."))
-
-        levelbar.set_max_value(self.preferences['target'])
-        levelbar.set_value(self.get_number_of_tasks())
 
     def update_streak_widget(self):
         streak_number = self.builder.get_object('streak_number')
@@ -259,7 +253,7 @@ class Gamify:
         self.preferences_load()
         self.pref_dialog.set_transient_for(manager_dialog) 
         
-        self.spinner.set_value(self.preferences['target'])
+        self.spinner.set_value(self.preferences['goal'])
 
         self.pref_dialog.show_all()
 
@@ -271,7 +265,7 @@ class Gamify:
         self.preferences_load()
 
         # Get the new preferences
-        self.preferences['target'] = self.spinner.get_value_as_int()
+        self.preferences['goal'] = self.spinner.get_value_as_int()
         
         self.save_preferences() 
         self.update_goal()

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -25,9 +25,9 @@ class Gamify:
         "goal": 3,
         "ui_type": "FULL",
         "tag_mapping": {
-            _('@easy'): 1,
-            _('@medium'): 2,
-            _('@hard'): 3,
+            _('easy'): 1,
+            _('medium'): 2,
+            _('hard'): 3,
         }
     }
     LEVELS = {
@@ -232,8 +232,9 @@ class Gamify:
     def update_date(self):
         today = date.today()
         if self.data['last_task_date'] != today:
-            if self.data['last_task_number'] < self.preferences['goal']:
+            if self.data['last_task_number'] < self.preferences['goal'] or (today - self.data['last_task_date']).days > 1:
                 self.data['streak'] = 0
+
             self.data['goal_achieved'] = False
             self.data['last_task_number'] = 0
             self.data['last_task_date'] = today
@@ -253,9 +254,9 @@ class Gamify:
     def button_update_score(self):
         """Update the score in the BUTTON widget"""
         score_label = self.builder.get_object('score_label')
-        score_label.set_markup(_("<b>{current_level}</b>").format(current_level=self.get_current_level()))
+        score_label.set_markup(_("Level: <b>{current_level}</b>").format(current_level=self.get_current_level()))
         score_value = self.builder.get_object('score_value')
-        score_value.set_markup(_('You have: <b>{score}</b> points').format(score=self.get_score()))
+        score_value.set_markup(ngettext("%d Point", "%d Points",self.get_score()) % self.get_score())
 
     def button_update_goal(self):
         """Update the numbers of tasks done in the BUTTON widget"""
@@ -284,12 +285,12 @@ class Gamify:
     def button_update_streak(self):
         """Update the streak numbers in the BUTTON widget"""
         streak_number = self.builder.get_object('streak_number')
-        streak_emoji = self.builder.get_object('streak_emoji')
         if self.get_streak() > 0:
-            streak_emoji.set_markup("\U0001F525")
+            streak_emoji = "\U0001F525"
         else:
-            streak_emoji.set_markup("\U0001F9CA")
-        streak_number.set_markup(ngettext("You've completed your goal %d day in a row.", "You've completed your goal %d days in a row.", self.get_streak()) % self.get_streak())
+            streak_emoji = "\U0001F9CA"
+
+        streak_number.set_markup(_("{emoji} <b>{streak} day</b> streak").format(streak=self.get_streak(), emoji=streak_emoji))
 
     def update_levelbar(self):
         self.levelbar.set_min_value(0.0)

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -209,13 +209,16 @@ class Gamify:
 
     def update_score(self):
         score_label = self.builder.get_object('score_label')
-        score_label.set_markup(_("<b>Your current level is</b> {current_level}").format(current_level=self.get_current_level()))
+        score_label.set_markup(_("<b>{current_level}</b>").format(current_level=self.get_current_level()))
         score_value = self.builder.get_object('score_value')
         score_value.set_markup(_('You have: <b>{score}</b> points').format(score=self.get_score()))
 
     def update_goal(self):
         goal_label = self.builder.get_object('goal_label')
         goal_label.set_markup(_("<b>{tasks_done}/{goal}</b>").format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
+        levelbar = self.builder.get_object('gamify-level-bar')
+        levelbar.set_max_value(self.preferences['target'])
+        levelbar.set_value(self.get_number_of_tasks())
 
     def update_widget(self):
         self.update_score()
@@ -241,6 +244,7 @@ class Gamify:
         self.preferences_load()
 
         # Get the new preferences
-        self.preferences['target'] = self.spinner.get_value()
+        self.preferences['target'] = self.spinner.get_value_as_int()
         
         self.save_preferences() 
+        self.update_goal()

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -2,14 +2,15 @@ import os
 import random
 from datetime import date
 from collections import defaultdict
+import logging
 
 from gi.repository import Gio
 from gi.repository import Gtk
 
-from GTG.core.logger import log
 from gettext import gettext as _
 from gettext import ngettext
 
+log = logging.getLogger(__name__)
 class Gamify:
     PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
     PLUGIN_NAMESPACE = 'gamify'

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -1,4 +1,5 @@
 import os
+import random
 from datetime import date
 
 from gi.repository import Gio
@@ -221,10 +222,28 @@ class Gamify:
     def update_goal(self):
         goal_label = self.builder.get_object('goal_label')
         headerbar_label_button = self.builder.get_object('headerbar-label-button')
+        headerbar_label = self.builder.get_object('headerbar-label')
+        headerbar_msg = self.builder.get_object('headerbar-msg')
         levelbar = self.builder.get_object('gamify-level-bar')
 
-        goal_label.set_markup(_("<b>{tasks_done} tasks out of {goal}</b>").format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
-        headerbar_label_button.set_markup("{tasks_done}/{goal}".format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
+        tasks_done = self.get_number_of_tasks()
+        target = self.preferences['target']
+        goal_label.set_markup(_("<b>{tasks_done} tasks out of {goal}</b>").format(tasks_done=tasks_done, goal=target))
+        headerbar_label_button.set_markup("{tasks_done}/{goal}".format(tasks_done=tasks_done, goal=target))
+
+        # Select a msg and emojo depending on the number of tasks done.
+        if tasks_done >= target:
+            emoji = ["\U0001F60E", "\U0001F920", "\U0001F640"]
+            headerbar_label.set_markup(random.choice(emoji))
+            headerbar_msg.set_markup(_("Good Job!\nYou have achieved your goal."))
+        elif tasks_done > 1:
+            emoji = ["\U0001F600", "\U0001F60C"]
+            headerbar_label.set_markup(random.choice(emoji))
+            headerbar_msg.set_markup(_("Only a few tasks to go!"))
+        else:
+            emoji = ["\U0001F643", "\U0001F648"]
+            headerbar_label.set_markup(random.choice(emoji))
+            headerbar_msg.set_markup(_("Get Down to Business\nYou haven't achieved any tasks today."))
 
         levelbar.set_max_value(self.preferences['target'])
         levelbar.set_value(self.get_number_of_tasks())

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -11,7 +11,7 @@ from gettext import gettext as _
 class Gamify:
     PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
     PLUGIN_NAMESPACE = 'gamify'
-    DEFAULT_ANALITICS = {
+    DEFAULT_ANALYTICS = {
         "last_task_date": date.today(), # The date of the last task marked as done
         "last_task_number": 0, # The number of tasks done today
         "streak": 0, # The number of days in which the goal was achieved
@@ -132,25 +132,26 @@ class Gamify:
         """Returns the number of point for doing a perticular task
 
         If a task is taged as @hard: the user receives 3 points
-        If a task is taged as @meduim: the use receives 2 points
+        If a task is taged as @medium: the use receives 2 points
         If a task is taged as @easy: the user receives 1 point
         """
         easy = False
-        meduim = False
+        medium = False
         hard = False
+
         task = self.plugin_api.get_requester().get_task(task_id)
         tags = task.get_tags_name()
         for tag in tags:
             if tag == '@easy':
                 easy = True
-            elif tag == '@meduim':
-                meduim = True
+            elif tag == '@medium':
+                medium = True
             elif tag == '@hard':
                 hard = True
 
         if easy:
             return 1
-        if meduim:
+        if medium:
             return 2
         if hard:
             return 3
@@ -211,7 +212,7 @@ class Gamify:
     def analytics_load(self):
         self.data = self.plugin_api.load_configuration_object(
             self.PLUGIN_NAMESPACE, "analytics",
-            default_values=self.DEFAULT_ANALITICS
+            default_values=self.DEFAULT_ANALYTICS
         )
 
     def analytics_save(self):

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -191,6 +191,7 @@ class Gamify:
             pass
 
     def deactivate(self, plugin_api):
+        self.browser.disconnect(self.connect_id)
         self.remove_ui()
 
     def is_configurable(self):

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -270,15 +270,15 @@ class Gamify:
 
         # Select a msg and emojo depending on the number of tasks done.
         if tasks_done >= goal:
-            emoji = ["\U0001F60E", "\U0001F920", "\U0001F640"]
+            emoji = ["\U0001F60E", "\U0001F920", "\U0001F640", "\U0001F31F"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Good Job!\nYou have achieved your goal."))
         elif tasks_done >= 1:
-            emoji = ["\U0001F600", "\U0001F60C"]
+            emoji = ["\U0001F600", "\U0001F60C", "\U0000270A"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Only a few tasks to go!"))
         else:
-            emoji = ["\U0001F643", "\U0001F648"]
+            emoji = ["\U0001F643", "\U0001F648", "\U0001F995", "\U0001F9A5"]
             headerbar_label.set_markup(random.choice(emoji))
             headerbar_msg.set_markup(_("Get Down to Business\nYou haven't achieved any tasks today."))
 

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -8,14 +8,32 @@ from gettext import gettext as _
 
 class Gamify:
     PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
+    PLUGIN_NAMESPACE = 'gamify'
+    DEFAULT_PREFERENCES = {
+        "target": 3
+    }
 
     def __init__(self):
-        self.task_target = 0
+        self.configureable = True
 
+    def _init_dialog_pref(self):
         self.builder = Gtk.Builder()
         path = f"{self.PLUGIN_PATH}/prefs.ui"
         self.builder.add_from_file(path)
-        self.pref_dialog = self.builder.get_object('gamify-pref-window')
+        # Get the dialog widget
+        self.pref_dialog = self.builder.get_object('gamify-pref-dialog')
+        # Get the buttonSpin
+        self.spinner = self.builder.get_object('target-spin-button')
+
+        if self.pref_dialog is None or self.spinner is None:
+            raise ValueError('Cannot load preference dialog widget')
+
+        SIGNALS = {
+            "on_preferences_changed": self.on_preferences_changed,
+            "on_dialog_close": self.on_preferences_closed
+        }
+        self.builder.connect_signals(SIGNALS) 
+
 
     def activate(self, plugin_api):
         self.plugin_api = plugin_api
@@ -26,6 +44,13 @@ class Gamify:
         self.menu_item.set_label(_("Gamify"))
         self.menu_item.connect("clicked", self.on_marked_as_done, plugin_api)
         self.plugin_api.add_menu_item(self.menu_item)
+
+        # Init the preference dialog
+        try:
+            self._init_dialog_pref()
+        except ValueError:
+            self.configureable = False
+            log.debug('Cannot load preference dialog widget')
 
         # Connect to the signals
         self.connect_id = self.browser.connect("task-marked-as-done", self.on_marked_as_done)
@@ -42,5 +67,39 @@ class Gamify:
     def is_configurable(self):
         return True
 
+    def preferences_load(self):
+        return self.plugin_api.load_configuration_object(
+            self.PLUGIN_NAMESPACE, "preferences",
+            default_values=self.DEFAULT_PREFERENCES
+        )
+
+    def save_preferences(self, preferences):
+        self.plugin_api.save_configuration_object(
+            self.PLUGIN_NAMESPACE, 
+            "preferences", 
+            preferences
+        )
+
     def configure_dialog(self, manager_dialog):
-        pass
+        if not self.configureable:
+            log.debug('trying to open preference menu, but dialog widget not loaded')
+            return
+
+        preferences = self.preferences_load()
+        self.pref_dialog.set_transient_for(manager_dialog) 
+        
+        self.spinner.set_value(preferences['target'])
+
+        self.pref_dialog.show_all()
+
+    def on_preferences_closed(self, widget=None, data=None):
+        self.pref_dialog.hide()
+        return True
+
+    def on_preferences_changed(self, widget=None, data=None):
+        preferences = self.preferences_load()
+
+        # Get the new preferences
+        preferences['target'] = self.spinner.get_value()
+        
+        self.save_preferences(preferences) 

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -154,7 +154,7 @@ class Gamify:
         3 points for @hard
         """
         task = self.plugin_api.get_requester().get_task(task_id)
-        return max(list(map(self.get_points, task.get_tags_name())))
+        return max(list(map(self.get_points, task.get_tags_name())), default=1)
 
     def is_full(self):
         """Return True if ui type is FULL"""

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -8,6 +8,7 @@ from gi.repository import Gtk
 
 from GTG.core.logger import log
 from gettext import gettext as _
+from gettext import ngettext
 
 class Gamify:
     PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -286,7 +287,7 @@ class Gamify:
             streak_emoji.set_markup("\U0001F525")
         else:
             streak_emoji.set_markup("\U0001F9CA")
-        streak_number.set_markup(_("You've completed your goal {streak} day in a row.").format(streak=self.get_streak()))
+        streak_number.set_markup(ngettext("You've completed your goal %d day in a row.", "You've completed your goal %d days in a row.", self.get_streak()) % self.get_streak())
 
     def update_levelbar(self):
         self.levelbar.set_min_value(0.0)

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -1,0 +1,46 @@
+import os
+
+from gi.repository import Gio
+from gi.repository import Gtk
+
+from GTG.core.logger import log
+from gettext import gettext as _
+
+class Gamify:
+    PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
+
+    def __init__(self):
+        self.task_target = 0
+
+        self.builder = Gtk.Builder()
+        path = f"{self.PLUGIN_PATH}/prefs.ui"
+        self.builder.add_from_file(path)
+        self.pref_dialog = self.builder.get_object('gamify-pref-window')
+
+    def activate(self, plugin_api):
+        self.plugin_api = plugin_api
+        self.browser = plugin_api.get_browser()
+
+        # Add a button to the MainWindow
+        self.menu_item = Gtk.ModelButton.new()
+        self.menu_item.set_label(_("Gamify"))
+        self.menu_item.connect("clicked", self.on_marked_as_done, plugin_api)
+        self.plugin_api.add_menu_item(self.menu_item)
+
+        # Connect to the signals
+        self.connect_id = self.browser.connect("task-marked-as-done", self.on_marked_as_done)
+
+    def on_marked_as_done(self, sender, task_id):
+        log.debug('a task has been marked as done')
+
+    def OnTaskOpened(self, plugin_api):
+        pass
+    
+    def deactivate(self, plugin_api):
+        self.plugin_api.remove_menu_item(self.menu_item)
+
+    def is_configurable(self):
+        return True
+
+    def configure_dialog(self, manager_dialog):
+        pass

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -379,7 +379,7 @@ class Gamify:
         for key, value in self.preferences['tag_mapping'].items():
             row = Gtk.ListBoxRow()
             box = Gtk.HBox(orientation=Gtk.Orientation.HORIZONTAL)
-            label = Gtk.Label(f'{key}')
+            label = Gtk.Label(key)
 
             spin = Gtk.SpinButton()
             spin.set_adjustment(Gtk.Adjustment(upper=100, step_increment=1, page_increment=10))
@@ -396,4 +396,18 @@ class Gamify:
             self.tag_listbox.remove(row)
 
     def on_tag_submit_clicked(self, widget=None, data=None):
-        pass
+        if tag := self.tag_entry_field.get_text():
+            row = Gtk.ListBoxRow()
+            box = Gtk.HBox(orientation=Gtk.Orientation.HORIZONTAL)
+            label = Gtk.Label(f'@{tag}')
+
+            spin = Gtk.SpinButton()
+            spin.set_adjustment(Gtk.Adjustment(upper=100, step_increment=1, page_increment=10))
+            spin.set_numeric(True)
+            spin.set_value(1)
+
+            row.add(box)
+            box.add(label)
+            box.add(spin)
+            self.tag_listbox.add(row)
+            self.tag_listbox.show_all()

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -64,10 +64,15 @@ class Gamify:
         self.menu = self.plugin_api.get_menu()
         self.stack = self.menu.get_child()
         self.submenu = self.builder.get_object('submenu-popover')
+        self.headerbar_button = self.builder.get_object('gamify-headerbar')
+
         self.stack.add_named(self.submenu, 'gamify')
+        self.headerbar = self.plugin_api.get_header()
+        self.headerbar.add(self.headerbar_button)
 
     def remove_submenu(self):
         self.stack.remove(self.submenu)
+        self.headerbar.remove(self.headerbar_button)
 
     def add_menu_enty(self):
         self.menu_item = self.builder.get_object('gamify-entry')
@@ -215,8 +220,12 @@ class Gamify:
 
     def update_goal(self):
         goal_label = self.builder.get_object('goal_label')
-        goal_label.set_markup(_("<b>{tasks_done}/{goal}</b>").format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
+        headerbar_label_button = self.builder.get_object('headerbar-label-button')
         levelbar = self.builder.get_object('gamify-level-bar')
+
+        goal_label.set_markup(_("<b>{tasks_done} tasks out of {goal}</b>").format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
+        headerbar_label_button.set_markup("{tasks_done}/{goal}".format(tasks_done=self.get_number_of_tasks(), goal=self.preferences['target']))
+
         levelbar.set_max_value(self.preferences['target'])
         levelbar.set_value(self.get_number_of_tasks())
 

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -1,4 +1,5 @@
 import os
+from datetime import date
 
 from gi.repository import Gio
 from gi.repository import Gtk
@@ -9,6 +10,13 @@ from gettext import gettext as _
 class Gamify:
     PLUGIN_PATH = os.path.dirname(os.path.abspath(__file__))
     PLUGIN_NAMESPACE = 'gamify'
+    DEFAULT_ANALITICS = {
+        "last_task_date": date.today(), # The date of the last task marked as done
+        "last_task_number": 0, # The number of tasks done today
+        "streak": 0, # The number of days in which the goal was achieved
+        "goal_achieved": False, # achieved today's goal
+        "score": 0
+    }
     DEFAULT_PREFERENCES = {
         "target": 3
     }
@@ -23,6 +31,8 @@ class Gamify:
         self.menu = None
         self.stack = None
         self.submenu = None
+
+        self.data = None
 
     def _init_dialog_pref(self):
         # Get the dialog widget
@@ -50,7 +60,6 @@ class Gamify:
 
     def add_menu_enty(self):
         self.menu_item = self.builder.get_object('gamify-entry')
-        self.menu_item.connect("clicked", self.on_marked_as_done, self.plugin_api)
         self.plugin_api.add_menu_item(self.menu_item)
 
     def remove_menu_entry(self):
@@ -74,8 +83,27 @@ class Gamify:
         # Connect to the signals
         self.connect_id = self.browser.connect("task-marked-as-done", self.on_marked_as_done)
 
+        self.data = self.analitics_load()
+        preferences = self.preferences_load()
+        self.update_date(preferences)
+        self.update_streak(preferences)
+        self.analitics_save(self.data)
+        print(self.data)
+
     def on_marked_as_done(self, sender, task_id):
         log.debug('a task has been marked as done')
+        self.data = self.analitics_load()
+        preferences = self.preferences_load()
+
+        # Update the date, if it is different from today
+        self.update_date(preferences)
+
+        # Increase the number of tasks done and update the streak
+        # if the target number of tasks was achieved
+        self.data['last_task_number'] += 1
+        self.update_streak(preferences)
+        self.analitics_save(self.data)
+        print(self.data)
 
     def OnTaskOpened(self, plugin_api):
         pass
@@ -99,6 +127,34 @@ class Gamify:
             "preferences", 
             preferences
         )
+
+    def analitics_load(self):
+        return self.plugin_api.load_configuration_object(
+            self.PLUGIN_NAMESPACE, "analitics",
+            default_values=self.DEFAULT_ANALITICS
+        )
+
+    def analitics_save(self, analitics):
+        self.plugin_api.save_configuration_object(
+            self.PLUGIN_NAMESPACE,
+            "analitics",
+            analitics
+        )
+
+    def update_streak(self, preferences):
+        if self.data['last_task_number'] >= preferences['target']:
+            if not self.data['goal_achieved']:
+                self.data['goal_achieved'] = True
+                self.data['streak'] += 1
+
+    def update_date(self, preferences):
+        today = date.today()
+        if self.data['last_task_date'] != today:
+            if self.data['last_task_number'] < preferences['target']:
+                self.data['streak'] = 0
+            self.data['goal_achieved'] = False
+            self.data['last_task_number'] = 0
+            self.data['last_task_date'] = today
 
     def configure_dialog(self, manager_dialog):
         if not self.configureable:

--- a/GTG/plugins/gamify/meson.build
+++ b/GTG/plugins/gamify/meson.build
@@ -1,0 +1,7 @@
+gtg_plugin_gamify = [
+	'__init__.py',
+	'gamify.py',
+  'prefs.ui',
+]
+
+python3.install_sources(gtg_plugin_gamify, subdir: 'GTG' / 'plugins' / 'gamify', pure: true)

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -151,7 +151,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel">
+      <object class="GtkLabel" id="goal_label">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label" translatable="yes">Your target</property>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -1,29 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
-  <object class="GtkDialog" id="gamify-pref-window">
-    <property name="can_focus">False</property>
-    <property name="type_hint">dialog</property>
+  <object class="GtkDialog" id="gamify-pref-dialog">
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
+    <signal name="delete-event" handler="on_dialog_close" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="close-settings">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_dialog_close" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="apply-settings">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_preferences_changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
@@ -35,12 +58,12 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Gamify Preferences</property>
               </object>
               <packing>
@@ -52,12 +75,12 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Target Tasks per day</property>
                   </object>
                   <packing>
@@ -67,12 +90,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSpinButton" id="target-spinner">
+                  <object class="GtkSpinButton" id="target-spin-button">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="input_purpose">digits</property>
+                    <property name="can-focus">True</property>
+                    <property name="input-purpose">digits</property>
                     <property name="adjustment">adjustment1</property>
-                    <property name="climb_rate">1</property>
+                    <property name="climb-rate">1</property>
                     <property name="numeric">True</property>
                     <property name="value">1.0000000002235174</property>
                   </object>
@@ -97,9 +120,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -2,159 +2,46 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="lower">100</property>
-    <property name="upper">1000</property>
-    <property name="value">500</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkDialog" id="gamify-pref-dialog">
+  <object class="GtkWindow" id="Preferences">
     <property name="can-focus">False</property>
+    <property name="default-width">550</property>
+    <property name="default-height">500</property>
     <property name="type-hint">dialog</property>
-    <signal name="delete-event" handler="on_dialog_close" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox">
+    <signal name="delete-event" handler="on-preferences-closed" swapped="no"/>
+    <child>
+      <object class="GtkBox" id="main_window_box">
+        <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
-            <child>
-              <object class="GtkButton" id="close-settings">
-                <property name="label" translatable="yes">Close</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="on_dialog_close" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="apply-settings">
-                <property name="label" translatable="yes">Apply</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="on_preferences_changed" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkStack" id="stack">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">10</property>
+            <property name="transition-type">crossfade</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkBox" id="General">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">🗲Gamify Preferences</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="scale" value="1.5"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="homogeneous">True</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Target Tasks per day</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="target-spin-button">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="input-purpose">digits</property>
-                    <property name="adjustment">adjustment1</property>
-                    <property name="climb-rate">1</property>
-                    <property name="numeric">True</property>
-                    <property name="value">1.0000000002235174</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="margin-left">25</property>
+                <property name="margin-right">22</property>
+                <property name="margin-top">15</property>
+                <property name="margin-bottom">9</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">8</property>
+                <property name="spacing">4</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox" id="toplevel-settings">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Tag Mappings</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="spacing">8</property>
-                    <property name="baseline-position">top</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkLabel" id="general-label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-start">10</property>
-                        <property name="margin-end">140</property>
-                        <property name="label" translatable="yes">Tag :</property>
+                        <property name="margin-bottom">7</property>
+                        <property name="label" translatable="yes">General</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.1499999999999999"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -163,9 +50,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="tag-input-field">
+                      <object class="GtkListBox" id="general-listbox">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="selection-mode">none</property>
+                        <property name="activate-on-single-click">False</property>
+                        <style>
+                          <class name="prefs_list"/>
+                        </style>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -173,34 +65,18 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkButton" id="tag-submit-button">
-                        <property name="label" translatable="yes">Add</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
-                        <signal name="clicked" handler="on_tag_submit_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton">
-                        <property name="label" translatable="yes">Delete</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
-                        <signal name="clicked" handler="on_tag_delete_button_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparator">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">24</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -209,27 +85,42 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkScrolledWindow">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="vadjustment">adjustment2</property>
-                    <property name="vscrollbar-policy">never</property>
-                    <property name="shadow-type">in</property>
-                    <property name="min-content-width">18</property>
-                    <property name="min-content-height">18</property>
-                    <property name="max-content-width">18</property>
-                    <property name="max-content-height">18</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkViewport">
+                      <object class="GtkLabel" id="mappings-label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <child>
-                          <object class="GtkListBox" id="tag-listbox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                          </object>
-                        </child>
+                        <property name="margin-bottom">9</property>
+                        <property name="label" translatable="yes">Tag Mappings</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.1499999999999999"/>
+                        </attributes>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkListBox" id="mappings-listbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="selection-mode">none</property>
+                        <property name="activate-on-single-click">False</property>
+                        <style>
+                          <class name="prefs_list"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -238,11 +129,147 @@
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="action_area">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="label" translatable="yes">Apply</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <signal name="clicked" handler="on-preferences-changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack-type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="title" translatable="yes">General</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="header_bar">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="title" translatable="yes">🗲Gamify Preferences</property>
+        <property name="spacing">0</property>
+        <property name="show-close-button">True</property>
+      </object>
+    </child>
+  </object>
+  <object class="GtkImage">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
+    <property name="icon-name">list-remove-symbolic</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkBox" id="target-tasks">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="homogeneous">True</property>
+    <child>
+      <object class="GtkLabel" id="target-label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">13</property>
+        <property name="margin-right">117</property>
+        <property name="label" translatable="yes">Target Tasks per day</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="target-spinbutton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="input-purpose">number</property>
+        <property name="adjustment">adjustment1</property>
+        <property name="climb-rate">1</property>
+        <property name="numeric">True</property>
+        <property name="value">1</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkWindow" id="new-mapping-dialog">
+    <property name="can-focus">False</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
+    <property name="urgency-hint">True</property>
+    <property name="decorated">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkHeaderBar">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="title" translatable="yes">Mappings</property>
+            <property name="subtitle" translatable="yes">Add</property>
+            <child>
+              <object class="GtkButton" id="dismiss-new-mapping">
+                <property name="label" translatable="yes">close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="dismiss-new-mapping" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="submit-new-mapping">
+                <property name="label" translatable="yes">Add</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="submit-new-mapping" swapped="no"/>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -253,28 +280,45 @@
           </packing>
         </child>
         <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-left">7</property>
-            <property name="margin-right">7</property>
+            <property name="margin-left">12</property>
+            <property name="margin-right">12</property>
+            <property name="margin-top">27</property>
+            <property name="margin-bottom">47</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">40</property>
+            <property name="homogeneous">True</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Select UI version</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Tag Name:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="new-mapping-entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="can-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -288,14 +332,10 @@
                 <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton0">
-                    <property name="label" translatable="yes">Both/Full UI</property>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="active">True</property>
-                    <property name="draw-indicator">True</property>
-                    <property name="group">radiobutton2</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Points:</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -304,35 +344,18 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton1">
-                    <property name="label" translatable="yes">Button UI</property>
+                  <object class="GtkSpinButton" id="new-mapping-spinner">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="active">True</property>
-                    <property name="draw-indicator">True</property>
-                    <property name="group">radiobutton2</property>
+                    <property name="input-purpose">number</property>
+                    <property name="adjustment">adjustment2</property>
+                    <property name="climb-rate">1</property>
+                    <property name="value">1</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkRadioButton" id="radiobutton2">
-                    <property name="label" translatable="yes">Discrete mode</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="tooltip-text" translatable="yes">A GtkLevelBar in under the quickadd entry</property>
-                    <property name="active">True</property>
-                    <property name="draw-indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -346,11 +369,17 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="adjustment3">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkLevelBar" id="goal-levelbar">
     <property name="visible">True</property>
@@ -487,6 +516,51 @@
           <attribute name="weight" value="bold"/>
         </attributes>
       </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="ui-mode">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="homogeneous">True</property>
+    <child>
+      <object class="GtkLabel" id="ui-label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">13</property>
+        <property name="margin-right">124</property>
+        <property name="label" translatable="yes">UI mode</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkComboBoxText" id="ui-combobox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="active">0</property>
+        <property name="button-sensitivity">on</property>
+        <property name="has-entry">True</property>
+        <property name="active-id">0</property>
+        <items>
+          <item id="0" translatable="yes">Full/Both</item>
+          <item id="1" translatable="yes">Button</item>
+          <item id="2" translatable="yes">Discrete</item>
+        </items>
+        <child internal-child="entry">
+          <object class="GtkEntry">
+            <property name="can-focus">False</property>
+            <property name="text" translatable="yes">Full/Both UI</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -158,14 +158,14 @@
                 <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton2">
+                  <object class="GtkRadioButton" id="radiobutton0">
                     <property name="label" translatable="yes">Both/Full UI</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
-                    <property name="group">radiobutton1</property>
+                    <property name="group">radiobutton2</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -174,14 +174,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton">
+                  <object class="GtkRadioButton" id="radiobutton1">
                     <property name="label" translatable="yes">Button UI</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
-                    <property name="group">radiobutton1</property>
+                    <property name="group">radiobutton2</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -190,7 +190,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton1">
+                  <object class="GtkRadioButton" id="radiobutton2">
                     <property name="label" translatable="yes">Discrete mode</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -221,6 +221,12 @@
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkLevelBar" id="goal-levelbar">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="max-value">3</property>
+    <property name="mode">discrete</property>
   </object>
   <object class="GtkPopover" id="headerbar-popover">
     <property name="can-focus">False</property>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -15,7 +15,7 @@
       <object class="GtkBox">
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
+        <property name="spacing">6</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
             <property name="can-focus">False</property>
@@ -52,7 +52,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -60,11 +60,16 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">10</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Gamify Preferences</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="scale" value="1.5"/>
+                </attributes>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,7 +121,102 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Select UI version</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton2">
+                    <property name="label" translatable="yes">Both/Full UI</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">radiobutton1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton">
+                    <property name="label" translatable="yes">Button UI</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">radiobutton1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton1">
+                    <property name="label" translatable="yes">Discrete mode</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">A GtkLevelBar in under the quickadd entry</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.36.0 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkDialog" id="gamify-pref-window">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Gamify Preferences</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Target Tasks per day</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="target-spinner">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="adjustment">adjustment1</property>
+                    <property name="climb_rate">1</property>
+                    <property name="numeric">True</property>
+                    <property name="value">1.0000000002235174</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -129,6 +129,51 @@
     <property name="text" translatable="yes">Gamify</property>
     <property name="menu-name">gamify</property>
   </object>
+  <object class="GtkPopover" id="headerbar-popover">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="headerbar-label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">label</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkMenuButton" id="gamify-headerbar">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="focus-on-click">False</property>
+    <property name="receives-default">True</property>
+    <property name="popover">headerbar-popover</property>
+    <child>
+      <object class="GtkLabel" id="headerbar-label-button">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">0/5</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+    </child>
+  </object>
   <object class="GtkBox" id="submenu-popover">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -167,9 +212,8 @@
       <object class="GtkLevelBar" id="gamify-level-bar">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="value">4</property>
+        <property name="value">3</property>
         <property name="max-value">5</property>
-        <property name="mode">discrete</property>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -164,9 +164,12 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLevelBar">
+      <object class="GtkLevelBar" id="gamify-level-bar">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="value">4</property>
+        <property name="max-value">5</property>
+        <property name="mode">discrete</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -186,16 +189,29 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="score_label">
+      <object class="GtkLabel" id="label">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Your level</property>
+        <property name="label" translatable="yes">Your current level is</property>
         <property name="wrap">True</property>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="score_label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">label</property>
+        <property name="wrap">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">5</property>
       </packing>
     </child>
     <child>
@@ -207,7 +223,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">5</property>
+        <property name="position">6</property>
       </packing>
     </child>
   </object>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -155,6 +155,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label" translatable="yes">Your target</property>
+        <property name="wrap">True</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -185,15 +186,28 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel">
+      <object class="GtkLabel" id="score_label">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label" translatable="yes">Your level</property>
+        <property name="wrap">True</property>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="score_value">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">label</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">5</property>
       </packing>
     </child>
   </object>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -359,6 +359,7 @@
     <property name="mode">discrete</property>
   </object>
   <object class="GtkPopover" id="headerbar-popover">
+    <property name="width-request">260</property>
     <property name="can-focus">False</property>
     <child>
       <object class="GtkBox">
@@ -367,12 +368,13 @@
         <property name="margin-start">10</property>
         <property name="margin-end">10</property>
         <property name="margin-top">10</property>
-        <property name="margin-bottom">8</property>
+        <property name="margin-bottom">13</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="headerbar-label">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-bottom">7</property>
             <property name="label" translatable="yes">label</property>
             <attributes>
               <attribute name="scale" value="2"/>
@@ -388,6 +390,10 @@
           <object class="GtkLabel" id="headerbar-msg">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">7</property>
+            <property name="margin-bottom">10</property>
             <property name="label" translatable="yes">Put a msg here</property>
             <property name="justify">center</property>
             <property name="wrap">True</property>
@@ -414,23 +420,10 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Your current level is</property>
-            <property name="wrap">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="score_label">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">label</property>
+            <property name="label" translatable="yes">Level</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -442,7 +435,7 @@
           <object class="GtkLabel" id="score_value">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">label</property>
+            <property name="label" translatable="yes">Points</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -462,27 +455,12 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="streak_emoji">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">label</property>
-            <attributes>
-              <attribute name="scale" value="1.3999999999999999"/>
-            </attributes>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">7</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="streak_number">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">Your streak</property>
             <attributes>
-              <attribute name="scale" value="0.80000000000000004"/>
+              <attribute name="scale" value="1"/>
             </attributes>
           </object>
           <packing>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -122,4 +122,79 @@
       </object>
     </child>
   </object>
+  <object class="GtkModelButton" id="gamify-entry">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="receives-default">True</property>
+    <property name="text" translatable="yes">Gamify</property>
+    <property name="menu-name">gamify</property>
+  </object>
+  <object class="GtkBox" id="submenu-popover">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">7</property>
+    <child>
+      <object class="GtkModelButton" id="return">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="text" translatable="yes">Go back</property>
+        <property name="menu-name">main</property>
+        <property name="inverted">True</property>
+        <property name="centered">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Your target</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLevelBar">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Your level</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">4</property>
+      </packing>
+    </child>
+  </object>
 </interface>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -122,13 +122,6 @@
       </object>
     </child>
   </object>
-  <object class="GtkModelButton" id="gamify-entry">
-    <property name="visible">True</property>
-    <property name="can-focus">True</property>
-    <property name="receives-default">True</property>
-    <property name="text" translatable="yes">Gamify</property>
-    <property name="menu-name">gamify</property>
-  </object>
   <object class="GtkPopover" id="headerbar-popover">
     <property name="can-focus">False</property>
     <child>
@@ -146,7 +139,7 @@
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">label</property>
             <attributes>
-              <attribute name="scale" value="2.5"/>
+              <attribute name="scale" value="2"/>
             </attributes>
           </object>
           <packing>
@@ -163,8 +156,8 @@
             <property name="justify">center</property>
             <property name="wrap">True</property>
             <attributes>
-              <attribute name="style" value="italic"/>
-              <attribute name="weight" value="bold"/>
+              <attribute name="weight" value="normal"/>
+              <attribute name="scale" value="0.90000000000000002"/>
             </attributes>
           </object>
           <packing>
@@ -174,7 +167,93 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Your current level is</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="score_label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">label</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="score_value">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">label</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="streak_emoji">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">label</property>
+            <attributes>
+              <attribute name="scale" value="1.3999999999999999"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="streak_number">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Your streak</property>
+            <attributes>
+              <attribute name="scale" value="0.80000000000000004"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">8</property>
+          </packing>
         </child>
       </object>
     </child>
@@ -194,107 +273,6 @@
           <attribute name="weight" value="bold"/>
         </attributes>
       </object>
-    </child>
-  </object>
-  <object class="GtkBox" id="submenu-popover">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="margin-start">10</property>
-    <property name="margin-end">10</property>
-    <property name="margin-top">8</property>
-    <property name="margin-bottom">10</property>
-    <property name="orientation">vertical</property>
-    <property name="spacing">7</property>
-    <child>
-      <object class="GtkModelButton" id="return">
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">True</property>
-        <property name="text" translatable="yes">Go back</property>
-        <property name="menu-name">main</property>
-        <property name="inverted">True</property>
-        <property name="centered">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="goal_label">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Your target</property>
-        <property name="wrap">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLevelBar" id="gamify-level-bar">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="value">3</property>
-        <property name="max-value">5</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSeparator">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Your current level is</property>
-        <property name="wrap">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="score_label">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">label</property>
-        <property name="wrap">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">5</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="score_value">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">label</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">6</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -7,6 +7,13 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="lower">100</property>
+    <property name="upper">1000</property>
+    <property name="value">500</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkDialog" id="gamify-pref-dialog">
     <property name="can-focus">False</property>
     <property name="type-hint">dialog</property>
@@ -65,7 +72,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Gamify Preferences</property>
+                <property name="label" translatable="yes">🗲Gamify Preferences</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                   <attribute name="scale" value="1.5"/>
@@ -117,6 +124,127 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">8</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Tag Mappings</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">8</property>
+                    <property name="baseline-position">top</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">140</property>
+                        <property name="label" translatable="yes">Tag :</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="tag-input-field">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="tag-submit-button">
+                        <property name="label" translatable="yes">Add</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <signal name="clicked" handler="on_tag_submit_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="label" translatable="yes">Delete</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <signal name="clicked" handler="on_tag_delete_button_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="vadjustment">adjustment2</property>
+                    <property name="vscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
+                    <property name="min-content-width">18</property>
+                    <property name="min-content-height">18</property>
+                    <property name="max-content-width">18</property>
+                    <property name="max-content-height">18</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <object class="GtkListBox" id="tag-listbox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -139,6 +267,8 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-left">7</property>
+            <property name="margin-right">7</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">

--- a/GTG/plugins/gamify/prefs.ui
+++ b/GTG/plugins/gamify/prefs.ui
@@ -135,12 +135,19 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="headerbar-label">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">label</property>
+            <attributes>
+              <attribute name="scale" value="2.5"/>
+            </attributes>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -149,7 +156,22 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkLabel" id="headerbar-msg">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Put a msg here</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+            <attributes>
+              <attribute name="style" value="italic"/>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
         <child>
           <placeholder/>
@@ -177,6 +199,10 @@
   <object class="GtkBox" id="submenu-popover">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
+    <property name="margin-start">10</property>
+    <property name="margin-end">10</property>
+    <property name="margin-top">8</property>
+    <property name="margin-bottom">10</property>
     <property name="orientation">vertical</property>
     <property name="spacing">7</property>
     <child>

--- a/GTG/plugins/meson.build
+++ b/GTG/plugins/meson.build
@@ -12,6 +12,7 @@ gtg_plugins = [
   'urgency-color',
   'hamster',
   'dev_console',
+	'gamify',
 ]
 
 foreach plugin : gtg_plugins

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -108,3 +108,5 @@ GTG/plugins/urgency_color/urgency_color.py
 GTG/plugins/dev_console.gtg-plugin.desktop
 GTG/plugins/dev_console/console.py
 GTG/plugins/dev_console/utils.py
+GTG/plugins/gamify/gamify.py
+GTG/plugins/gamify/__init__.py

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,7 @@ GTG/plugins/send-email.gtg-plugin.desktop
 GTG/plugins/untouched-tasks.gtg-plugin.desktop
 GTG/plugins/urgency-color.gtg-plugin.desktop
 GTG/plugins/hamster.gtg-plugin.desktop
+GTG/plugins/gamify.gtg-plugin.desktop
 
 GTG/gtk/data/backends.ui
 GTG/gtk/data/calendar.ui


### PR DESCRIPTION
Hi,
I have implemented the three main feature that I think are most important for this kind of plugins.

### Features
1. Count the number of tasks done per day.
2. Count the number of days in which the user has completed the goal
3. Added a score and level.
* message and emoji are displayed depending on the number of tasks done.
* The scores are calculated depending on a tag
  * if the task has `@hard` as a tag, the user receives +3 points.
  * if the task has `@meduim` as a tag, the user receives +2 points.
  * if the task has `@easy` as a tag, the user receives +1 point.
* Levels
  * 100 Beginner
  * 1000 Novice
  * 2000 professional
  * 4000 Expert
  * 9000 Master
  * 13000 Master II
  * 19000 Grand Master
  * 25000 Productivity Lord

### Preferences
For the moment, the user can only change one thing which is the goal number of tasks per day.

### Plugin API
I had to add a couple of method to the plugin API so that I get the headerbar.

### Some screenshots
[No task marked as done](https://user-images.githubusercontent.com/34837535/98710585-234f8000-2384-11eb-8bce-9c57c1710fdd.png)
[one or more tasks are done](https://user-images.githubusercontent.com/34837535/98710733-598cff80-2384-11eb-8e33-d5a0f82af4aa.png)
[achieved daily goal](https://user-images.githubusercontent.com/34837535/98710929-91944280-2384-11eb-96ca-2827e05bd688.png)

### Update
* Added the GtkLevelBar to the plugin, as well as the possibility to activate one or the other.
* Ability to add custom tag mappings from the settings of the plugin

Hope you like it.
ref #435 #441