### PR TITLE
README: Install python3-gi-cairo for debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo dnf install meson python3-cairo python3-gobject gtk3 itstool gettext python
 # On Debian 10 (buster), you need to install the backported version, activate it with:
 echo 'deb http://deb.debian.org/debian buster-backports main' | sudo tee -a /etc/apt/sources.list
 # On Debian/Ubuntu:
-sudo apt install meson python3-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml libgirepository1.0-dev
+sudo apt install meson python3-gi-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml libgirepository1.0-dev
 ```
 
 liblarch may be harder to come by until distributions package the python3 version of it, alongside GTG 0.4+ itself.


### PR DESCRIPTION
This is required for getting GTG to work, otherwhise the following error
would occur:

TypeError: Couldn't find foreign struct converter for 'cairo.Context'

It seems that package is installed by gedit, which is a default
applictaion for GNOME, so during package testing it might be easy to
miss.

Since python3-gi-cairo depends on python3-cairo, I "replaced" that
dependency, so the line isn't getting too long.

Found out by #716
I actually haven't tested this, but according to the reporter it should work.
Also, I haven't looked at Fedora yet, and I am unsure how to call it in the textual dependency list (where we mention pycairo).