### PR TITLE
Fix tasks losing status at restart

### DIFF
--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -37,6 +37,7 @@ def task_from_element(task, element: etree.Element):
 
     task.set_title(element.find('title').text)
     task.set_uuid(element.get('id'))
+    task.set_status(element.attrib['status'], init=True) # Done date set later
 
     # Retrieving all dates
     dates = element.find('dates')


### PR DESCRIPTION
The recent date thing #597 also changed the file loading code to make the
date reading code more compact, but also accidentally also removed
reading the tasks status, so all tasks were considered Open after a
restart.

Fixes #718

Also, it seems to only rewrite tasks in the XML tree when the task has been changed? Seems this is the behaviour, so unless something else was changed in the tasks other than just closing them, they should automatically be closed when this PR is applied (since the state is still in the XML file).