### PR TITLE
Prefill new task with selected tags

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1008,9 +1008,8 @@ class MainWindow(Gtk.ApplicationWindow):
             return True
 
     def on_add_task(self, widget=None):
-        tags = [tag for tag in self.get_selected_tags(nospecial=True)
-                if tag.startswith('@')]
-
+        tags = [tag for tag in self.get_selected_tags(nospecial=True)]
+        
         task = self.req.new_task(tags=tags, newtask=True)
         uid = task.get_id()
         self.app.open_task(uid, new=True)


### PR DESCRIPTION
Fixes https://github.com/getting-things-gnome/gtg/issues/684

Removes unneeded condition line that checks if tag name includes `@` character. Actual tag names are chains that follow this character, it only acts as an indicator that the tag name starts here.