### PR TITLE
meson: Require xgettext to build plugins

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -5,3 +5,7 @@ i18n.gettext('gtg',
     '--keyword=name', '--keyword=short-description', '--keyword=description'
     ]
   )
+
+# Used because plugins require i18n.merge_file which silently does nothing when
+# xgettext hasn't been found.
+find_program('xgettext', required: true)


### PR DESCRIPTION
Otherwise it would just silently don't copy the plugin files, so no plugins would be available when using GTG.
Found by nekohayo, where the test machine didn't had gettext.
Couldn't really test whenever it works so please test if you have such environment.