### PR TITLE
Skip ending dots in tags

### DIFF
--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 # Regex to find GTG's tags.
 # GTG Tags start with @ and can contain alphanumeric
 # characters and/or dashes
-TAG_REGEX = re.compile(r'\B\@\w+([\-\w+\.\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
+TAG_REGEX = re.compile(r'\B\@\w+(\.*[\-\w+(\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
 
 # Regex to find internal links
 # Starts with gtg:// followed by a UUID.

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 # Regex to find GTG's tags.
 # GTG Tags start with @ and can contain alphanumeric
 # characters and/or dashes
-TAG_REGEX = re.compile(r'\B\@\w+(\.*[\-\w+(\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
+TAG_REGEX = re.compile(r'\B\@\w+(\.*[\-\w+\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
 
 # Regex to find internal links
 # Starts with gtg:// followed by a UUID.


### PR DESCRIPTION
Fixes #807

Allows dots only to be used only inside tags, but not at the end, so tags can be clearly used in sentences like:

> will also appear when you select `@money`.

> I wish I have more `@time`...