### PR TITLE
Update recurring calendar to today or selected date

### DIFF
--- a/GTG/gtk/data/task_editor.ui
+++ b/GTG/gtk/data/task_editor.ui
@@ -441,8 +441,7 @@
                   <object class="GtkCalendar" id="month_calender">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="year">2020</property>
-                    <property name="month">11</property>
+                    <property name="month">0</property>
                     <property name="show_heading">False</property>
                     <property name="show_day_names">False</property>
                     <property name="no_month_change">True</property>
@@ -513,8 +512,6 @@
                   <object class="GtkCalendar" id="year_calender">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="year">2020</property>
-                    <property name="month">8</property>
                     <signal name="day-selected" handler="set_recurring_term_calender_year" swapped="no"/>
                   </object>
                   <packing>


### PR DESCRIPTION
Previously it'll always default to the same year and month, by removing
the attributes it defaults to being today.

In code, it is then updated to match the current recurring status when
applicable.

The monthly selection is now always using January since it has 31 days,
the max days in a month.
To make sure this detail isn't seen when going to the yearly calendar,
this is made hidden with an ugly loop, trying out the next possible
month.


Fixes #637. Yes, the code is just a mess.