### PR TITLE
Make Synchronization menu entry keyboard selectable

### DIFF
--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -289,7 +289,6 @@
         <child>
           <object class="GtkModelButton" id="synchronization">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="sensitive">False</property>
             <property name="receives_default">True</property>
             <property name="action_name">app.open_backends</property>


### PR DESCRIPTION
Basically #665 but for that entry that (wrong) property was introduced in the CalDav changes it seems.