### PR TITLE
Make setting due date today an option in context menu

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -188,6 +188,7 @@ class MainWindow(Gtk.ApplicationWindow):
             ('start_next_year', self.on_start_for_next_year, None),
             ('start_custom', self.on_start_for_specific_date, None),
             ('start_clear', self.on_start_clear, None),
+            ('due_today', self.on_set_due_today, None),
             ('due_tomorrow', self.on_set_due_tomorrow, None),
             ('due_next_week', self.on_set_due_next_week, None),
             ('due_next_month', self.on_set_due_next_month, None),

--- a/GTG/gtk/data/context_menus.ui
+++ b/GTG/gtk/data/context_menus.ui
@@ -125,6 +125,11 @@
       <attribute name="label" translatable="yes">Set Due Date</attribute>
 
       <item>
+        <attribute name="label" translatable="yes">Today</attribute>
+        <attribute name="action">win.due_today</attribute>
+      </item>
+
+      <item>
         <attribute name="label" translatable="yes">Tomorrow</attribute>
         <attribute name="action">win.due_tomorrow</attribute>
       </item>


### PR DESCRIPTION
This is useful for when you want to reschedule future tasks to today, or bump forward overdue tasks to today.