### PR TITLE
Ability to "Add a parent task" to a task

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -220,6 +220,7 @@ class Application(Gtk.Application):
             ('open_plugins', self.open_plugins_manager, None),
             ('new_task', self.new_task, ('app.new_task', ['<ctrl>N'])),
             ('new_subtask', self.new_subtask, ('app.new_subtask', ['<ctrl><shift>N'])),
+            ('add_parent', self.add_parent, ('app.add_parent', ['<ctrl><shift>P'])),
             ('edit_task', self.edit_task, ('app.edit_task', ['<ctrl>E'])),
             ('mark_as_done', self.mark_as_done, ('app.mark_as_done', ['<ctrl>D'])),
             ('dismiss', self.dismiss, ('app.dismiss', ['<ctrl>I'])),
@@ -261,6 +262,10 @@ class Application(Gtk.Application):
             self.get_active_editor().insert_subtask()
         except AttributeError:
             self.browser.on_add_subtask()
+
+    def add_parent(self, param, action):
+        """Callback to add a parent to a task"""
+        self.browser.on_add_parent()
 
     def edit_task(self, param, action):
         """Callback to edit a task."""

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -265,7 +265,8 @@ class Application(Gtk.Application):
 
     def add_parent(self, param, action):
         """Callback to add a parent to a task"""
-        self.browser.on_add_parent()
+        if self.browser.have_same_parent():
+            self.browser.on_add_parent()
 
     def edit_task(self, param, action):
         """Callback to edit a task."""

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -990,6 +990,27 @@ class MainWindow(Gtk.ApplicationWindow):
 
             self.app.open_task(task.get_id(), new=True)
 
+    def on_add_parent(self, widget=None):
+        uid = self.get_selected_task()
+        selected_task = self.req.get_task(uid)
+        if uid:
+            parents = selected_task.get_parents()
+            if parents:
+                # Switch parents
+                for p_tid in parents:
+                    par = self.req.get_task(p_tid)
+                    if (par.is_loaded() and par.get_status() in
+                        (Task.STA_ACTIVE)):
+                        new_parent = par.new_subtask()
+                        par.remove_child(uid)
+                        new_parent.add_child(uid)
+            else:
+                # If the tasks has no parent already, no need to switch parents
+                new_parent = self.req.new_task(newtask=True)
+                new_parent.add_child(uid)
+
+            self.app.open_task(new_parent.get_id(), new=True)
+
     def on_edit_active_task(self, widget=None, row=None, col=None):
         tid = self.get_selected_task()
         if tid:

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -999,8 +999,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 # Switch parents
                 for p_tid in parents:
                     par = self.req.get_task(p_tid)
-                    if (par.is_loaded() and par.get_status() in
-                        (Task.STA_ACTIVE)):
+                    if par.get_status() == Task.STA_ACTIVE:
                         new_parent = par.new_subtask()
                         par.remove_child(uid)
                         new_parent.add_child(uid)

--- a/GTG/gtk/data/context_menus.ui
+++ b/GTG/gtk/data/context_menus.ui
@@ -32,6 +32,10 @@
         <attribute name="action">app.new_subtask</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Add a Parent task...</attribute>
+        <attribute name="action">app.add_parent</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">Edit...</attribute>
         <attribute name="action">app.edit_task</attribute>
       </item>


### PR DESCRIPTION
This PR implements the feature discussed in #516 by @nekohayo.

Anytime the user uses the shortcut or the context menu, add new parent task will be added to the selected task _(switch parents if necessary)_ and a task editor will be opened.

I have also chosen the keyboard shortcut of `<ctrl><shift>P`.
close #516 