### PR TITLE
cell_renderer_tags: don't antialias on lodpi

### DIFF
--- a/GTG/gtk/browser/cell_renderer_tags.py
+++ b/GTG/gtk/browser/cell_renderer_tags.py
@@ -140,6 +140,10 @@ class CellRendererTags(Gtk.CellRenderer):
 
         # Drawing context
         gdkcontext = cr
+        scale_factor = widget.get_scale_factor()
+        # Don't blur border on lodpi
+        if scale_factor == 1:
+            gdkcontext.set_antialias(cairo.ANTIALIAS_NONE)
 
         # Coordinates of the origin point
         x_align = self.get_property("xalign")
@@ -162,7 +166,6 @@ class CellRendererTags(Gtk.CellRenderer):
             if my_tag_icon:
                 if my_tag_icon in self.SYMBOLIC_ICONS:
                     icon_theme = Gtk.IconTheme.get_default()
-                    scale_factor = widget.get_scale_factor()
                     info = icon_theme.lookup_icon_for_scale(my_tag_icon, 16,
                                                             scale_factor, 0)
                     pixbuf, was_symbolic = info.load_symbolic(symbolic_color)


### PR DESCRIPTION
This blurs the pretty border and imo makes it look very smeared (and the shape looks weird too).

This definetely is better than having a low res rounded rectangle in
HIDPI though, so there it is still anti-aliased.

![now-lodpi](https://user-images.githubusercontent.com/77527554/140898318-764cc7f6-30ca-4285-a2c0-b35f9aa8c09d.png)
![before-lodpi](https://user-images.githubusercontent.com/77527554/140898339-d0f7f108-c883-4661-a185-7c72e0f42d75.png)

See https://github.com/getting-things-gnome/gtg/issues/727  (I first typod the issue number, this is why I mentioned the wrong issue)


