### PR TITLE
Fixing export plugin PDF template

### DIFF
--- a/GTG/plugins/export/export_templates/script_pocketmod
+++ b/GTG/plugins/export/export_templates/script_pocketmod
@@ -27,9 +27,9 @@ pdflatex -interaction nonstopmode -output-directory $TMPFOLDER -jobname temp $SO
 PDFFILE=$TMPFOLDER/temp.pdf
 pdftk $PDFFILE cat 6 7 8 1 output $TMPFOLDER/seite6781.pdf   1>&2
 pdftk $PDFFILE cat 5 4 3 2 output $TMPFOLDER/seite5432.pdf   1>&2
-pdf90 $TMPFOLDER/seite5432.pdf --outfile $TMPFOLDER/seite5432-r.pdf      1>&2
-pdf90 $TMPFOLDER/seite5432-r.pdf --outfile $TMPFOLDER/seite5432-r2.pdf      1>&2
+pdfjam --angle 90 $TMPFOLDER/seite5432.pdf --outfile $TMPFOLDER/seite5432-r.pdf      1>&2
+pdfjam --angle 90 $TMPFOLDER/seite5432-r.pdf --outfile $TMPFOLDER/seite5432-r2.pdf      1>&2
 pdftk $TMPFOLDER/seite6781.pdf $TMPFOLDER/seite5432-r2.pdf cat output $TMPFOLDER/gesamt.pdf      1>&2
-pdfnup $TMPFOLDER/gesamt.pdf --nup 4x2 --landscape --outfile $OUTFILE      1>&2
+pdfjam $TMPFOLDER/gesamt.pdf --nup 4x2 --landscape --outfile $OUTFILE      1>&2
 rm -rf $TMPFOLDER      1>&2
 echo -n $OUTFILE


### PR DESCRIPTION
Fixes #831

Converting old wrapper scripts `pdf90` and `pdfnup` directly to `pdfjam`.

It works for me with default first-run task list, but please test with much more tasks, at least to fill the whole 8 pages.