### PR TITLE
Show as enabled delete context menu in closed task

### DIFF
--- a/GTG/gtk/data/context_menus.ui
+++ b/GTG/gtk/data/context_menus.ui
@@ -20,7 +20,7 @@
       </item>
       <item>
         <attribute name="label" translatable="yes">Delete</attribute>
-        <attribute name="action">win.delete</attribute>
+        <attribute name="action">win.delete_task</attribute>
       </item>
     </section>
   </menu>
@@ -150,7 +150,7 @@
           <attribute name="label" translatable="yes">Now</attribute>
           <attribute name="action">win.due_now</attribute>
         </item>
-        
+
         <item>
           <attribute name="label" translatable="yes">Soon</attribute>
           <attribute name="action">win.due_soon</attribute>


### PR DESCRIPTION
the logic was working and for example shortcut works, but the menu was disabled.
here we enable the logic for closed tasks.
close #405 