### PR TITLE
GTK Backendtree: Use correct RGB to hex function

### DIFF
--- a/GTG/gtk/backends/backendstree.py
+++ b/GTG/gtk/backends/backendstree.py
@@ -20,7 +20,7 @@ from gi.repository import Gtk
 from gi.repository import GdkPixbuf
 
 from GTG.core.tag import ALLTASKS_TAG
-from GTG.gtk.colors import get_colored_tags_markup, rgb_to_hex
+from GTG.gtk.colors import get_colored_tags_markup, rgba_to_hex
 from GTG.backends.backend_signals import BackendSignals
 
 


### PR DESCRIPTION
We only import `rgb_to_hex` but not `rgba_to_hex`, but the latter is
being used.
It seems to work with RGBA, so we just use the RGBA version.

Fixes the following error message:

    File "/usr/lib/python3.10/site-packages/GTG/gtk/backends/backendstree.py", line 125, in on_backend_state_changed
      color = rgba_to_hex(color)
    NameError: name 'rgba_to_hex' is not defined

Fixes #755