### PR TITLE
 Use Gdk.Cursor.new_from_name()

### DIFF
--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -597,8 +597,8 @@ class TaskView(Gtk.TextView):
         tags = view.get_iter_at_location(x, y)[1].get_tags()
 
         # Reset cursor and hover states
-        cursor = Gdk.Cursor.new_for_display(window.get_display(),
-                                            Gdk.CursorType.XTERM)
+        cursor = Gdk.Cursor.new_from_name(window.get_display(),
+                                          'text')
         window.set_cursor(cursor)
 
         if self.hovered_tag:
@@ -613,8 +613,8 @@ class TaskView(Gtk.TextView):
         try:
             tag = tags[0]
             tag.set_hover()
-            cursor = Gdk.Cursor.new_for_display(window.get_display(),
-                                                Gdk.CursorType.HAND2)
+            cursor = Gdk.Cursor.new_from_name(window.get_display(),
+                                              'pointer')
             window.set_cursor(cursor)
             self.hovered_tag = tag
 

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -599,7 +599,6 @@ class TaskView(Gtk.TextView):
         # Reset cursor and hover states
         cursor = Gdk.Cursor.new_from_name(window.get_display(),
                                           'text')
-        window.set_cursor(cursor)
 
         if self.hovered_tag:
             try:
@@ -615,12 +614,12 @@ class TaskView(Gtk.TextView):
             tag.set_hover()
             cursor = Gdk.Cursor.new_from_name(window.get_display(),
                                               'pointer')
-            window.set_cursor(cursor)
             self.hovered_tag = tag
 
         except (AttributeError, IndexError):
             # Not an interactive tag, or no tag at all
             pass
+        window.set_cursor(cursor)
 
 
     def do_populate_popup(self, popup) -> None:

--- a/GTG/plugins/unmaintained/tomboy/tomboy.py
+++ b/GTG/plugins/unmaintained/tomboy/tomboy.py
@@ -337,8 +337,8 @@ class TomboyPlugin():
         # cursor changes to a hand
 
         def realize_callback(widget):
-            cursor = Gdk.Cursor.new_for_display(eventbox.window.get_display(),
-                                                Gdk.CursorType.HAND2)
+            cursor = Gdk.Cursor.new_from_name(eventbox.window.get_display(),
+                                              'pointer')
             eventbox.window.set_cursor(cursor)
         eventbox.connect("realize", realize_callback)
         return eventbox


### PR DESCRIPTION
Because GDK4 dropped new_for_display in favour of new_from_name, and it *might* have better cursor theme compatibility.

Also partially see #647 and the linked #621. Not sure if it fixes it.

Also fixed a small flicker in the 2nd commit, that is very small that I think is OK for that PR.