### PR TITLE
Sorting Actionable from most urgent due dates

### DIFF
--- a/GTG/gtk/browser/treeview_factory.py
+++ b/GTG/gtk/browser/treeview_factory.py
@@ -163,7 +163,7 @@ class TreeviewFactory():
             t1 = task1.get_due_date_constraint()
         if t2 == Date.no_date():
             t2 = task2.get_due_date_constraint()
-        return self.__date_comp_continue(task1, task2, order, t1, t2)
+        return self.__date_comp_continue(task1, task2, order, t2, t1)
 
     def sort_by_closeddate(self, task1, task2, order):
         t1 = task1.get_closed_date()


### PR DESCRIPTION
Related to https://github.com/getting-things-gnome/gtg/issues/859

Current sorting in Actionable view starts with no date tasks and most urgent dates go to the end, which means `today` might not be even visible. This simple patch reverses the sorting order of due date, so it starts with `today` tasks.