### PR TITLE
Don't loop forever with invalid quick add date

### DIFF
--- a/GTG/gtk/browser/quick_add.py
+++ b/GTG/gtk/browser/quick_add.py
@@ -85,20 +85,20 @@ def parse(text: str) -> Dict:
             try:
                 result['start'] = Date.parse(data)
             except ValueError:
-                continue
+                pass
 
         elif token in DUE_TOKEN:
             try:
                 result['due'] = Date.parse(data)
             except ValueError:
-                continue
+                pass
 
         elif token in REPEAT_TOKEN:
             try:
                 Date.today().parse_from_date(data)
                 result['recurring'] = data
             except ValueError:
-                continue
+                pass
 
         # Remove this part from the title
         text = text[:match.start()] + text[match.end():]

--- a/tests/core/test_quickadd.py
+++ b/tests/core/test_quickadd.py
@@ -232,3 +232,14 @@ class TestQuickAddParse(TestCase):
         self.assertEqual(expected1, parse(text2))
         self.assertEqual(expected2, parse(text3))
         self.assertEqual(expected4, parse(text5))
+
+    def test_invalid_date(self):
+        expected = {
+            'title': 'Do a thing',
+            'tags': set(),
+            'start': None,
+            'due': None,
+            'recurring': None
+        }
+
+        self.assertEqual(expected, parse('Do a thing due:never'))


### PR DESCRIPTION
Quick entering `Do a thing due:meh` causes GTG to completely freeze, and need to be killed. This fixes it to treat tokens with invalid dates the as other invalid tokens, ignoring them (and removing them from the input text).

This issue was caused since the the `continue` in the parsing loop didn't remove the token, causing it to loop forever on the invalid token.