### PR TITLE
debug.sh: Introduce -p to enable python dev mode

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -9,20 +9,22 @@ fi
 args=""
 dataset="default"
 norun=0
+pydebug=0
 title=""
 
 # Create execution-time data directory if needed
 mkdir -p tmp
 
 # Interpret arguments. The ":" following the letter indicates that the opstring (optarg) needs a parameter specified. See also: https://stackoverflow.com/questions/18414054/rreading-optarg-for-optional-flags
-while getopts "bdns:t:" o;
+while getopts "bdwns:t:" o;
 do  case "$o" in
     b)   args="$args --boot-test";;
     d)   args="$args -d";;
+    w)   pydebug=1;;
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG";;
-    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-n] (-- args passed to gtg)"
+    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-w] [-n] (-- args passed to gtg)"
          exit 1;;
     esac
 done
@@ -56,6 +58,10 @@ if [[ "$norun" -eq 0 ]]; then
         meson -Dprofile=development -Dprefix="$(pwd)"/.local_build/install .local_build || exit $?
     fi
     ninja -C .local_build install || exit $?
+    if [ "$pydebug" = 1 ]; then
+        # https://docs.python.org/3/library/devmode.html#devmode
+        export PYTHONDEVMODE=1
+    fi
     # double quoting args seems to prevent python script from picking up flag arguments correctly
     # shellcheck disable=SC2086
     ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} -t "$title" "${extra_args[@]}" || exit $?


### PR DESCRIPTION
From https://docs.python.org/3/library/devmode.html
Introduced in Python 3.7

Basically enables warnings and other stuff that could be useful to look into, including deprecation warnings.

Also see #549; Does not really fix it since it doesn't set `G_ENABLE_DIAGNOSTIC=1`.