### PR TITLE
Include the git commit id in the version string

### DIFF
--- a/GTG/core/info.py.in
+++ b/GTG/core/info.py.in
@@ -36,7 +36,7 @@ URL = "https://wiki.gnome.org/Apps/GTG"
 TRANSLATE_URL = "https://github.com/getting-things-gnome/gtg/"
 REPORT_BUG_URL = "https://github.com/getting-things-gnome/gtg/issues/new"
 EMAIL = "gtg-contributors@lists.launchpad.net"
-VERSION = '0.4.0'
+VERSION = '@VCS_TAG@'
 
 AUTHORS_MAINTAINERS = """
 • Diego Garcia Gangl

--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -1,15 +1,25 @@
-infodir = python3.get_install_dir()
-version = run_command('git', 'describe', '--dirty').stdout().strip()
+# Find the version number and put it in info.py.
+# Use git --describe if available.
+
+git = find_program('git', required : false, disabler : true)
+git_description = run_command(git, 'describe', '--dirty')
+
+if not git.found() or git_description.returncode() != 0
+  version = meson.project_version()
+else
+  version = git_description.stdout().strip()
+endif
 
 info_config = configuration_data()
 info_config.set('VCS_TAG', version)
 
+infodir = python3.get_install_dir()
 info_py = configure_file(
             input : 'info.py.in',
             output :'info.py',
             configuration: info_config,
             install : true,
-            install_dir: infodir / 'GTG/core')
+            install_dir: infodir / 'GTG' / 'core')
 
 gtg_core_sources = [
   '__init__.py',

--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -1,3 +1,16 @@
+infodir = python3.get_install_dir()
+version = run_command('git', 'describe', '--dirty').stdout().strip()
+
+info_config = configuration_data()
+info_config.set('VCS_TAG', version)
+
+info_py = configure_file(
+            input : 'info.py.in',
+            output :'info.py',
+            configuration: info_config,
+            install : true,
+            install_dir: infodir / 'GTG/core')
+
 gtg_core_sources = [
   '__init__.py',
   'borg.py',
@@ -7,7 +20,6 @@ gtg_core_sources = [
   'dates.py',
   'dirs.py',
   'firstrun_tasks.py',
-  'info.py',
   'interruptible.py',
   'keyring.py',
   'logger.py',


### PR DESCRIPTION
This is my attempt to fix #503 .

Use the output of "git describe --dirty" as the version string.
The info is filled in by meson.
I'm not sure if I'm happy about it because the version is now always taken from git describe.
Maybe the commit id should be somewhere else?