### PR TITLE
Use application ID as the window icon

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -89,6 +89,7 @@ class Application(Gtk.Application):
     def do_startup(self):
         """Callback when primary instance should initialize"""
         Gtk.Application.do_startup(self)
+        Gtk.Window.set_default_icon_name(self.props.application_id)
 
         # Register backends
         datastore = DataStore()

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -220,8 +220,6 @@ class MainWindow(Gtk.ApplicationWindow):
         """
         # TODO(izidor): Add icon dirs on app level
         Gtk.IconTheme.get_default().prepend_search_path(ICONS_DIR)
-        # TODO(izidor): Set it outside browser as it applies to every window
-        Gtk.Window.set_default_icon_name("gtg")
 
     def _init_widget_aliases(self):
         """


### PR DESCRIPTION
Because otherwise in at least KDE it will display the default one.
It uses the application id because you need one anyway for the desktop
file, and would show the development icon version appropriately.

Before: Look at after but all the Icons are "X"
After (in development mode): ![Screenshot of GTG with various window open and the development icon visible](https://user-images.githubusercontent.com/1196130/116792616-13f2f900-aac2-11eb-92b3-df1cea9979e8.png)
