### PR TITLE
Fix exception when trying to use calendar widget

### DIFF
--- a/GTG/gtk/editor/calendar.py
+++ b/GTG/gtk/editor/calendar.py
@@ -76,6 +76,7 @@ class GTGCalendar(GObject.GObject):
             date = Date.today()
         self.__date = date
         if not date.is_fuzzy():
+            date = date.date()
             self.__calendar.select_day(date.day)
             # Calendar use 0..11 for a month so we need -1
             # We can't use conversion through python's datetime


### PR DESCRIPTION
Fixes the "Pick a date" button next to the Tomorrow button dropdown
menu, or inside the menu when you right click on a task.

    Traceback (most recent call last):
      File "GTG/gtk/browser/main_window.py", line 1216, in on_set_due_for_specific_date
        self.calendar.set_date(date, GTGCalendar.DATE_KIND_DUE)
      File "GTG/gtk/editor/calendar.py", line 79, in set_date
        self.__calendar.select_day(date.day)
    AttributeError: 'Date' object has no attribute 'day'

Fixes #779, broken by the Date class rewrite. Using grep I tried to look for other places we missed to convert, but it seems this was the only location we overlooked.