### PR TITLE
Fixing switch pane optimization

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -128,7 +128,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.restore_state_from_conf()
 
-        self._reapply_filter()
+        self.reapply_filter()
         self._set_defer_days()
         self.browser_shown = False
 
@@ -571,7 +571,7 @@ class MainWindow(Gtk.ApplicationWindow):
     def refresh_all_views(self, timer):
         for pane in 'active', 'workview', 'closed':
             self.req.get_tasks_tree(pane, False).reset_filters(refresh=False)
-        self._reapply_filter()
+        self.reapply_filter()
 
     def find_value_in_treestore(self, store, treeiter, value):
         """Search for value in tree store recursively."""
@@ -1272,7 +1272,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 task.set_status(Task.STA_DISMISSED)
                 self.close_all_task_editors(uid)
 
-    def _reapply_filter(self, current_pane: str = None):
+    def reapply_filter(self, current_pane: str = None):
         if current_pane is None:
             current_pane = self.get_selected_pane()
         filters = self.get_selected_tags()
@@ -1312,7 +1312,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 self.quickadd_entry.set_text(tag.get_attribute("query"))
                 break
 
-        self._reapply_filter()
+        self.reapply_filter()
 
     def on_pane_switch(self, obj, pspec):
         """ Callback for pane switching.
@@ -1320,7 +1320,7 @@ class MainWindow(Gtk.ApplicationWindow):
         """
         current_pane = self.get_selected_pane()
         self.config.set('view', current_pane)
-        self._reapply_filter(current_pane)
+        self.reapply_filter(current_pane)
 
 # PUBLIC METHODS ###########################################################
     def have_same_parent(self):

--- a/GTG/gtk/browser/tag_editor.py
+++ b/GTG/gtk/browser/tag_editor.py
@@ -288,7 +288,7 @@ class TagEditor(Gtk.Window):
 
                 # Select on sidebar and update values
                 self.app.browser.select_on_sidebar(new_name)
-                self.app.browser.apply_filter_on_panes(new_name)
+                self.app.browser.reapply_filter()
 
             return False
 


### PR DESCRIPTION
While working on pane switching optimization, forgot one instance of `apply_filter_on_panes` getting called in the tag editor. Renaming `_reapply_filter` to `apply_filter` (since called outside of base class, can't be a "private" method anymore).