### PR TITLE
Open tag panel by default

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -32,7 +32,7 @@ DEFAULTS = {
     'browser': {
         "bg_color_enable": True,
         "contents_preview_enable": False,
-        'tag_pane': False,
+        'tag_pane': True,
         "sidebar_width": 120,
         'collapsed_tasks': [],
         'expanded_tags': [],


### PR DESCRIPTION
Left panel seems to be important tool for managing tags, so I think it should be open by default. 

It's especially important for the first time users to see it. Opening panel is described in the initial guiding tasks, but let's make it as easy as possible to discover this important feature, even without getting through the guide.

Current initial state looks like this:
![Zrzut ekranu z 2022-03-06 11-49-44](https://user-images.githubusercontent.com/5439713/156919898-df089fe6-ec2f-4a7b-8e21-3c1ae4289922.png)

