### PR TITLE
Optim/no refresh on hidden pane

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -75,21 +75,18 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Active Tasks
         self.activetree = self.req.get_tasks_tree(name='active', refresh=False)
-        self.activetree.apply_filter('active', refresh=False)
         self.vtree_panes['active'] = \
             self.tv_factory.active_tasks_treeview(self.activetree)
 
         # Workview Tasks
         self.workview_tree = \
             self.req.get_tasks_tree(name='workview', refresh=False)
-        self.workview_tree.apply_filter('workview', refresh=False)
         self.vtree_panes['workview'] = \
             self.tv_factory.active_tasks_treeview(self.workview_tree)
 
         # Closed Tasks
         self.closedtree = \
             self.req.get_tasks_tree(name='closed', refresh=False)
-        self.closedtree.apply_filter('closed', refresh=False)
         self.vtree_panes['closed'] = \
             self.tv_factory.closed_tasks_treeview(self.closedtree)
 
@@ -131,7 +128,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.restore_state_from_conf()
 
-        self.on_select_tag()
+        self._reapply_filter()
         self._set_defer_days()
         self.browser_shown = False
 
@@ -408,8 +405,6 @@ class MainWindow(Gtk.ApplicationWindow):
         clsd_tsk_key_prs = self.on_closed_task_treeview_key_press_event
         self.vtree_panes['closed'].connect('key-press-event', clsd_tsk_key_prs)
         self.vtree_panes['closed'].connect('cursor-changed', self.on_cursor_changed)
-
-        self.closedtree.apply_filter(self.get_selected_tags()[0], refresh=True)
 
         b_signals = BackendSignals()
         b_signals.connect(b_signals.BACKEND_FAILED, self.on_backend_failed)
@@ -1282,7 +1277,9 @@ class MainWindow(Gtk.ApplicationWindow):
                 task.set_status(Task.STA_DISMISSED)
                 self.close_all_task_editors(uid)
 
-    def _reapply_filter(self, current_pane):
+    def _reapply_filter(self, current_pane: str = None):
+        if current_pane is None:
+            current_pane = self.get_selected_pane()
         filters = self.get_selected_tags()
         filters.append(current_pane)
         vtree = self.req.get_tasks_tree(name=current_pane, refresh=False)
@@ -1320,7 +1317,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 self.quickadd_entry.set_text(tag.get_attribute("query"))
                 break
 
-        self._reapply_filter(self.get_selected_pane())
+        self._reapply_filter()
 
     def on_pane_switch(self, obj, pspec):
         """ Callback for pane switching.

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -569,14 +569,9 @@ class MainWindow(Gtk.ApplicationWindow):
             GObject.idle_add(open_task, self.req, t)
 
     def refresh_all_views(self, timer):
-        active_tree = self.req.get_tasks_tree(name='active', refresh=False)
-        active_tree.refresh_all()
-
-        workview_tree = self.req.get_tasks_tree(name='workview', refresh=False)
-        workview_tree.refresh_all()
-
-        closed_tree = self.req.get_tasks_tree(name='closed', refresh=False)
-        closed_tree.refresh_all()
+        for pane in 'active', 'workview', 'closed':
+            self.req.get_tasks_tree(pane, False).reset_filters(refresh=False)
+        self._reapply_filter()
 
     def find_value_in_treestore(self, store, treeiter, value):
         """Search for value in tree store recursively."""


### PR DESCRIPTION
Depends on https://github.com/getting-things-gnome/liblarch/pull/22 won't `self.refilter` on non-displayed tree, cutting by 3 the display time when selecting a tag.

### Context

When selecting a tag with around 150 tasks, the process time gets up to 1s5. Mainly I found that a lot of callbacks are called in `liblarch` but as I don't fully understand that library, I didn't do much on that side. 

I did witness though, that for all three panes the `apply_filter` function, each times, calls on `refilter`. That last one browse the tree in _lots_ of ways. 
Although, and that's where I have doubts, all three `refilter` aren't necessary, and it's only needed for the displayed pane.
The fix is to only trigger the refresh for the active pane. 