### PR TITLE
Fix recurring term not displayed correctly in Editor

### DIFF
--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -81,6 +81,7 @@ class Task(TreeNode):
 
         # Setting the attributes related to repeating tasks.
         self.recurring_term = None
+        self.recurring_updated_date = Date.no_date()
         self.inherit_recursion()
 
     def get_added_date(self):
@@ -330,11 +331,13 @@ class Task(TreeNode):
                 self.recurring = False
             else:
                 self.recurring_term = recurring_term
+                self.recurring_updated_date = datetime.now()
                 if newtask:
                     self.set_due_date(newdate)
         else:
             if valid:
                 self.recurring_term = recurring_term
+                self.recurring_updated_date = datetime.now()
 
         self.sync()
         # setting its children to recurrent
@@ -348,7 +351,7 @@ class Task(TreeNode):
                         child.set_due_date(newdate)
 
     def toggle_recurring(self):
-        """ Toggle a task's recurrency ON/OFF """
+        """ Toggle a task's recurrency ON/OFF. Use this function to toggle, not set_recurring"""
         # If there is no recurring_term, We assume it to recur every day.
         newtask = False
         if self.recurring_term is None:
@@ -362,6 +365,12 @@ class Task(TreeNode):
 
     def get_recurring_term(self):
         return self.recurring_term
+
+    def get_recurring_updated_date(self):
+        return self.recurring_updated_date
+
+    def set_recurring_updated_date(self, date):
+        self.recurring_updated_date = date
 
     def inherit_recursion(self):
         """ Inherits the recurrent state of the parent.

--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -83,6 +83,12 @@ def task_from_element(task, element: etree.Element):
                             None if recurring_term == 'None'
                             else recurring_term)
 
+    try:
+        recurring_updated_date = recurring.find('updated_date').text
+        task.set_recurring_updated_date(datetime.fromisoformat(recurring_updated_date))
+    except AttributeError:
+        pass
+
 
     taglist = element.find('tags')
 
@@ -149,6 +155,9 @@ def task_to_element(task) -> etree.Element:
 
     recurring_term = etree.SubElement(recurring, 'term')
     recurring_term.text = str(task.get_recurring_term())
+
+    recurring_updated_date = etree.SubElement(recurring, 'updated_date')
+    recurring_updated_date.text = task.get_recurring_updated_date().isoformat()
 
     subtasks = etree.SubElement(element, 'subtasks')
 

--- a/GTG/gtk/editor/recurring_menu.py
+++ b/GTG/gtk/editor/recurring_menu.py
@@ -104,11 +104,11 @@ class RecurringMenu():
             elif self.selected_recurring_term == 'other-day': # Recurring every other day
                 self.title.set_markup(_('Every <b>other day</b>'))
             elif self.selected_recurring_term == 'week': # Recurring weekly from today
-                self.title.set_markup(_('Every <b>{week_day}</b>').format(week_day=datetime.today().strftime('%A')))
+                self.title.set_markup(_('Every <b>{week_day}</b>').format(week_day=self.task.get_recurring_updated_date().strftime('%A')))
             elif self.selected_recurring_term == 'month': # Recurring monthly from today
-                self.title.set_markup(_('Every <b>{month_day} of the month</b>').format(month_day=datetime.today().strftime('%d')))
+                self.title.set_markup(_('Every <b>{month_day} of the month</b>').format(month_day=self.task.get_recurring_updated_date().strftime('%d')))
             elif self.selected_recurring_term == 'year': # Recurring yearly from today
-                date = datetime.today()
+                date = self.task.get_recurring_updated_date()
                 self.title.set_markup(_('Every <b>{month} {day}</b>').format(month=date.strftime('%B'), day=date.strftime('%d')))
             else: # Recurring weekly from selected week day
                 week_day = _(self.selected_recurring_term)


### PR DESCRIPTION
While testing recurring tasks, I experienced a bug that way related to the recurring term in the editor; the title (aka `Every: <term>`) was being generate from `datetime.today()` which means that if you set the task to repeat every week you would have `Every: Friday` (correct) but when you open GTG tomorrow you would have `Every: Saturday` (incorrect) displayed.

To fix it, I added a timestamp for recurring tasks that gets updated whenever the recurring term is updated.