### PR TITLE
don't use invalid ranges in quick add

### DIFF
--- a/GTG/gtk/browser/quick_add.py
+++ b/GTG/gtk/browser/quick_add.py
@@ -69,7 +69,10 @@ def parse(text: str) -> Dict:
         data = match.group(0)
         result['tags'].add(data[1:])
 
-    for match in re.finditer(TOKEN_REGEX, text):
+    while True:
+        match = re.search(TOKEN_REGEX, text)
+        if match is None:
+            break
         token = match.group(2)
         data = match.group(3)
 


### PR DESCRIPTION
The `re.finditer()` function yields matches of the expression on the original passed string. When this string is modified and truncated later, the subsequent matches return invalid ranges.

This should fix bugs like #653 and #652.

I decided to implement this with this `while True` loop with the break condition. If you think that there is a better way, let me known. I'm always happy to learn :grinning:. 