### PR TITLE
Prevent errors when no task is selected

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -335,8 +335,14 @@ class Application(Gtk.Application):
 
     def add_parent(self, param, action):
         """Callback to add a parent to a task"""
-        if self.browser.have_same_parent():
-            self.browser.on_add_parent()
+        
+        try:
+            if self.browser.have_same_parent():
+                self.browser.on_add_parent()
+
+        # When no task has been selected
+        except IndexError:
+            return
 
     def edit_task(self, param, action):
         """Callback to edit a task."""


### PR DESCRIPTION
This can be triggered when GTG first starts and there are no selected
tasks.

fixes #753