### PR TITLE
E-mail plugin content fix

### DIFF
--- a/GTG/plugins/send_email/sendEmail.py
+++ b/GTG/plugins/send_email/sendEmail.py
@@ -58,7 +58,7 @@ class SendEmailPlugin():
             _("\nTags: %s") % (", ".join(task.get_tags_name())) + \
             _("\nSubtasks:\n%s") % (
                 "\n - ".join([i.get_title() for i in task.get_subtasks()])) + \
-            _("\nTask content:\n%s") % (task.get_excerpt())
+            _("\nTask content:\n%s") % (task.get_text())
 
         # Title contains the title and the start and due dates.
         title = _("Task: %(task_title)s") % {'task_title': task.get_title()}


### PR DESCRIPTION
Closing part of  #821

Allows to export task content via e-mail.