### PR TITLE
Exclude preceeding whitespace from urls in textview

### DIFF
--- a/GTG/core/urlregex.py
+++ b/GTG/core/urlregex.py
@@ -28,7 +28,6 @@ import re
 UTF_CHARS = r'a-z0-9_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff'
 
 SUBST_DICT = {
-    "pre": r'(?:[^/"\':!=]|^|\:)',
     "domain": r'([\.-]|[^\s_\!\.\/])+\.[a-z]{2,}(?::[0-9]+)?',
     "path": r'(?:[\.,]?[%s!\*\'\(\);:&=\+\$/%s#\[\]\-_,~@])' % (
         UTF_CHARS, '%'),
@@ -38,7 +37,7 @@ SUBST_DICT = {
     "query_end": '[a-z0-9_&=#]',
 }
 
-HTTP_URI = '((%(pre)s)((https?://|www\\.)(%(domain)s)(\/%(path)s*' \
+HTTP_URI = '(((https?://|www\\.)(%(domain)s)(\/%(path)s*' \
     '%(path_end)s?)?(\?%(query)s*%(query_end)s)?))' % SUBST_DICT
 FILE_URI = f"(file:///({SUBST_DICT['path']}*{SUBST_DICT['path_end']}?)?)"
 

--- a/tests/core/test_urlregex.py
+++ b/tests/core/test_urlregex.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------
+# Gettings Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) 2008-2021 - the GTG contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+from unittest import TestCase
+import GTG.core.urlregex as urlregex
+
+class TestUrlregex(TestCase):
+    def test_search_does_not_include_preceeding_whitespace(self):
+        match = urlregex.search("This snippet contains an url with whitespace"
+            "before it:  https://wiki.gnome.org/Apps/GTG/")
+        self.assertEqual(list(match)[0].group(), "https://wiki.gnome.org/Apps/GTG/")


### PR DESCRIPTION
The urlregex to find urls in the text contained a pattern that also
matched [a space character before the url][1]. This part of the pattern
was removed completely.

[1]: #618 