### PR TITLE
scripts/debug.sh: Add install dir while running

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -54,6 +54,7 @@ echo "-----------------------------------------------------------------------"
 export XDG_DATA_HOME="$PWD/tmp/$dataset/xdg/data"
 export XDG_CACHE_HOME="$PWD/tmp/$dataset/xdg/cache"
 export XDG_CONFIG_HOME="$PWD/tmp/$dataset/xdg/config"
+export XDG_DATA_DIRS="$PWD/.local_build/install/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 
 # Title has to be passed to GTG directly, not through $args
 # title could be more word, and only the first word would be taken


### PR DESCRIPTION
This makes the icon in the about dialog and probably some other stuff working in the `launch.sh`-script (so *not* when installed, where it works correctly, just when run locally).

Before:
![image](https://user-images.githubusercontent.com/1196130/113237326-e76f7580-92a6-11eb-92b0-fd46ab01a08a.png)

After:
![image](https://user-images.githubusercontent.com/1196130/113237085-7b8d0d00-92a6-11eb-922d-99de3be9aeb3.png)
