### PR TITLE
Add StartupWMClass to make pinning on KDE working

### DIFF
--- a/data/org.gnome.GTG.desktop.in.in
+++ b/data/org.gnome.GTG.desktop.in.in
@@ -14,3 +14,4 @@ Keywords=Organizer;Task;Tasks;Projects;Activities;Productivity;Plan;Planning;Pla
 MimeType=x-scheme-handler/gtg;
 StartupNotify=true
 DBusActivatable=true
+StartupWMClass=Gtg


### PR DESCRIPTION
Using this because it is recommended by the following FAQ entry, and
the seems the most appropriately solution after looking at the KDE
heuristics.

https://userbase.kde.org/LatteDock/FAQ#My_launcher_and_its_window_are_not_associated_correctly_OR_my_launcher_is_using_a_low-resolution_icon.3F
https://invent.kde.org/plasma/plasma-workspace/-/blob/951587ffaeb4c687cd2dd4a74e434fde15b06da6/libtaskmanager/tasktools.cpp#L210

I used D-Feet to look why it works there, and it turns out it matches
on the Name= part, that we don't want to modify (which would be GTG
here).

It probably works on gnome because it uses the (GTK) Application ID:
https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/a472657490892592ce34ad3bc095c013c0d75e56/src/shell-window-tracker.c#L426

Thus it seems StartupWMClass= is the right solution for this.
I am using "Gtg" and not "gtg" because WM_CLASS also contains "Gtg" and
with some comments from the gnome code it seems to be a common
convention(?), so let's use that.

---

Fixes #651, at least when running locally, using X11, via a live Kubuntu VM.