### PR TITLE
debug.sh: Add -p prefix-prog for better control

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -12,24 +12,28 @@ norun=0
 pydebug=0
 title=""
 explicit_title=0
+prefix_prog=""
 
 # Create execution-time data directory if needed
 mkdir -p tmp
 
 # Interpret arguments. The ":" following the letter indicates that the opstring (optarg) needs a parameter specified. See also: https://stackoverflow.com/questions/18414054/rreading-optarg-for-optional-flags
-while getopts "dwns:t:" o;
+while getopts "dwns:t:p:" o;
 do  case "$o" in
     d)   args="$args -d";;
     w)   pydebug=1;;
     n)   norun=1;;
     s)   dataset="$OPTARG";;
     t)   title="$OPTARG" explicit_title=1;;
+    p)   prefix_prog="$OPTARG";;
     [?]) cat >&2 <<EOF
 Usage: $0 [-s dataset] [-t title] [-d] [-w] [-n] (-- args passed to gtg)
     -s dataset     Use the dataset located in $PWD/tmp/<dataset>
     -t title       Set a custom title/program name to use.
                    Use -t '' (empty) to un-set the title
                    (default is: Dev GTG: (<dataset> dataset))
+    -p prefix-prog Insert prefix-prog before the application file when
+                   executing GTG. Example: -p 'python3 -m cProfile -o gtg.prof'
     -d             Enable debug mode, basically enables debug logging
     -w             Enable python warnings like deprecation warnings,
                    and other python 3.7+ development mode features.
@@ -80,5 +84,6 @@ if [[ "$norun" -eq 0 ]]; then
     fi
     # double quoting args seems to prevent python script from picking up flag arguments correctly
     # shellcheck disable=SC2086
-    ./.local_build/prefix-gtg.sh ./.local_build/install/bin/gtg ${args} "${extra_args[@]}" || exit $?
+    cd .local_build # To let python be able to find the modules
+    ./prefix-gtg.sh $prefix_prog ./install/bin/gtg ${args} "${extra_args[@]}" || exit $?
 fi


### PR DESCRIPTION
This would allow to easily run custom python modules such as profiling or even an debugger.
I needed to `cd` into the build directory, otherwise it wouldn't find the modules, since at least with `cProfile` and `profile` I get different module path configuration.

Also, since I am not quoting `$prefix_proc`, it could have strange behaviour when the user passes `;` or other "shell characters", but I couldn't find a better way to make an single string to be something more "safe".