### PR TITLE
Save task before creating parent

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -787,6 +787,7 @@ class TaskEditor:
         and to prevent visible content divergence when the child title changes.
         """
         parents = self.task.get_parents()
+        self.save()
 
         if not parents:
             tags = [t.get_name() for t in self.task.get_tags()]


### PR DESCRIPTION
Saving makes sure the task has the correct title when being added as a
subtask to the new parent. Otherwise the title gets overwritten with the
default title.

fixes #745