### PR TITLE
Adjust anonymize task script to work with new file format

### DIFF
--- a/scripts/anonymize_task_file.py
+++ b/scripts/anonymize_task_file.py
@@ -16,12 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import os.path
 import sys
+import re
 
 from xml.dom.minidom import parse
 
 from gi.repository import GLib
-
 
 def anonymize(filename, outputfile):
     try:
@@ -35,32 +36,47 @@ def anonymize(filename, outputfile):
     for task in tasks:
         textnode = task.getElementsByTagName("title")[0].childNodes[0]
         nodevalue = textnode.nodeValue
-        newnodevalue = ""
-
-        for i in range(len(nodevalue)):
-            if nodevalue[i] not in [" ", "\t", "\n"]:
-                newnodevalue = newnodevalue + "m"
-            else:
-                newnodevalue = newnodevalue + nodevalue[i]
-
-        textnode.nodeValue = newnodevalue
+        replaced_title = re.sub('[^ \n\t]', 'm', textnode.nodeValue)
+        textnode.nodeValue = "%s %s" % (task.getAttribute('id'),
+                                        replaced_title)
 
         contentnode = task.getElementsByTagName("content")
         if len(contentnode) == 0:
             continue
 
-        contentnode = contentnode[0].childNodes[0]
+        if contentnode[0].childNodes != []:
+            contentnode = contentnode[0].childNodes[0]
+            contentnode.nodeValue = re.sub('[^ \n\t]', 'm',
+                                           contentnode.nodeValue)
 
-        nodevalue = contentnode.nodeValue
-        newnodevalue = ""
+    taglist = dom.getElementsByTagName("taglist")
+    tags = taglist[0].getElementsByTagName("tag")
+    tag_dict = {}
 
-        for i in range(len(nodevalue)):
-            if nodevalue[i] not in [" ", "\t", "\n"]:
-                newnodevalue = newnodevalue + "m"
-            else:
-                newnodevalue = newnodevalue + nodevalue[i]
+    for tag in tags:
+        tag_dict[tag.getAttribute("name")] = tag.getAttribute("id")
 
-        contentnode.nodeValue = newnodevalue
+    for tag in tags:
+        tag.setAttribute("name", tag.getAttribute("id"))
+        if tag.getAttribute('parent') != '':
+            tag.setAttribute("parent",
+                             tag_dict.get(tag.getAttribute("parent"), 'unk'))
+
+    searchlist = dom.getElementsByTagName("searchlist")
+    searches = searchlist[0].getElementsByTagName("savedSearch")
+    search_dict = {}
+
+    for search in searches:
+        search_dict[search.getAttribute("name")] = search.getAttribute("id")
+
+    for search in searches:
+        search.setAttribute("query", "anon")
+        search.setAttribute("name", search.getAttribute("id"))
+        if search.getAttribute('parent') != 'search' \
+                and search.getAttribute('parent') != '':
+            search.setAttribute("parent",
+                                search_dict.get(search.getAttribute("parent"),
+                                                'search'))
 
     try:
         fp = open(outputfile, "w")
@@ -74,7 +90,7 @@ def usage():
     print()
     print("Removes private data from specified taskfile, or your")
     print("default gtg tasks file if unspecified.  Writes output")
-    print("to /tmp/gtg-tasks.xml by default, or to specified")
+    print("to /tmp/gtg_data.xml by default, or to specified")
     print("outputfile if provided.")
     sys.exit(1)
 
@@ -84,12 +100,40 @@ def main():
         xmlfile = sys.argv[1]
     else:
         try:
-            data_dir = os.path.join(GLib.get_user_data_dir(), "gtg")
-            project_filepath = os.path.join(data_dir, "projects.xml")
-            dom = parse(project_filepath)
-            xmlproject = dom.getElementsByTagName("backend")[0]
-            xmlfile = str(xmlproject.getAttribute("path"))
-            xmlfile = os.path.join(data_dir, xmlfile)
+            local_dir = os.path.join(GLib.get_user_data_dir(), "gtg")
+            flatpak_dir = os.path.join(GLib.get_home_dir(),
+                                       '.var', 'app',
+                                       'org.gnome.GTG',
+                                       'data', 'gtg')
+
+            local_xml = os.path.join(local_dir, "gtg_data.xml")
+            flatpak_xml = os.path.join(flatpak_dir, "gtg_data.xml")
+
+            try:
+                local_xml_time = os.path.getmtime(local_xml)
+            except OSError:
+                local_xml_time = 0
+
+            try:
+                flatpak_xml_time = os.path.getmtime(flatpak_xml)
+            except OSError:
+                flatpak_xml_time = 0
+
+            if local_xml_time == flatpak_xml_time:
+                if os.path.exists(flatpak_xml):
+                    xmlfile = flatpak_xml
+                elif os.path.exists(local_xml):
+                    xmlfile = local_xml
+                else:
+                    print("Could not find the data file in default locations")
+                    raise Exception("Could not find data file in default "
+                                    "locations")
+            elif local_xml_time < flatpak_xml_time:
+                xmlfile = flatpak_xml
+            elif local_xml_time > flatpak_xml_time:
+                xmlfile = local_xml
+            else:
+                print("This should not happen")
 
             print("Reading tasks from %s" % (xmlfile))
         except Exception:
@@ -100,7 +144,7 @@ def main():
         outputfile = sys.argv[2]
     else:
         # Use a reasonable default, and write out where it's sent
-        outputfile = "/tmp/gtg-tasks.xml"
+        outputfile = "/tmp/gtg_data.xml"
         print("Saving anonymized tasks to %s" % (outputfile))
 
     anonymize(xmlfile, outputfile)


### PR DESCRIPTION
Also, flatpak detection added because I can, but untested.
And anonymizes tags by using their ID.
And adds the task ID to the title so it is easier to identify them.
And saved searches, where the query is a constant value.

Fixes #733

Testing appreciated since I whipped this in like 30 minutes. Works for neko however.