### PR TITLE
Add optional setproctitle to set process title

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -64,6 +64,12 @@ if __name__ == "__main__":
     gettext.bindtextdomain('gtg', LOCALE_DIR)
     gettext.textdomain('gtg')
 
+    try:
+        import setproctitle
+        setproctitle.setproctitle("gtg")
+    except ImportError:
+        pass
+
 import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Later, when you want to update to the latest development version (assuming you a
   - gdk-pixbuf
   - GTK 3
 
+
 You can get most of those from your distribution packages:
 
     # On Fedora
@@ -81,6 +82,9 @@ Dependencies for the "Export and print" plugin:
 On Ubuntu you can install all that with:
 
     sudo apt install python3-cheetah pdftk-java texlive-extra-utils texlive-latex-base
+
+Optional Dependencies:
+* setproctitle (to set the process title when listing processes like `ps`)
 
 ### Running the beast
 


### PR DESCRIPTION
Uses https://pypi.org/project/setproctitle/.
Made optional since it isn't necessary for the application itself and is basically a use-once thing.
Fixes #638. An icon is even displayed (although it is provided by a 3rd party theme here):
![Screenshot of system monitor of the change](https://user-images.githubusercontent.com/1196130/115631476-2fae1080-a306-11eb-8c55-8709ba66e69c.png)
The only downside I can see is that it also overwrites the command line thing, so you can't see with what command line it has been started with.