### PR TITLE
Harmonize the headerbar's task deferral popover menubutton labels with the right-click menus'

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -282,17 +282,20 @@ class MainWindow(Gtk.ApplicationWindow):
         self.calendar.connect("date-changed", self.on_date_changed)
 
     def _set_defer_days(self, timer=None):
-        """Set days for the defer task menu."""
-
-        # Today is day 0, tomorrow is day 1. We don't need
-        # to calculate the weekday for those.
-
+        """
+        Set dynamic day labels for the toolbar's task deferring menubutton.
+        """
         today = datetime.datetime.today()
-
+        # Day 0 is "Today", day 1 is "Tomorrow",
+        # so we don't need to calculate the weekday name for those.
         for i in range(2, 7):
             defer_btn = self.builder.get_object(f"defer_{i}_btn")
-            name = (today + datetime.timedelta(days=i)).strftime('%A')
-            defer_btn.props.text = name
+
+            weekday_name = (today + datetime.timedelta(days=i)).strftime('%A')
+            translated_weekday_combo = _("In {number_of_days} days — {weekday}").format(
+                      weekday=weekday_name, number_of_days=i)
+
+            defer_btn.props.text = translated_weekday_combo
 
     def init_tags_sidebar(self):
         """

--- a/GTG/gtk/data/context_menus.ui
+++ b/GTG/gtk/data/context_menus.ui
@@ -85,14 +85,14 @@
         <attribute name="label" translatable="yes">In 6 days</attribute>
         <attribute name="action">win.start_next_day_6</attribute>
       </item>
-      </section>
-      <section>
 
       <item>
         <attribute name="label" translatable="yes">Next Week</attribute>
         <attribute name="action">win.start_next_week</attribute>
       </item>
+      </section>
 
+      <section>
       <item>
         <attribute name="label" translatable="yes">Next Month</attribute>
         <attribute name="action">win.start_next_month</attribute>
@@ -102,7 +102,9 @@
         <attribute name="label" translatable="yes">Next Year</attribute>
         <attribute name="action">win.start_next_year</attribute>
       </item>
+      </section>
 
+      <section>
       <item>
         <attribute name="label" translatable="yes">Pick a Date...</attribute>
         <attribute name="action">win.start_custom</attribute>
@@ -120,6 +122,7 @@
     <submenu>
       <attribute name="label" translatable="yes">Set Due Date</attribute>
 
+    <section>
       <item>
         <attribute name="label" translatable="yes">Today</attribute>
         <attribute name="action">win.due_today</attribute>
@@ -129,7 +132,9 @@
         <attribute name="label" translatable="yes">Tomorrow</attribute>
         <attribute name="action">win.due_tomorrow</attribute>
       </item>
+      </section>
 
+      <section>
       <item>
         <attribute name="label" translatable="yes">Next Week</attribute>
         <attribute name="action">win.due_next_week</attribute>
@@ -144,11 +149,7 @@
         <attribute name="label" translatable="yes">Next Year</attribute>
         <attribute name="action">win.due_next_year</attribute>
       </item>
-
-      <item>
-        <attribute name="label" translatable="yes">Pick a Date...</attribute>
-        <attribute name="action">win.due_custom</attribute>
-      </item>
+      </section>
 
       <section>
         <item>
@@ -164,6 +165,13 @@
         <item>
           <attribute name="label" translatable="yes">Someday</attribute>
           <attribute name="action">win.due_someday</attribute>
+        </item>
+      </section>
+
+      <section>
+        <item>
+          <attribute name="label" translatable="yes">Pick a Date...</attribute>
+          <attribute name="action">win.due_custom</attribute>
         </item>
       </section>
 

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -123,6 +123,21 @@
           </packing>
         </child>
         <child>
+          <object class="GtkModelButton" id="defer_nextweek_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Start 7 days from now</property>
+            <property name="action_name">win.start_next_week</property>
+            <property name="text" translatable="yes">Next Week</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -132,7 +147,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -146,7 +161,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -159,7 +174,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">7</property>
+            <property name="position">8</property>
           </packing>
         </child>
         <child>
@@ -173,7 +188,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">9</property>
           </packing>
         </child>
       </object>

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -48,18 +48,78 @@
         <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkModelButton" id="defer_0_btn">
+          <object class="GtkModelButton" id="defer_2_btn">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start today</property>
-            <property name="action_name">win.start_today</property>
-            <property name="text" translatable="yes">Today</property>
+            <property name="tooltip_text" translatable="yes">Start 2 days from now</property>
+            <property name="action_name">win.start_next_day_2</property>
+            <property name="text" translatable="no">label placeholder - in 2 days</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="defer_3_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Start 3 days from now</property>
+            <property name="action_name">win.start_next_day_3</property>
+            <property name="text" translatable="no">label placeholder - in 3 days</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="defer_4_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Start 4 days from now</property>
+            <property name="action_name">win.start_next_day_4</property>
+            <property name="text" translatable="no">label placeholder - in 4 days</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="defer_5_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Start 5 days from now</property>
+            <property name="action_name">win.start_next_day_5</property>
+            <property name="text" translatable="no">label placeholder - in 5 days</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="defer_6_btn">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Start 6 days from now</property>
+            <property name="action_name">win.start_next_day_6</property>
+            <property name="text" translatable="no">label placeholder - in 6 days</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -72,82 +132,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="defer_2_btn">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start 2 days from now</property>
-            <property name="action_name">win.start_next_day_2</property>
-            <property name="text" translatable="yes">Tuesday</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="defer_3_btn">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start 3 days from now</property>
-            <property name="action_name">win.start_next_day_3</property>
-            <property name="text" translatable="yes">Wednesday</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="defer_4_btn">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start 4 days from now</property>
-            <property name="action_name">win.start_next_day_4</property>
-            <property name="text" translatable="yes">Thursday</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="defer_5_btn">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start 5 days from now</property>
-            <property name="action_name">win.start_next_day_5</property>
-            <property name="text" translatable="yes">Friday</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
             <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="defer_6_btn">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Start 6 days from now</property>
-            <property name="action_name">win.start_next_day_6</property>
-            <property name="text" translatable="yes">Saturday</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -161,7 +146,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -174,7 +159,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">9</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -188,7 +173,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">10</property>
+            <property name="position">8</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
This is an attempt at resolving some of the consistency problems presented in issue #550.

It doesn't solve them _100%_ because I couldn't find a way to access the individual menu items in the right-click menus like you can with GtkPopover's menu button widget IDs, so I got stumped by that. I tried some things but they didn't work and they also looked like nasty hacks. If you have ideas/suggestions of how to achieve that easily (or maybe it's just possible in GTK4, if the menus changed there?...) I'd be happy to try them, but I think I've run out of patience for now. The existing changes should already be a noticeable improvement, and maybe someone else can come in to fix the remaining part (right-click menus) on top afterwards.

I have tested this to be working both in English and my locally translated version, so while this adds some new translatable strings, it should still be entirely translatable. I would probably provide an updated FR translation separately from this branch, afterwards.