### PR TITLE
Squash some deprecations

### DIFF
--- a/GTG/backends/backend_signals.py
+++ b/GTG/backends/backend_signals.py
@@ -16,7 +16,7 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 
 from GTG.core.borg import Borg
 
@@ -104,7 +104,7 @@ class _BackendSignalsGObject(GObject.GObject):
     # As a general rule, signals should only be emitted in the GenericBackend
     # class
     def _emit_signal(self, signal, backend_id):
-        GObject.idle_add(self.emit, signal, backend_id)
+        GLib.idle_add(self.emit, signal, backend_id)
 
     def backend_state_changed(self, backend_id):
         self._emit_signal(self.BACKEND_STATE_TOGGLED, backend_id)
@@ -119,15 +119,15 @@ class _BackendSignalsGObject(GObject.GObject):
         self._emit_signal(self.BACKEND_REMOVED, backend_id)
 
     def default_backend_loaded(self):
-        GObject.idle_add(self.emit, self.DEFAULT_BACKEND_LOADED)
+        GLib.idle_add(self.emit, self.DEFAULT_BACKEND_LOADED)
 
     def backend_failed(self, backend_id, error_code):
-        GObject.idle_add(self.emit, self.BACKEND_FAILED, backend_id,
+        GLib.idle_add(self.emit, self.BACKEND_FAILED, backend_id,
                          error_code)
 
     def interaction_requested(self, backend_id, description,
                               interaction_type, callback_str):
-        GObject.idle_add(self.emit, self.INTERACTION_REQUESTED,
+        GLib.idle_add(self.emit, self.INTERACTION_REQUESTED,
                          backend_id, description, interaction_type,
                          callback_str)
 

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -613,13 +613,7 @@ class DataStore():
                 # after 20 seconds, we give up
                 thread.join(20)
 
-                #TODO: This method got a new name in Python 3.9. We should
-                # remove this try/catch when we raise the minimum supported
-                # Python version
-                try:
-                    alive = thread.isAlive()
-                except AttributeError:
-                    alive = thread.is_alive()
+                alive = thread.is_alive()
 
                 if alive:
                     log.error("The %s backend stalled while quitting",

--- a/GTG/core/timer.py
+++ b/GTG/core/timer.py
@@ -22,7 +22,7 @@ import datetime
 import re
 import logging
 
-from gi.repository import GObject, Gio
+from gi.repository import GObject, GLib, Gio
 
 log = logging.getLogger(__name__)
 
@@ -86,8 +86,8 @@ class Timer(GObject.GObject):
         if self.timeout_source:
             GObject.source_remove(self.timeout_source)
 
-        self.timeout_source = GObject.timeout_add_seconds(secs_to_refresh,
-                                                          self.emit_refresh)
+        self.timeout_source = GLib.timeout_add_seconds(secs_to_refresh,
+                                                       self.emit_refresh)
 
     def set_configuration(self, time):
         self.config.set('hour', time.hour)

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -34,9 +34,9 @@ class CellRendererTags(Gtk.CellRenderer):
 
     __gproperties__ = {
         'tag_list': (GObject.TYPE_PYOBJECT,
-                     "Tag list", "A list of tags", GObject.PARAM_READWRITE),
+                     "Tag list", "A list of tags", GObject.ParamFlags.READWRITE),
         'tag': (GObject.TYPE_PYOBJECT, "Tag",
-                "Tag", GObject.PARAM_READWRITE),
+                "Tag", GObject.ParamFlags.READWRITE),
     }
 
     # Private methods

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -591,7 +591,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 return True
 
         for t in self.config.get("opened_tasks"):
-            GObject.idle_add(open_task, self.req, t)
+            GLib.idle_add(open_task, self.req, t)
 
     def refresh_all_views(self, timer):
         collapsed = self.config.get("collapsed_tasks")
@@ -807,7 +807,7 @@ class MainWindow(Gtk.ApplicationWindow):
                     selection.select_iter(iter)
 
                 # It cannot be another thread than the main gtk thread !
-                GObject.idle_add(selecter, treemodelsort, path, iter, self)
+                GLib.idle_add(selecter, treemodelsort, path, iter, self)
 
             data = quick_add.parse(text)
             # event that is set when the new task is created
@@ -839,7 +839,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.quickadd_entry.set_text('')
 
             # signal the event for the plugins to catch
-            GObject.idle_add(self.emit, "task-added-via-quick-add", task.get_id())
+            GLib.idle_add(self.emit, "task-added-via-quick-add", task.get_id())
         else:
             # if no text is selected, we open the currently selected task
             nids = self.vtree_panes['active'].get_selected_nodes()
@@ -1525,7 +1525,7 @@ class MainWindow(Gtk.ApplicationWindow):
         """ Hides the task browser """
         self.browser_shown = False
         self.hide()
-        GObject.idle_add(self.emit, "visibility-toggled")
+        GLib.idle_add(self.emit, "visibility-toggled")
 
     def show(self):
         """ Unhides the MainWindow """
@@ -1535,7 +1535,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.present()
         self.grab_focus()
         self.quickadd_entry.grab_focus()
-        GObject.idle_add(self.emit, "visibility-toggled")
+        GLib.idle_add(self.emit, "visibility-toggled")
 
     def iconify(self):
         """ Minimizes the MainWindow """

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -505,9 +505,7 @@ class MainWindow(Gtk.ApplicationWindow):
         and stores the state in self.config.max
         This is used to check the window state afterwards
         and maximize it if needed """
-        mask = Gdk.WindowState.MAXIMIZED
-        is_maximized = widget.get_window().get_state() & mask == mask
-        self.config.set("maximized", is_maximized)
+        self.config.set("maximized", self.is_maximized())
 
     def restore_collapsed_tasks(self, tasks=None):
         tasks = tasks or self.config.get("collapsed_tasks")

--- a/GTG/gtk/browser/simple_color_selector.py
+++ b/GTG/gtk/browser/simple_color_selector.py
@@ -358,6 +358,6 @@ class SimpleColorSelector(Gtk.Box):
 
 GObject.type_register(SimpleColorSelector)
 GObject.signal_new("color-changed", SimpleColorSelector,
-                   GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, ())
+                   GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())
 GObject.signal_new("color-added", SimpleColorSelector,
-                   GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, ())
+                   GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())

--- a/GTG/gtk/editor/calendar.py
+++ b/GTG/gtk/editor/calendar.py
@@ -18,7 +18,7 @@
 
 import datetime
 
-from gi.repository import GObject, Gdk, Gtk
+from gi.repository import GObject, GLib, Gdk, Gtk
 
 from GTG.gtk.editor import GnomeConfig
 from GTG.core.dates import Date
@@ -188,7 +188,7 @@ class GTGCalendar(GObject.GObject):
         else:
             # inform the Editor that the date has changed
             self.close_calendar()
-            GObject.idle_add(self.emit, "date-changed")
+            GLib.idle_add(self.emit, "date-changed")
 
     def __from_calendar_date_to_datetime(self, calendar_date):
         """

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -74,10 +74,6 @@ class TaskView(Gtk.TextView):
     # Timeout in milliseconds
     PROCESSING_DELAY = 250
 
-    # Mouse cursors
-    CURSOR_HAND = Gdk.Cursor.new(Gdk.CursorType.HAND2)
-    CURSOR_NORMAL = Gdk.Cursor.new(Gdk.CursorType.XTERM)
-
 
     def __init__(self, req: Requester, clipboard) -> None:
         super().__init__()
@@ -601,7 +597,9 @@ class TaskView(Gtk.TextView):
         tags = view.get_iter_at_location(x, y)[1].get_tags()
 
         # Reset cursor and hover states
-        window.set_cursor(self.CURSOR_NORMAL)
+        cursor = Gdk.Cursor.new_for_display(window.get_display(),
+                                            Gdk.CursorType.XTERM)
+        window.set_cursor(cursor)
 
         if self.hovered_tag:
             try:
@@ -615,7 +613,9 @@ class TaskView(Gtk.TextView):
         try:
             tag = tags[0]
             tag.set_hover()
-            window.set_cursor(self.CURSOR_HAND)
+            cursor = Gdk.Cursor.new_for_display(window.get_display(),
+                                                Gdk.CursorType.HAND2)
+            window.set_cursor(cursor)
             self.hovered_tag = tag
 
         except (AttributeError, IndexError):

--- a/GTG/gtk/general_preferences.py
+++ b/GTG/gtk/general_preferences.py
@@ -94,7 +94,7 @@ class GeneralPreferences():
         self.refresh_time.set_text(self.timer.get_formatted_time())
         self.refresh_time.modify_fg(Gtk.StateFlags.NORMAL, None)
 
-        self.font_button.set_font_name(self.get_default_editor_font())
+        self.font_button.set_font(self.get_default_editor_font())
 
         enable_autoclean = self.config.get("autoclean")
         self.autoclean_enable.set_active(enable_autoclean)
@@ -159,7 +159,7 @@ class GeneralPreferences():
 
     def on_font_change(self, widget):
         """ Set a new font for editor """
-        self.config.set("font_name", self.font_button.get_font_name())
+        self.config.set("font_name", self.font_button.get_font())
 
     def on_autoclean_toggled(self, widget, state):
         """Toggle automatic deletion of old closed tasks."""

--- a/GTG/gtk/general_preferences.py
+++ b/GTG/gtk/general_preferences.py
@@ -27,6 +27,9 @@ from gi.repository import Gtk, Gdk
 from GTG.core.dirs import UI_DIR
 from gettext import gettext as _
 
+import logging
+
+log = logging.getLogger(__name__)
 
 class GeneralPreferences():
 
@@ -77,9 +80,15 @@ class GeneralPreferences():
     def get_default_editor_font(self):
         editor_font = self.config.get("font_name")
         if editor_font == "":
-            font = self.ui_widget.get_style_context().get_font(
-                Gtk.StateFlags.NORMAL)
-            editor_font = font.to_string()
+            try:
+                font = self.ui_widget.get_style_context().get_property(
+                    "font", Gtk.StateFlags.NORMAL)
+                editor_font = font.to_string()
+            except UnicodeError:
+                log.exception("Using deprecated but still working font way")
+                font = self.ui_widget.get_style_context().get_font(
+                    Gtk.StateFlags.NORMAL)
+                editor_font = font.to_string()
         return editor_font
 
     def _refresh_preferences_store(self):

--- a/GTG/plugins/dev_console/buffer.py
+++ b/GTG/plugins/dev_console/buffer.py
@@ -38,7 +38,7 @@ class ConsoleHistory(GObject.Object):
     """Represents a console commands history."""
 
     __gsignals__ = {
-        "pos-changed": (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "pos-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self):

--- a/GTG/plugins/export/templates.py
+++ b/GTG/plugins/export/templates.py
@@ -27,7 +27,7 @@ import threading
 from GTG.core.dirs import plugin_configuration_dir
 
 from Cheetah.Template import Template as CheetahTemplate
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 
 TEMPLATE_PATHS = [
     os.path.join(plugin_configuration_dir('export'), "export_templates"),
@@ -169,7 +169,7 @@ class Template():
         def wait_for_document():
             """ Wait for the completion of the script and finish generation """
             document_ready.wait()
-            GObject.idle_add(callback)
+            GLib.idle_add(callback)
 
         threading.Thread(target=script).start()
         threading.Thread(target=wait_for_document).start()

--- a/GTG/plugins/unmaintained/bugzilla/bugzilla.py
+++ b/GTG/plugins/unmaintained/bugzilla/bugzilla.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 import re
 import threading
 import xmlrpc.client
@@ -81,14 +81,14 @@ class GetBugInformationTask(threading.Thread):
             send_notification(bugzillaService.name, err.message)
         else:
             title = f'#{bug_id}: {bug.summary}'
-            GObject.idle_add(self.task.set_title, title)
+            GLib.idle_add(self.task.set_title, title)
             text = f"{bug_url}\n\n{bug.description}"
-            GObject.idle_add(self.task.set_text, text)
+            GLib.idle_add(self.task.set_text, text)
 
             tags = bugzillaService.getTags(bug)
             if tags is not None and tags:
                 for tag in tags:
-                    GObject.idle_add(self.task.add_tag, f'@{tag}')
+                    GLib.idle_add(self.task.add_tag, f'@{tag}')
 
 
 class BugzillaPlugin():
@@ -102,7 +102,7 @@ class BugzillaPlugin():
     def task_added_cb(self, sender, task_id):
         # this is a gobject callback that will block the Browser.
         # decoupling with a thread. All interaction with task and tags objects
-        # (anything in a Tree) must be done with gobject.idle_add (invernizzi)
+        # (anything in a Tree) must be done with GLib.idle_add (invernizzi)
 
         task = self.plugin_api.get_requester().get_task(task_id)
         bugTask = GetBugInformationTask(task)

--- a/GTG/plugins/unmaintained/tomboy/tomboy.py
+++ b/GTG/plugins/unmaintained/tomboy/tomboy.py
@@ -337,6 +337,8 @@ class TomboyPlugin():
         # cursor changes to a hand
 
         def realize_callback(widget):
-            eventbox.window.set_cursor(Gdk.Cursor.new(Gdk.HAND2))
+            cursor = Gdk.Cursor.new_for_display(eventbox.window.get_display(),
+                                                Gdk.CursorType.HAND2)
+            eventbox.window.set_cursor(cursor)
         eventbox.connect("realize", realize_callback)
         return eventbox


### PR DESCRIPTION
See commit messages for more info. I basically ran `./launch.sh -w` and fixed some of the DeprecationWarnings it came up. I didn't touch theme/colour related stuff yet.

I am unsure about the "Try to use .get_property instead of .get_font" commit (with the UnicodeError) if I am doing something wrong. A quick `print` tells me `font` is `Pango.FontDescription`, just like what the old `.get_font()` returns. I'd guess it is maybe a object lifetime problem?

Testing appreciated.