### PR TITLE
meson: Always build plugin files for translation

### DIFF
--- a/GTG/plugins/meson.build
+++ b/GTG/plugins/meson.build
@@ -22,7 +22,10 @@ foreach plugin : gtg_plugins
     install: true,
     install_dir: plugin_install_dir,
     type: 'desktop',
-    args: ['--keyword=name', '--keyword=short-description', '--keyword=description']
+    args: ['--keyword=name', '--keyword=short-description', '--keyword=description'],
+    build_by_default: true,
+    build_always_stale: true
+    # build always because otherwise new translations won't be applied
   )
   subdir(plugin.underscorify())
 endforeach

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -74,8 +74,5 @@ Make sure to this AFTER COMMITING YOUR CHANGES!
 * During launching, it might complain about certain files not being found in [`po/POTFILES.in`][POTFILES.IN].
   It is safe to remove the lines from that file and re-run until it works.
   It would be useful to comment about that if you're submitting your translation, just in case.
-* Plugin related strings don't update after updating the translation.
-  The cause is unknown, but you can delete the plugin files to re-generate
-  them using the new translations: `rm -f .local_build/GTG/plugins/*.gtg-plugin`
 
 [POTFILES.IN]: ../../po/POTFILES.in


### PR DESCRIPTION
Because otherwise when updating translations, those new translations aren't applied until forced a rebuild.

This would also mean you don't need the plugin workaround anymore when I introduced it in #494.