### PR TITLE
Add info.py.in to be translated to have their strings be translatable

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,6 +28,7 @@ GTG/backends/generic_backend.py
 GTG/backends/__init__.py
 GTG/backends/periodic_import_backend.py
 GTG/backends/sync_engine.py
+GTG/core/info.py.in
 GTG/core/borg.py
 GTG/core/xml.py
 GTG/core/clipboard.py


### PR DESCRIPTION
Makes the description in the about dialog working.
Fixes #602, but you need to re-generate the translation.
It seems it once was translatable, since it is still in the german translation (`po/de.po`), but commented out, and a simple regeneration (not done here) should bring it back to life.