### PR TITLE
Fix adaptive widget offset when maximized in gnome

### DIFF
--- a/GTG/gtk/browser/adaptive_button.py
+++ b/GTG/gtk/browser/adaptive_button.py
@@ -209,6 +209,11 @@ class AdaptiveFittingWidget(Gtk.Container):
         self.set_realized(True)
 
         allocation = self.get_allocation()
+        if self._spammy_debug:
+            log.debug("allocation={x=%r, y=%r, w=%r, h=%r}",
+                      allocation.x, allocation.y,
+                      allocation.width, allocation.height)
+
         attributes = Gdk.WindowAttr()
         attributes.window_type = Gdk.WindowType.CHILD
         attributes.x = allocation.x
@@ -233,8 +238,11 @@ class AdaptiveFittingWidget(Gtk.Container):
                       allocation.width, allocation.height)
 
         self.set_allocation(allocation)
+        Gtk.Container.do_size_allocate(self, allocation)  # Resizes Gdk.Window
+
         for ci in self._children:
             ci.widget.size_allocate(allocation)
+
         self._determine_and_save_active_child()
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
For some reason when using gnome-shell and maximizing GTG the widget
will be offset (just enough you can still see part of it outside the
button).

After reading more code it seems we need to resize the Gdk.Window when
doing size_allocation (which some of the GTK code doesn't do because it
was hidden behind some CSS helper functions it seems). We just call the
Gtk.Widget.do_size_allocation because they do it already for us.

Fixes #785