### PR TITLE
Demote default editor font log error to a warning

### DIFF
--- a/GTG/gtk/general_preferences.py
+++ b/GTG/gtk/general_preferences.py
@@ -84,8 +84,9 @@ class GeneralPreferences():
                 font = self.ui_widget.get_style_context().get_property(
                     "font", Gtk.StateFlags.NORMAL)
                 editor_font = font.to_string()
-            except UnicodeError:
-                log.exception("Using deprecated but still working font way")
+            except UnicodeError as e:
+                log.warning("Using deprecated but still working font way (%r)",
+                            e)
                 font = self.ui_widget.get_style_context().get_font(
                     Gtk.StateFlags.NORMAL)
                 editor_font = font.to_string()


### PR DESCRIPTION
Caused some confusion to think it could have something to do with some issue (like https://github.com/getting-things-gnome/gtg/pull/658#issuecomment-834830045), but it doesn't.
Thus demoted to a simple warning, which isn't shown by default (without `-d`).