### PR TITLE
Revert meson plugin translation apply thing

### DIFF
--- a/GTG/plugins/meson.build
+++ b/GTG/plugins/meson.build
@@ -24,9 +24,7 @@ foreach plugin : gtg_plugins
     install_dir: plugin_install_dir,
     type: 'desktop',
     args: ['--keyword=name', '--keyword=short-description', '--keyword=description'],
-    build_by_default: true,
-    build_always_stale: true
-    # build always because otherwise new translations won't be applied
+    build_by_default: true
   )
   subdir(plugin.underscorify())
 endforeach

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -75,5 +75,8 @@ Make sure to this AFTER COMMITING YOUR CHANGES!
 * During launching, it might complain about certain files not being found in [`po/POTFILES.in`][POTFILES.IN].
   It is safe to remove the lines from that file and re-run until it works.
   It would be useful to comment about that if you're submitting your translation, just in case.
+* Plugin related strings don't update after updating the translation.
+  The cause is unknown, but you can delete the plugin files to re-generate
+  them using the new translations: `rm -f .local_build/GTG/plugins/*.gtg-plugin`
 
 [POTFILES.IN]: ../../po/POTFILES.in


### PR DESCRIPTION
Since meson 0.60, the `build_always_stale` option was removed:
https://github.com/mesonbuild/meson/commit/6b1a80024c79876dc3b75f2b525be24ca8fe671a

However, meson doesn't make such files depend on the translation .po
files, which is a known bug:
https://github.com/mesonbuild/meson/issues/2621

So with that option taken away, I tried passing a list to the input
which includes all .po files, since I saw it only uses the first element
for the translations, but that fails when trying to generate po files.

Since it seems you can't dynamically add dependencies after the fact,
this seems like a dead end, so I am reverting this for now to make it
compile on meson 0.60.

Reverts #555 to fix #720