### PR TITLE
Fix crash when creating new profile in xml.py

### DIFF
--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -340,9 +340,9 @@ def skeleton() -> etree.Element:
 
     root = etree.Element('gtgData')
     # Bump this on each new GTG release, no matter what:
-    new_root.set('appVersion', '0.6')
+    root.set('appVersion', '0.6')
     # Bump this when there are known file format changes:
-    new_root.set('xmlVersion', '2')
+    root.set('xmlVersion', '2')
 
     etree.SubElement(root, 'taglist')
     etree.SubElement(root, 'searchlist')


### PR DESCRIPTION
Fixes #796
Caused by 3ab87019ab7d163aeb91db4728f95ef2424d8a23
Reproduction steps: `./launch -s completelynew`