### PR TITLE
Update NEWS for 0.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,74 @@
 ===========
+Version 0.6
+===========
+
+GTG 0.6 brings even more performance improvements, bug fixes,
+the introduction of the CalDAV synchronization service, 
+the new Gamify plugin, and a redesign of the Tag Editor. 
+
+New Features:
+
+ • CalDAV is a calendaring protocol that allows a client to access items 
+   from a server. GTG now provides support for this standard, and with this new sync 
+   service, you can manage all your tasks in one place.
+ • New CalDAV backends are available, and the backends dialog is available again.
+ • The new Gamify plugin adds a game aspect to your GTG workflow, 
+   such as the ability to set task targets and task completion streaks.
+ • The Tag Editor was completely redesigned.
+ • Added support for undo/redo actions in the Task Editor.
+ • Added the ability to collapse and expand all tasks in the main menu.
+ • Added the F10 shortcut to open the main menu.
+ • ESC now closes the calendar picker window.
+ • Added the CTRL+B shortcut to set focus on the sidebar.
+ • Added an option to set the due date to "today" in the context menu.
+ • Added a unified "Reopen" action for closed tasks.
+ 
+ Backend, Code Quality, and Performance Improvements:
+ 
+ • Made task expansion more efficient (prevents the maximum recursion depth error).
+ • Made an improvement to avoid infinite loops when entering invalid 
+   dates in the Quick Add dialog.
+ • Made an update to prevent errors when no task is selected.
+ • Removed some deprecation warnings.
+ • Added StartupWMClass to make pinning on KDE work.
+ • Used application ID as the window icon (so KDE shows the correct icon).
+ • Made several changes in preparation for Gtk 4.0, as well as updated 
+   a number of deprecated GTK-related items.
+ • Made a ton of PEP8 and style fixes.
+ • Refactored the date class.
+ • Updated the ability to render tag icons better on HiDPI.
+ • Introduced an exception popup (i.e., a dialog that comes up when there’s an error).
+ • Updated the anonymize script.
+ • Added gtg://TASK-ID to the command-line help.
+ • Added the -p parameter for profiling in debug.sh.
+ 
+Bug Fixes:
+ 
+ • Made a change to save a task before creating a parent. 
+   This prevents an error that appeared when a task title would be reset 
+   after adding a parent.
+ • Fixed an issue with tasks losing their status during restart.
+ • Fixed an issue where tags were being duplicated.
+ • Fixed an issue where tags and saved searches with the same name were 
+    being considered duplicates.
+ • Fixed a bug where every editor window would come back if GTG wasn’t 
+    closed cleanly (i.e., shut down).
+ • Made several fixes for scripts.
+ • Fixed certain main menu entries not being selectable via the keyboard.
+ • Fixed the cut-off when you expand the columns too much.
+  
+Documentation Updates:
+
+ • Added documentation to the Contributor Docs for contributing to the User Manual 
+   (i.e., for writing help files).
+ • Added information about using flamegraph for profiling GTG for 
+   performance documentation (in the Contributor Docs).
+ • Updated the user manual for this release.
+
+For details on all of these new features, improvements, and fixes,
+see the release's milestone: https://github.com/getting-things-gnome/gtg/milestone/4. 
+
+===========
 Version 0.5
 ===========
 These are abbreviated release notes.

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,7 @@ New Features:
  • CalDAV is a calendaring protocol that allows a client to access items 
    from a server. GTG now provides support for this standard, and with this new sync 
    service, you can manage all your tasks in one place.
- • New CalDAV backends are available, and the backends dialog is available again.
+ • A new CalDAV backend is available, and the backends dialog is available again.
  • The new Gamify plugin adds a game aspect to your GTG workflow, 
    such as the ability to set task targets and task completion streaks.
  • The Tag Editor was completely redesigned.
@@ -21,11 +21,13 @@ New Features:
  • ESC now closes the calendar picker window.
  • Added the CTRL+B shortcut to set focus on the sidebar.
  • Added an option to set the due date to "today" in the context menu.
- • Added a unified "Reopen" action for closed tasks.
+ • The "Mark as not done" and "Undismiss" actions were replaced by a unified 
+   "Reopen" action for closed tasks in the right-click context menu.
+ • Updated the "Start Tomorrow" button to be adaptive so that the window
+   can be resized to smaller widths. 
  
  Backend, Code Quality, and Performance Improvements:
  
- • Made task expansion more efficient (prevents the maximum recursion depth error).
  • Made an improvement to avoid infinite loops when entering invalid 
    dates in the Quick Add dialog.
  • Made an update to prevent errors when no task is selected.
@@ -43,11 +45,12 @@ New Features:
  • Added the -p parameter for profiling in debug.sh.
  
 Bug Fixes:
- 
+
+ • Fixed possible crash when trying to create parent task, and similar operations, 
+   when the "Open" tab has not been opened yet (maximum recursion depth error).
  • Made a change to save a task before creating a parent. 
    This prevents an error that appeared when a task title would be reset 
    after adding a parent.
- • Fixed an issue with tasks losing their status during restart.
  • Fixed an issue where tags were being duplicated.
  • Fixed an issue where tags and saved searches with the same name were 
     being considered duplicates.
@@ -56,6 +59,11 @@ Bug Fixes:
  • Made several fixes for scripts.
  • Fixed certain main menu entries not being selectable via the keyboard.
  • Fixed the cut-off when you expand the columns too much.
+ • Fixed a regression where symbols in tags (e.g., dashes and dots) were not 
+   recognized by the Task Editor. Also, added support for a few more.
+ • Fixed a bug where tags' icon, parent, and color were not being removed in the XML file.
+ • Fixed a bug that occured when GTG just starts up with no tasks selected, 
+   and the user tried to use the "Add Parent" hotkey.
   
 Documentation Updates:
 


### PR DESCRIPTION
I added in the updates from the Gdoc. I put it in similar categories as was done for the previous releases. I went a little more in-depth than 1 line for some of the new features since I wasn't sure if we were also going to have a blog post. 

The only one that I didn't include was `Fixed several nekobugs [expand]` because I wasn't really sure what that meant. If you want me to add something for that, I can. I also want to make sure `Fixed the bug where every editor window would pop back if GTG wasn’t closed cleanly (ie, shutting down the pc)` was true because there was a comment on the Gdoc questioning it. 

Let me know if you would like any other changes. 