### PR TITLE
Add gtg://TASK-ID to the command line help

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -92,6 +92,7 @@ class Application(Gtk.Application):
 
         super().__init__(application_id=app_id,
                          flags=Gio.ApplicationFlags.HANDLES_OPEN)
+        self.set_option_context_parameter_string("[gtg://TASK-ID…]")
 
     # --------------------------------------------------------------------------
     # INIT


### PR DESCRIPTION
Fixes #721

Looks like this now:
```
$ LC_ALL=C ./launch.sh -- --help
[cut build system output]
Usage:
  gtg [OPTION?] [gtg://TASK-ID?]

Help Options:
  -h, --help                 Show help options
  --help-all                 Show all help options
  --help-gapplication        Show GApplication options
  --help-gtk                 Show GTK+ Options

Application Options:
  -v, --version              Show program version
  -d, --debug                Enable debug output
  -t, --title=TITLE          Use special title for windows' title
  --display=DISPLAY          X display to use

```

For some reason, the special triple dots "…" displays as a question mark when using `LC_ALL=C`, but display correctly in my language (German UTF-8). Using `LC_ALL=C.UTF-8` just displays the German text for me.