### PR TITLE
Fix menu button alignment from plugins

### DIFF
--- a/GTG/plugins/export/export.py
+++ b/GTG/plugins/export/export.py
@@ -148,7 +148,7 @@ class ExportPlugin():
     def _init_gtk(self):
         """ Initialize all the GTK widgets """
         self.menu_item = Gtk.ModelButton()
-        self.menu_item.set_label(_("Export the tasks currently listed"))
+        self.menu_item.props.text = _("Export the tasks currently listed")
         self.menu_item.connect('clicked', self.show_dialog)
         self.menu_item.show()
         self.plugin_api.add_menu_item(self.menu_item)

--- a/GTG/plugins/hamster/hamster.py
+++ b/GTG/plugins/hamster/hamster.py
@@ -192,9 +192,9 @@ class HamsterPlugin():
         task_menu_item = Gtk.ModelButton()
         self.task_menu_items.update({task.get_id(): task_menu_item})
         if self.is_task_active(task.get_id()):
-            task_menu_item.set_label(self.STOP_ACTIVITY_LABEL)
+            task_menu_item.props.text = self.STOP_ACTIVITY_LABEL
         else:
-            task_menu_item.set_label(self.START_ACTIVITY_LABEL)
+            task_menu_item.props.text = self.START_ACTIVITY_LABEL
         task_menu_item.show_all()
         task_menu_item.connect('clicked', self.task_cb, plugin_api)
         plugin_api.add_menu_item(task_menu_item)

--- a/GTG/plugins/send_email/sendEmail.py
+++ b/GTG/plugins/send_email/sendEmail.py
@@ -37,7 +37,7 @@ class SendEmailPlugin():
         self.plugin_api = plugin_api
 
         self.menu_item = Gtk.ModelButton.new()
-        self.menu_item.set_label(_("Send via email"))
+        self.menu_item.props.text = _("Send via email")
         self.menu_item.connect("clicked", self.onTbTaskButton, plugin_api)
         self.plugin_api.add_menu_item(self.menu_item)
 

--- a/GTG/plugins/untouched_tasks/untouchedTasks.py
+++ b/GTG/plugins/untouched_tasks/untouchedTasks.py
@@ -60,7 +60,7 @@ class UntouchedTasksPlugin():
 
         self.builder.connect_signals(SIGNAL_CONNECTIONS_DIC)
         self.menu_item = Gtk.ModelButton.new()
-        self.menu_item.set_label(_("Add @untouched tag"))
+        self.menu_item.props.text = _("Add @untouched tag")
         self.menu_item.connect("clicked", self.add_untouched_tag)
 
     def activate(self, plugin_api):


### PR DESCRIPTION
It seems using Gtk.ModelButton.set_label() inserts a label widget, but
Gtk.ModelButton.props.text also adds a Gtk.Box around the label.

The first method makes the label centered, which looks out of place with
the other menu entries, but the latter does not. So just switch it out
to maintain consistency.

Interestingly, the dev console already uses the `text` property, so it
wasn't affected since it was already doing it correctly.

Fixes #800