### PR TITLE
Remove .gtg-plugin in ./launch.sh for translators

### DIFF
--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -75,8 +75,5 @@ Make sure to this AFTER COMMITING YOUR CHANGES!
 * During launching, it might complain about certain files not being found in [`po/POTFILES.in`][POTFILES.IN].
   It is safe to remove the lines from that file and re-run until it works.
   It would be useful to comment about that if you're submitting your translation, just in case.
-* Plugin related strings don't update after updating the translation.
-  The cause is unknown, but you can delete the plugin files to re-generate
-  them using the new translations: `rm -f .local_build/GTG/plugins/*.gtg-plugin`
 
 [POTFILES.IN]: ../../po/POTFILES.in

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -80,6 +80,7 @@ if [[ ! -d .local_build ]] || [[ ! -e .local_build/build.ninja ]]; then
 fi
 
 if [[ "$norun" -eq 0 ]]; then
+    rm -f .local_build/GTG/plugins/*.gtg-plugin # Regenerate for translations
     ninja -C .local_build install || exit $?
     if [ "$pydebug" = 1 ]; then
         # https://docs.python.org/3/library/devmode.html#devmode


### PR DESCRIPTION
More of a workaround since external build system setups (not
`./launch.sh`) still have the buggy behaviour.

From #729 as a suggested alternative workaround (and lastly mentioned in #799 because I forgot already).