### PR TITLE
Fix cut-off when you expand the columns too much

### DIFF
--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -503,7 +503,6 @@
                       <object class="GtkScrolledWindow" id="open_pane">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">never</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -517,7 +516,6 @@
                       <object class="GtkScrolledWindow" id="actionable_pane">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">never</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -532,7 +530,6 @@
                       <object class="GtkScrolledWindow" id="closed_pane">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">never</property>
                         <child>
                           <placeholder/>
                         </child>


### PR DESCRIPTION
Scrollbar policy "Never" means that it'll let the widget expand, not
sure why it was inserted there.
The default value works as expected.

Fixes #669. Note that the columns aren't re-adjusted when the window is resized, it just allows you to scroll.

https://user-images.githubusercontent.com/1196130/117730588-db070280-b1ec-11eb-87e1-bcc1231266ec.mp4

