### PR TITLE
Better help message for debug.sh (& remove -b argument)

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -16,15 +16,14 @@ title=""
 mkdir -p tmp
 
 # Interpret arguments. The ":" following the letter indicates that the opstring (optarg) needs a parameter specified. See also: https://stackoverflow.com/questions/18414054/rreading-optarg-for-optional-flags
-while getopts "bdwns:t:" o;
+while getopts "dwns:t:" o;
 do  case "$o" in
-    b)   args="$args --boot-test";;
     d)   args="$args -d";;
     w)   pydebug=1;;
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG";;
-    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-b] [-d] [-w] [-n] (-- args passed to gtg)"
+    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-d] [-w] [-n] (-- args passed to gtg)"
          exit 1;;
     esac
 done

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -23,7 +23,19 @@ do  case "$o" in
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG";;
-    [?]) echo >&2 "Usage: $0 [-s dataset] [-t title] [-d] [-w] [-n] (-- args passed to gtg)"
+    [?]) cat >&2 <<EOF
+Usage: $0 [-s dataset] [-t title] [-d] [-w] [-n] (-- args passed to gtg)
+    -s dataset     Use the dataset located in $PWD/tmp/<dataset>
+    -t title       Set a custom title/program name to use.
+    -d             Enable debug mode, basically enables debug logging
+    -w             Enable python warnings like deprecation warnings,
+                   and other python 3.7+ development mode features.
+                   Also see https://docs.python.org/3/library/devmode.html
+    -n             Just generate the build system, don't actually run gtg
+    -- args passed to gtg
+                   These arguments are passed to the application as-is
+                   Use -- --help to get help for the application
+EOF
          exit 1;;
     esac
 done


### PR DESCRIPTION
Builds upon #561 (the `-p` argument), so merge that first.
Removed `-b` since it doesn't work and `--boot-test` doesn't really say anything.

Looks now like this:
```
Usage: $0 [-s dataset] [-t title] [-d] [-p] [-n] (-- args passed to gtg)
    -s dataset     Use the dataset located in $PWD/tmp/<dataset>
    -t title       Set a custom title/program name to use.
    -d             Enable debug mode, basically enables debug logging
    -p             Enable python 3.7+ debug mode, like deprecation warnings
                   Also see https://docs.python.org/3/library/devmode.html
    -n             Just generate the build system, don't actually run gtg
    -- args passed to gtg
                   These arguments are passed to the application as-is
                   Use -- --help to get help for the application
```