### PR TITLE
Fix bug: Recurring status of tasks is lost after GTG restart #578

### DIFF
--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -77,7 +77,7 @@ def task_from_element(task, element: etree.Element):
     recurring_enabled = recurring.get('enabled')
 
     try:
-        recurring_term = element.find('term').text
+        recurring_term = recurring.getchildren()[0].text
         task.set_recurring(recurring_enabled == 'true',
                            None if recurring_term == 'None'
                            else recurring_term)


### PR DESCRIPTION
I don't know why but `recurring_term = element.find('term').text` was always returning `None` even though the term was properly set which made the task lose its recurring status. So I've changed it to `recurring.getchildren()[0].text`

close #578