### PR TITLE
Use GtkSource.view for taskview and enable undo

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -73,6 +73,7 @@ if __name__ == "__main__":
 import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
+gi.require_version('GtkSource', '4') 
 
 from gi.repository import GLib
 

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -205,6 +205,9 @@ class TaskEditor:
         text = self.task.get_text()
         title = self.task.get_title()
 
+        # Insert text and tags as a non_undoable action, otherwise
+        # the user can CTRL+Z even this inserts.
+        self.textview.buffer.begin_not_undoable_action()
         self.textview.buffer.set_text(f"{title}\n")
 
         if text:
@@ -233,6 +236,7 @@ class TaskEditor:
         else:
             self.task.set_to_keep()
 
+        self.textview.buffer.end_not_undoable_action()
         self.window.connect("destroy", self.destruction)
 
         # Connect search field to tags popup

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -24,7 +24,7 @@ from time import time
 from uuid import uuid4
 import logging
 
-from gi.repository import Gtk, GLib, Gdk, GObject
+from gi.repository import Gtk, GLib, Gdk, GObject, GtkSource
 
 from GTG.core.requester import Requester
 import GTG.core.urlregex as url_regex
@@ -51,7 +51,7 @@ INTERNAL_REGEX = re.compile((r'gtg:\/\/'
                             re.IGNORECASE)
 
 
-class TaskView(Gtk.TextView):
+class TaskView(GtkSource.View):
     """Taskview widget
 
     This is a specialized Gtk textview with GTG features. It waits [n] seconds
@@ -251,7 +251,9 @@ class TaskView(Gtk.TextView):
             # Remove the -
             delete_end = start.copy()
             delete_end.forward_chars(2)
+            self.buffer.begin_not_undoable_action()
             self.buffer.delete(start, delete_end)
+            self.buffer.end_not_undoable_action()
 
             # Add new subtask
             tid = self.new_subtask_cb(text[2:])

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ git pull --rebase
   - pango
   - gdk-pixbuf
   - GTK 3
+  - GtkSourceView 4
 
 You can get most of those from your distribution packages:
 


### PR DESCRIPTION
This PR makes taskview sublcass GtkSource.view instead of the regular textview.
The immediate change is that now we can have undo/redo. It also opens the door for more features, like tag autocompletion.
It's a small enough change that can go into 0.6

The only limitation for now is that you can't undo a subtask once it's created. I don't think this is particularly bad though, since ctrl+z'ing a subtask would delete it without confirmation.

closes #296