### PR TITLE
Update the Flatpak runtime version to 40

### DIFF
--- a/flatpak/org.gnome.GTG-stable.json
+++ b/flatpak/org.gnome.GTG-stable.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTG",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "finish-args": [

--- a/flatpak/org.gnome.GTG.json
+++ b/flatpak/org.gnome.GTG.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTGDevel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "tags": ["devel", "development", "nightly"],


### PR DESCRIPTION
The previous runtime "is no longer supported as of February 13, 2021."