### PR TITLE
Add new files to POTFILES.in for translation

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -21,9 +21,11 @@ GTG/gtk/data/preferences.ui
 GTG/gtk/data/task_editor.ui
 GTG/plugins/export/export.ui
 GTG/plugins/gamify/prefs.ui
+GTG/plugins/hamster/prefs.ui
 GTG/plugins/untouched_tasks/untouchedTasks.ui
 GTG/plugins/urgency_color/preferences.ui
 
+GTG/backends/backend_caldav.py
 GTG/backends/backend_localfile.py
 GTG/backends/backend_signals.py
 GTG/backends/generic_backend.py
@@ -86,6 +88,7 @@ GTG/gtk/editor/editor.py
 GTG/gtk/editor/recurring_menu.py
 GTG/gtk/editor/__init__.py
 GTG/gtk/editor/taskview.py
+GTG/gtk/errorhandler.py
 GTG/gtk/general_preferences.py
 GTG/gtk/__init__.py
 GTG/gtk/plugins.py
@@ -113,3 +116,4 @@ GTG/plugins/dev_console/console.py
 GTG/plugins/dev_console/utils.py
 GTG/plugins/gamify/gamify.py
 GTG/plugins/gamify/__init__.py
+GTG/plugins/hamster/hamster.py


### PR DESCRIPTION
I used the following command to find out some of the files:

    diff -u \
	<(sort po/POTFILES.in | egrep -v '\.ui|\.desktop') \
	<(grep -r '[^_]_(' GTG --files-with-matches --include='*.py' | sort) | xclip -in -selection clipboard

Fixes #799, at least they show up (but haven't checked whenever they also really are applied, just took a look at `po/gtg.pot` after `ninja -C .local_build/ gtg-pot gtg-update-po`)