### PR TITLE
Fixing PDF export plugin

### DIFF
--- a/GTG/plugins/export/export_templates/script_pocketmod
+++ b/GTG/plugins/export/export_templates/script_pocketmod
@@ -27,8 +27,7 @@ pdflatex -interaction nonstopmode -output-directory $TMPFOLDER -jobname temp $SO
 PDFFILE=$TMPFOLDER/temp.pdf
 pdftk $PDFFILE cat 6 7 8 1 output $TMPFOLDER/seite6781.pdf   1>&2
 pdftk $PDFFILE cat 5 4 3 2 output $TMPFOLDER/seite5432.pdf   1>&2
-pdfjam --angle 90 $TMPFOLDER/seite5432.pdf --outfile $TMPFOLDER/seite5432-r.pdf      1>&2
-pdfjam --angle 90 $TMPFOLDER/seite5432-r.pdf --outfile $TMPFOLDER/seite5432-r2.pdf      1>&2
+pdfjam --angle 180 $TMPFOLDER/seite5432.pdf --outfile $TMPFOLDER/seite5432-r2.pdf      1>&2
 pdftk $TMPFOLDER/seite6781.pdf $TMPFOLDER/seite5432-r2.pdf cat output $TMPFOLDER/gesamt.pdf      1>&2
 pdfjam $TMPFOLDER/gesamt.pdf --nup 4x2 --landscape --outfile $OUTFILE      1>&2
 rm -rf $TMPFOLDER      1>&2

--- a/GTG/plugins/export/export_templates/template_pocketmod.tex
+++ b/GTG/plugins/export/export_templates/template_pocketmod.tex
@@ -2,7 +2,6 @@
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{lmodern}
-\usepackage[ngerman]{babel}
 \usepackage{wasysym}
 \usepackage[margin=0.2cm]{geometry}
 \usepackage{mdwlist}


### PR DESCRIPTION
This commit completes the fix for #831 - follow up from #833.

Also dropping German language specific TeX option.

![gtg](https://user-images.githubusercontent.com/5439713/156895141-9fb51227-97a7-4e43-a1e5-bbda0ac496b4.png)

