### PR TITLE
Some debug.sh fixes: Rerun meson with no build files, error handling and $PWD

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -52,7 +52,7 @@ if [[ "$title" = "" ]]; then
 fi
 
 if [[ "$norun" -eq 0 ]]; then
-    if [[ ! -d .local_build ]]; then
+    if [[ ! -d .local_build ]] || [[ ! -e .local_build/build.ninja ]]; then
         meson -Dprofile=development -Dprefix="$(pwd)"/.local_build/install .local_build
     fi
     ninja -C .local_build install

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -32,7 +32,7 @@ extra_args=("${args_array[@]:$((OPTIND-1))}")
 # Copy dataset
 if [[  "$dataset" != "default" && ! -d "./tmp/$dataset" ]]; then
     echo "Copying $dataset dataset to ./tmp/"
-    cp -r "data/test-data/$dataset" tmp/
+    cp -r "data/test-data/$dataset" tmp/ || exit $?
 fi
 
 echo "Running the development/debug version - using separate user directories"
@@ -53,10 +53,10 @@ fi
 
 if [[ "$norun" -eq 0 ]]; then
     if [[ ! -d .local_build ]] || [[ ! -e .local_build/build.ninja ]]; then
-        meson -Dprofile=development -Dprefix="$(pwd)"/.local_build/install .local_build
+        meson -Dprofile=development -Dprefix="$(pwd)"/.local_build/install .local_build || exit $?
     fi
-    ninja -C .local_build install
+    ninja -C .local_build install || exit $?
     # double quoting args seems to prevent python script from picking up flag arguments correctly
     # shellcheck disable=SC2086
-    ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} -t "$title" "${extra_args[@]}"
+    ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} -t "$title" "${extra_args[@]}" || exit $?
 fi

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -38,9 +38,9 @@ fi
 echo "Running the development/debug version - using separate user directories"
 echo "Your data is in the 'tmp' subdirectory with the '$dataset' dataset."
 echo "-----------------------------------------------------------------------"
-export XDG_DATA_HOME="./tmp/$dataset/xdg/data"
-export XDG_CACHE_HOME="./tmp/$dataset/xdg/cache"
-export XDG_CONFIG_HOME="./tmp/$dataset/xdg/config"
+export XDG_DATA_HOME="$PWD/tmp/$dataset/xdg/data"
+export XDG_CACHE_HOME="$PWD/tmp/$dataset/xdg/cache"
+export XDG_CONFIG_HOME="$PWD/tmp/$dataset/xdg/config"
 
 # Title has to be passed to GTG directly, not through $args
 # title could be more word, and only the first word would be taken


### PR DESCRIPTION
See commits for more info. Makes it a bit more user friendly. Mostly aimed to fix #518 without having to remove the `.local_build` folder manually as a "workaround".