### PR TITLE
Grab focus on sidebar

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -762,8 +762,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def focus_sidebar(self, action, param):
         """Callback to focus the sidebar widget."""
-        if not self.tagtreeview or not self.sidebar.get_property('visible'):
-            self.on_sidebar_toggled(action, param)
+        self.sidebar.props.visible = True
         self.tagtreeview.grab_focus()
 
     def on_quickadd_focus_in(self, widget, event):

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -171,6 +171,7 @@ class MainWindow(Gtk.ApplicationWindow):
             ('collapse_all_tasks', self.on_collapse_all_tasks, None),
             ('expand_all_tasks', self.on_expand_all_tasks, None),
             ('change_tags', self.on_modify_tags, ('win.change_tags', ['<ctrl>T'])),
+            ('focus_sidebar', self.focus_sidebar, ('win.focus_sidebar', ['<ctrl>B'])),
             ('search', self.toggle_search, ('win.search', ['<ctrl>F'])),
             ('focus_quickentry', self.focus_quickentry, ('win.focus_quickentry', ['<ctrl>L'])),
             ('delete_task', self.on_delete_tasks, ('win.delete_task', ['<ctrl>Delete'])),
@@ -758,6 +759,12 @@ class MainWindow(Gtk.ApplicationWindow):
         """Callback to focus the quick entry widget."""
 
         self.quickadd_entry.grab_focus()
+
+    def focus_sidebar(self, action, param):
+        """Callback to focus the sidebar widget."""
+        if not self.tagtreeview or not self.sidebar.get_property('visible'):
+            self.on_sidebar_toggled(action, param)
+        self.tagtreeview.grab_focus()
 
     def on_quickadd_focus_in(self, widget, event):
         self.toggle_delete_accel(False)


### PR DESCRIPTION
Fix #648 by adding shortcut Ctrl+B to set focus on sideBar