### PR TITLE
Cleanup the Cell Renderer Codebase

### DIFF
--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -49,9 +49,7 @@ class CellRendererTags(Gtk.CellRenderer):
         #  G       D
         #   F  *  E
 
-        context.move_to(
-            x + r, y
-        )  # Move to A
+        context.move_to(x + r, y)          # Move to A
         context.line_to(x + w - r, y)      # Line to B
 
         context.curve_to(

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -228,4 +228,5 @@ class CellRendererTags(Gtk.CellRenderer):
         else:
             return (self.xpad, self.ypad, self.xpad * 2, self.ypad * 2)
 
+
 GObject.type_register(CellRendererTags)

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -109,7 +109,6 @@ class CellRendererTags(Gtk.CellRenderer):
         self.config = config
         self._ignore_icon_error_for = set()
 
-
     def do_set_property(self, pspec, value):
         if pspec.name == "tag-list":
             self.tag_list = value

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -51,35 +51,35 @@ class CellRendererTags(Gtk.CellRenderer):
 
         context.move_to(
             x + r, y
-        ) # Move to A
-        context.line_to(x + w - r, y)     # Line to B
+        )  # Move to A
+        context.line_to(x + w - r, y)      # Line to B
 
         context.curve_to(
             x + w, y,
             x + w, y,
             x + w, y + r
-        ) # Curve to C
-        context.line_to(x + w, y + h - r) # Line to D
+        )  # Curve to C
+        context.line_to(x + w, y + h - r)  # Line to D
 
         context.curve_to(
             x + w, y + h,
             x + w, y + h,
             x + w - r, y + h
-        ) # Curve to E
-        context.line_to(x + r, y + h)     # Line to F
+        )  # Curve to E
+        context.line_to(x + r, y + h)      # Line to F
 
         context.curve_to(
             x, y + h,
             x, y + h,
             x, y + h - r
-        ) # Curve to G
-        context.line_to(x, y + r)         # Line to H
+        )  # Curve to G
+        context.line_to(x, y + r)          # Line to H
 
         context.curve_to(
             x, y,
             x, y,
             x + r, y
-        ) # Curve to A
+        )  # Curve to A
         return
 
     def __count_viewable_tags(self):

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -42,24 +42,43 @@ class CellRendererTags(Gtk.CellRenderer):
     # Private methods
     def __roundedrec(self, context, x, y, w, h, r=10):
         "Draw a rounded rectangle"
-        #   A****BQ
-        #  H      C
-        #  *      *
-        #  G      D
-        #   F****E
+        #   A  *  BQ
+        #  H       C
+        #  *       *
+        #  G       D
+        #   F  *  E
 
-        context.move_to(x + r, y)                          # Move to A
-        context.line_to(
-            x + w - r, y)                        # Straight line to B
-        # Curve to C, Control points are both at Q
-        context.curve_to(x + w, y, x + w, y, x + w, y + r)
-        context.line_to(x + w, y + h - r)                      # Move to D
+        context.move_to(
+            x + r, y
+        ) # Move to A
+        context.line_to(x + w - r, y)     # Line to B
+
         context.curve_to(
-            x + w, y + h, x + w, y + h, x + w - r, y + h)  # Curve to E
-        context.line_to(x + r, y + h)                        # Line to F
-        context.curve_to(x, y + h, x, y + h, x, y + h - r)       # Curve to G
-        context.line_to(x, y + r)                          # Line to H
-        context.curve_to(x, y, x, y, x + r, y)             # Curve to A
+            x + w, y,
+            x + w, y,
+            x + w, y + r
+        ) # Curve to C
+        context.line_to(x + w, y + h - r) # Line to D
+
+        context.curve_to(
+            x + w, y + h,
+            x + w, y + h,
+            x + w - r, y + h
+        ) # Curve to E
+        context.line_to(x + r, y + h)     # Line to F
+
+        context.curve_to(
+            x, y + h,
+            x, y + h,
+            x, y + h - r
+        ) # Curve to G
+        context.line_to(x, y + r)         # Line to H
+
+        context.curve_to(
+            x, y,
+            x, y,
+            x + r, y
+        ) # Curve to A
         return
 
     def __count_viewable_tags(self):

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -174,7 +174,7 @@ class CellRendererTags(Gtk.CellRenderer):
                         widget.get_style_context(), gdkcontext, surface,
                         rect_x, rect_y)
 
-                    count +=  1
+                    count += 1
 
                 else:
                     layout = PangoCairo.create_layout(cr)

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -160,7 +160,6 @@ class CellRendererTags(Gtk.CellRenderer):
             rect_x = orig_x + self.PADDING * 2 * count + 16 * count
             rect_y = orig_y
 
-
             if my_tag_icon:
                 if my_tag_icon in self.SYMBOLIC_ICONS:
                     icon_theme = Gtk.IconTheme.get_default()

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -16,13 +16,13 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-from gi.repository import Pango
-from gi.repository import PangoCairo
-from gi.repository import GObject, GLib, Gtk, Gdk
-
 import gi
 import cairo
 gi.require_version('PangoCairo', '1.0')
+
+from gi.repository import Pango
+from gi.repository import PangoCairo
+from gi.repository import GObject, GLib, Gtk, Gdk
 
 
 class CellRendererTags(Gtk.CellRenderer):

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -146,9 +146,10 @@ class CellRendererTags(Gtk.CellRenderer):
         x_align = self.get_property("xalign")
         y_align = self.get_property("yalign")
         padding = self.PADDING
-        orig_x = cell_area.x + int((cell_area.width - 16 * vw_tags -
-                                    padding * 2 * (vw_tags - 1)) * x_align)
-        orig_y = cell_area.y + int((cell_area.height - 16) * y_align)
+        orig_x = cell_area.x + int(
+            (cell_area.width - 16 * vw_tags - padding * 2 * (vw_tags - 1)) * x_align)
+        orig_y = cell_area.y + int(
+            (cell_area.height - 16) * y_align)
 
         # We draw the icons & squares
         for my_tag in tags:

--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -16,12 +16,13 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
+from gi.repository import Pango
+from gi.repository import PangoCairo
 from gi.repository import GObject, GLib, Gtk, Gdk
+
 import gi
 import cairo
 gi.require_version('PangoCairo', '1.0')
-from gi.repository import Pango
-from gi.repository import PangoCairo
 
 
 class CellRendererTags(Gtk.CellRenderer):


### PR DESCRIPTION
Hello, this is my first ever contribution to an open-source project, and the prospect of GTG seems very promising. I thought I'd start small with some code formatting cleanup and better self-documentation for readability.

If you have any suggestions, please let me know. I will be more than willing to adjust as necessary. Here's to my first contribution, hopefully! 🎉

The following errors and warnings according to PyCodeStyle have been fixed:

- E402 (import order)
- E261 (comment spacing)
- E303 (too many blank lines)
- W504 (line break after a binary operator)
- E222 (too many spaces after operator)
- E305 (expected 2 blank lines after class declaration)