### PR TITLE
Make unused recurring task work with v0.5

### DIFF
--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -136,8 +136,10 @@ def task_to_element(task) -> etree.Element:
     recurring_updated_date_elem = etree.SubElement(recurring, 'updated_date')
     recurring_updated_date = task.get_recurring_updated_date()
 
-    if recurring_updated_date: 
+    if recurring_updated_date:
         recurring_updated_date_elem.text = str(recurring_updated_date)
+    else:
+        recurring_updated_date_elem.text = '9999-12-30'
 
     subtasks = etree.SubElement(element, 'subtasks')
 


### PR DESCRIPTION
Previously, an task not using recurring GTG would write

    <updated_date/>

but v0.5 tries to parse the text which doesn't exists and thus errors:

    Traceback (most recent call last):
      File ".local_build/install/lib/python3.8/site-packages/GTG/gtk/application.py", line 97, in do_startup
        datastore.register_backend(backend_dic)
      File ".local_build/install/lib/python3.8/site-packages/GTG/core/datastore.py", line 463, in register_backend
        source.start_get_tasks()
      File ".local_build/install/lib/python3.8/site-packages/GTG/core/datastore.py", line 700, in start_get_tasks
        self.backend.start_get_tasks()
      File ".local_build/install/lib/python3.8/site-packages/GTG/backends/backend_localfile.py", line 185, in start_get_tasks
        task = xml.task_from_element(task, element)
      File ".local_build/install/lib/python3.8/site-packages/GTG/core/xml.py", line 88, in task_from_element
        task.set_recurring_updated_date(datetime.fromisoformat(recurring_updated_date))
    TypeError: fromisoformat: argument must be str

By testing what v0.5 writes, we just imitate that:

    <updated_date>9999-12-30</updated_date>

The reason to do this is to allow easy downgrade of GTG to test stuff and so on.