### PR TITLE
ESC now closes calendar picker window

### DIFF
--- a/GTG/gtk/editor/calendar.py
+++ b/GTG/gtk/editor/calendar.py
@@ -59,6 +59,11 @@ class GTGCalendar(GObject.GObject):
             "clicked", lambda w: self.__day_selected(w, "soon"))
         self.__builder.get_object("button_someday").connect(
             "clicked", lambda w: self.  __day_selected(w, "someday"))
+        # allow fast closing by Escape key
+        agr = Gtk.AccelGroup()
+        self.add_accel_group(agr)
+        key, modifier = Gtk.accelerator_parse('Escape')
+        agr.connect(key, modifier, Gtk.AccelFlags.VISIBLE, self._esc_close)
 
     def set_date(self, date, date_kind):
         self.__date_kind = date_kind
@@ -209,3 +214,14 @@ class GTGCalendar(GObject.GObject):
 
     def __getattr__(self, attr):
         return getattr(self.__window, attr)
+
+    def _esc_close(self, widget, event, arg1=None, arg2=None, arg3=None):
+        """
+        Callback: Close this window when pressing Escape.
+
+        Arguments arg1-arg3 are needed to satisfy callback when closing
+        by Escape
+        """
+
+        self.close_calendar()
+        return True


### PR DESCRIPTION
Copied the code used in the tag editor.

Fixes #382

Unfortunately not GTK4-ready since handling of shortcuts etc. has been changed in GTK4.