### PR TITLE
fix nonworkview/nonactionable attribute loading

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -232,7 +232,7 @@ class DataStore():
             color = element.get('color')
             icon = element.get('icon')
             parent = element.get('parent')
-            nonworkview = element.get('nonworkview')
+            nonactionable = element.get('nonactionable')
 
             tag_attrs = {}
 
@@ -242,8 +242,8 @@ class DataStore():
             if icon:
                 tag_attrs['icon'] = icon
 
-            if nonworkview:
-                tag_attrs['nonworkview'] = nonworkview
+            if nonactionable:
+                tag_attrs['nonactionable'] = nonactionable
 
             tag = self.new_tag(name, tag_attrs, tid)
 

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -232,7 +232,7 @@ class DataStore():
             color = element.get('color')
             icon = element.get('icon')
             parent = element.get('parent')
-            nonactionable = element.get('nonactionable')
+            nonworkview = element.get('nonworkview')
 
             tag_attrs = {}
 
@@ -242,8 +242,8 @@ class DataStore():
             if icon:
                 tag_attrs['icon'] = icon
 
-            if nonactionable:
-                tag_attrs['nonactionable'] = nonactionable
+            if nonworkview:
+                tag_attrs['nonworkview'] = nonworkview
 
             tag = self.new_tag(name, tag_attrs, tid)
 

--- a/GTG/core/treefactory.py
+++ b/GTG/core/treefactory.py
@@ -222,9 +222,9 @@ class TreeFactory():
         return ret
 
     def no_disabled_tag(self, task, parameters=None):
-        """Filter of task that don't have any disabled/nonworkview tag"""
+        """Filter of task that don't have any disabled/nonactionable tag"""
         toreturn = True
         for t in task.get_tags():
-            if t.get_attribute("nonworkview") == "True":
+            if t.get_attribute("nonactionable") == "True":
                 toreturn = False
         return toreturn

--- a/GTG/core/versioning.py
+++ b/GTG/core/versioning.py
@@ -96,7 +96,7 @@ def convert_tags(old_tree: et.Element) -> Tuple[et.Element, et.Element]:
     for tag in tree.iter('tag'):
         name = tag.get('name')
         parent = tag.get('parent')
-        notactionable = tag.get('nonworkview')
+        nonactionable = tag.get('nonworkview')
         color = tag.get('color')
         tid = str(uuid4())
 
@@ -117,8 +117,8 @@ def convert_tags(old_tree: et.Element) -> Tuple[et.Element, et.Element]:
             if parent:
                 new_tag.set('parent', parent[1:])
 
-            if notactionable:
-                new_tag.set('notactionable', notactionable)
+            if nonactionable:
+                new_tag.set('nonactionable', nonactionable)
 
         new_tag.set('id', tid)
 

--- a/GTG/gtk/browser/tag_editor.py
+++ b/GTG/gtk/browser/tag_editor.py
@@ -229,9 +229,9 @@ class TagEditor(Gtk.Window):
             # Update entry
             name = tag.get_name()
             self.tn_entry.set_text(name)
-            # Update visibility in Work View
-            s_hidden_in_wv = (self.tag.get_attribute("nonworkview") == "True")
-            self.tn_cb.set_active(not s_hidden_in_wv)
+            # Update visibility in Actionable View
+            s_hidden_in_av = (self.tag.get_attribute("nonactionable") == "True")
+            self.tn_cb.set_active(not s_hidden_in_av)
             # If available, update icon
             if (tag.get_attribute('icon') is not None):
                 icon = tag.get_attribute('icon')
@@ -309,12 +309,12 @@ class TagEditor(Gtk.Window):
             self.tn_entry_watch_id = GObject.timeout_add(1000, tn_entry_changes)
 
     def on_tn_cb_clicked(self, widget):
-        """Callback: toggle the nonworkview property according to the related
+        """Callback: toggle the nonactionable property according to the related
         widget's state."""
         if self.tag is not None:
             show_in_wv = self.tn_cb.get_active()
             hide_in_wv = not show_in_wv
-            self.tag.set_attribute('nonworkview', str(hide_in_wv))
+            self.tag.set_attribute('nonactionable', str(hide_in_wv))
 
     def on_tc_colsel_changed(self, widget):
         """Callback: update the tag color depending on the current color

--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -217,7 +217,7 @@ class TreeviewFactory():
         if label.startswith('@'):
             label = label[1:]
 
-        if node.get_attribute("nonworkview") == "True":
+        if node.get_attribute("nonactionable") == "True":
             return f"<span color='{self.unactive_color}'>{label}</span>"
         elif node.get_id() == 'search' and not node.get_children():
             return f"<span color='{self.unactive_color}'>{label}</span>"

--- a/docs/contributors/file format.md
+++ b/docs/contributors/file format.md
@@ -120,13 +120,13 @@ A single task tag.
 - Zero or more per file.
 
 
-| Attribute           | Description                                  |
-|---------------------|----------------------------------------------|
-| id                  | Tag UUID. Always present.                    |
-| name                | Tag name (without @). Always present.        |
-| color               | Custom color (in hex)                        |
-| icon                | Custom icon name                             |
-| nonworkview         | If the tag should show up in work view       |
+| Attribute           | Description                                   |
+|---------------------|-----------------------------------------------|
+| id                  | Tag UUID. Always present.                     |
+| name                | Tag name (without @). Always present.         |
+| color               | Custom color (in hex)                         |
+| icon                | Custom icon name                              |
+| nonactionable       | Tagged items won't show up in actionable view |
 
 
 

--- a/docs/contributors/file format.md
+++ b/docs/contributors/file format.md
@@ -126,6 +126,7 @@ A single task tag.
 | name                | Tag name (without @). Always present.        |
 | color               | Custom color (in hex)                        |
 | icon                | Custom icon name                             |
+| nonworkview         | If the tag should show up in work view       |
 
 
 


### PR DESCRIPTION
In the current development version, the state of the nonworkview attribute of a tag was correctly saved in the data file(s). After a restart of the application, this attribute was reset / not read properly by the loader.

Apart from the renaming in the code, I also added the `nonworkview` field in the format documentation.

However, I am not sure, if the attribute name shouldn't rather be `nonactionable` for everything. If you'd rather name it like that, I can change it accordingly in all other places.