### PR TITLE
Make sidebar in menu a toggle

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -115,6 +115,7 @@ class MainWindow(Gtk.ApplicationWindow):
         # Define aliases for specific widgets to reuse them easily in the code
         self._init_widget_aliases()
         self.sidebar.connect('notify::visible', self._on_sidebar_visible)
+        self.add_action(Gio.PropertyAction.new('sidebar', self.sidebar, 'visible'))
 
         self.set_titlebar(self.headerbar)
         self.set_title('Getting Things GNOME!')

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -211,11 +211,11 @@
         <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkModelButton" id="toggle_sidebar_button">
+          <object class="GtkCheckButton" id="toggle_sidebar_button">
             <property name="visible">True</property>
             <property name="receives_default">True</property>
-            <property name="action_name">win.toggle_sidebar</property>
-            <property name="text" translatable="yes">Toggle Sidebar</property>
+            <property name="label" translatable="yes">Show Sidebar</property>
+            <property name="active" bind-source="sidebar_vbox" bind-property="visible" bind-flags="bidirectional" />
           </object>
           <packing>
             <property name="expand">False</property>

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -211,11 +211,11 @@
         <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkCheckButton" id="toggle_sidebar_button">
+          <object class="GtkModelButton" id="toggle_sidebar_button">
             <property name="visible">True</property>
-            <property name="receives_default">True</property>
-            <property name="label" translatable="yes">Show Sidebar</property>
-            <property name="active" bind-source="sidebar_vbox" bind-property="visible" bind-flags="bidirectional" />
+            <property name="text" translatable="yes">Show Sidebar</property>
+            <property name="action-name">win.sidebar</property>
+            <property name="active" bind-source="sidebar_vbox" bind-property="visible" />
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Because other applications like nautilus do something similar.
Also makes the code a bit cleaner because the synchronisation is done by
GObject rather than doing it ourselves.

The F9 shortcut still works. Note that the video shows a bit of an older version, the newest has put the checkbox to the right like other GTK applications.
![Demonstration](https://user-images.githubusercontent.com/1196130/117056954-2b79ee00-ad1d-11eb-8f14-f4c3057ccc8d.gif)

