### PR TITLE
Plug new core

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -184,6 +184,23 @@ class BaseStore(GObject.Object):
             return len(self.lookup)
 
 
+    def refresh_lookup_cache(self) -> None:
+        """Refresh lookup cache."""
+
+        def add_children(nodes) -> None:
+            """Recursively add children to lookup."""
+
+            for n in nodes:
+                self.lookup[n.id] = n
+
+                if n.children:
+                    add_children(n.children)
+
+
+        self.lookup.clear()
+        add_children(self.data)
+
+
     def print_list(self) -> None:
         """Print the entre list of items."""
 

--- a/GTG/core/datastore2.py
+++ b/GTG/core/datastore2.py
@@ -38,6 +38,8 @@ import GTG.core.info as info
 
 from lxml import etree as et
 
+from typing import Optional
+
 
 log = logging.getLogger(__name__)
 
@@ -73,6 +75,8 @@ class Datastore2:
             'closed': {'all': 0, 'untagged': 0},
         }
 
+        self.data_path = None
+
 
     @property
     def mutex(self) -> threading.Lock:
@@ -107,6 +111,9 @@ class Datastore2:
             log.debug('Processed file %s in %.2fms',
                       path, (time() - bench_start) * 1000)
 
+        # Store path, so we can call save() on it
+        self.data_path = path
+
 
     def generate_xml(self) -> et.ElementTree:
         """Generate lxml element object with all data."""
@@ -132,9 +139,10 @@ class Datastore2:
                        encoding='UTF-8')
 
 
-    def save(self, path: str) -> None:
+    def save(self, path: Optional[str] = None) -> None:
         """Write GTG data file."""
 
+        path = path or self.data_path
         temp_file = path + '__'
         bench_start = 0
 

--- a/GTG/core/datastore2.py
+++ b/GTG/core/datastore2.py
@@ -667,10 +667,10 @@ class Datastore2:
                 task.add_tag(tag)
 
             if random_boolean():
-                task.toggle_status()
+                task.toggle_active()
 
             if random_boolean():
-                task.dismiss()
+                task.toggle_dismiss()
 
             for _ in range(random.randint(0, content_size)):
                 word = random_word(randint(4, 20))

--- a/GTG/core/datastore2.py
+++ b/GTG/core/datastore2.py
@@ -279,9 +279,10 @@ class Datastore2:
 
         now = time()
         day_in_secs = 86_400
+        basedir = os.path.dirname(path)
 
-        for filename in os.listdir(path):
-            filename = os.path.join(path, filename)
+        for filename in os.listdir(basedir):
+            filename = os.path.join(basedir, filename)
             filestamp = os.stat(filename).st_mtime
             filecompare = now - (days * day_in_secs)
 

--- a/GTG/core/datastore2.py
+++ b/GTG/core/datastore2.py
@@ -355,7 +355,6 @@ class Datastore2:
             try:
                 # Try making a new empty file and open it
                 self.first_run(path)
-                self.load_file(path)
 
             except IOError:
                 raise SystemError(f'Could not write a file at {path}')

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -448,18 +448,21 @@ class TaskStore(BaseStore):
             modified_date = SubElement(dates, 'modified')
             modified_date.text = str(task.date_modified)
 
-            done_date = SubElement(dates, 'done')
-            done_date.text = str(task.date_closed)
+            if task.status == Status.DONE:
+                done_date = SubElement(dates, 'done')
+                done_date.text = str(task.date_closed)
 
-            due_date = task.date_due
-            due_tag = 'fuzzyDue' if due_date.is_fuzzy() else 'due'
-            due = SubElement(dates, due_tag)
-            due.text = str(due_date)
+            if task.date_due:
+                due_date = task.date_due
+                due_tag = 'fuzzyDue' if due_date.is_fuzzy() else 'due'
+                due = SubElement(dates, due_tag)
+                due.text = str(due_date)
 
-            start_date = task.date_start
-            start_tag = 'fuzzyStart' if start_date.is_fuzzy() else 'start'
-            start = SubElement(dates, start_tag)
-            start.text = str(start_date)
+            if task.date_start:
+                start_date = task.date_start
+                start_tag = 'fuzzyStart' if start_date.is_fuzzy() else 'start'
+                start = SubElement(dates, start_tag)
+                start.text = str(start_date)
 
             subtasks = SubElement(element, 'subtasks')
 

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -327,10 +327,11 @@ class TaskStore(BaseStore):
         return self.lookup[tid]
 
 
-    def new(self, title: str, parent: UUID = None) -> Task2:
+    def new(self, title: str = None, parent: UUID = None) -> Task2:
         """Create a new task and add it to the store."""
 
         tid = uuid4()
+        title = title or _('New Task')
         task = Task2(id=tid, title=title)
         task.date_added = Date.now()
 

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -454,16 +454,12 @@ class TaskStore(BaseStore):
                 done_date.text = str(task.date_closed)
 
             if task.date_due:
-                due_date = task.date_due
-                due_tag = 'fuzzyDue' if due_date.is_fuzzy() else 'due'
-                due = SubElement(dates, due_tag)
-                due.text = str(due_date)
+                due = SubElement(dates, 'due')
+                due.text = str(task.date_due)
 
             if task.date_start:
-                start_date = task.date_start
-                start_tag = 'fuzzyStart' if start_date.is_fuzzy() else 'start'
-                start = SubElement(dates, start_tag)
-                start.text = str(start_date)
+                start = SubElement(dates, 'start')
+                start.text = str(task.date_start)
 
             subtasks = SubElement(element, 'subtasks')
 

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -116,7 +116,7 @@ class Task2(GObject.Object):
                 and can_start)
 
 
-    def toggle_status(self, propagate: bool = True) -> None:
+    def toggle_active(self, propagate: bool = True) -> None:
         """Toggle between possible statuses."""
 
         if self.status is Status.ACTIVE:
@@ -128,17 +128,30 @@ class Task2(GObject.Object):
             self.date_closed = Date.no_date()
 
             if self.parent and self.parent.status is not Status.ACTIVE:
-                self.parent.toggle_status(propagate=False)
+                self.parent.toggle_active(propagate=False)
 
         if propagate:
             for child in self.children:
-                child.toggle_status()
+                child.toggle_active()
 
 
-    def dismiss(self) -> None:
+    def toggle_dismiss(self, propagate: bool = True) -> None:
         """Set this task to be dismissed."""
 
-        self.set_status(Status.DISMISSED)
+        if self.status is Status.ACTIVE:
+            self.status = Status.DISMISSED
+            self.date_closed = Date.today()
+
+        else:
+            self.status = Status.ACTIVE
+            self.date_closed = Date.no_date()
+
+            if self.parent and self.parent.status is not Status.ACTIVE:
+                self.parent.toggle_active(propagate=False)
+
+        if propagate:
+            for child in self.children:
+                child.toggle_active()
 
 
     def set_status(self, status: Status) -> None:

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -502,7 +502,7 @@ class TaskStore(BaseStore):
             for t in self.data:
                 tags = [_tag for _tag in t.tags]
 
-                # Include the tag's childrens
+                # Include the tag's children
                 for _tag in t.tags:
                     for child in _tag.children:
                         tags.append(child)

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -142,16 +142,16 @@ class Task2(GObject.Object):
             self.status = Status.DISMISSED
             self.date_closed = Date.today()
 
-        else:
+        elif self.status is Status.DISMISSED:
             self.status = Status.ACTIVE
             self.date_closed = Date.no_date()
 
             if self.parent and self.parent.status is not Status.ACTIVE:
-                self.parent.toggle_active(propagate=False)
+                self.parent.toggle_dismiss(propagate=False)
 
         if propagate:
             for child in self.children:
-                child.toggle_active()
+                child.toggle_dismiss()
 
 
     def set_status(self, status: Status) -> None:

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -374,7 +374,7 @@ class Application(Gtk.Application):
         """Callback to mark a task as done."""
 
         try:
-            self.get_active_editor().dismiss()
+            self.get_active_editor().toggle_dismiss()
         except AttributeError:
             self.browser.on_dismiss_task()
     

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -113,7 +113,7 @@ class Application(Gtk.Application):
 
             # Load default file
             data_file = os.path.join(DATA_DIR, 'gtg_data.xml')
-            self.ds.load_file(data_file)
+            self.ds.find_and_load_file(data_file)
 
             # TODO: Remove this once the new core is stable
             self.ds.data_path = os.path.join(DATA_DIR, 'gtg_data2.xml')

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -25,6 +25,10 @@ import sys
 import logging
 import urllib.parse  # GLibs URI functions not available for some reason
 
+
+from GTG.core.dirs import DATA_DIR
+from GTG.core.datastore2 import Datastore2
+
 from GTG.gtk.browser.delete_task import DeletionUI
 from GTG.gtk.browser.main_window import MainWindow
 from GTG.gtk.editor.editor import TaskEditor
@@ -47,6 +51,9 @@ log = logging.getLogger(__name__)
 
 
 class Application(Gtk.Application):
+
+    ds: Datastore2 = Datastore2()
+    """Datastore loaded with the default data file"""
 
     # Requester
     req = None
@@ -103,6 +110,10 @@ class Application(Gtk.Application):
         try:
             Gtk.Application.do_startup(self)
             Gtk.Window.set_default_icon_name(self.props.application_id)
+
+            # Load default file
+            data_file = os.path.join(DATA_DIR, 'gtg_data.xml')
+            self.ds.load_file(data_file)
 
             # Register backends
             datastore = DataStore()

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -653,6 +653,11 @@ class Application(Gtk.Application):
 
         self.save_plugin_settings()
 
+        # TODO: Save and load from the same file once the
+        # new core is fully tested
+        data_file = os.path.join(DATA_DIR, 'gtg_data2.xml')
+        self.ds.save(data_file)
+
         if self.req is not None:
             # Save data and shutdown datastore backends
             self.req.save_datastore(quit=True)

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -115,6 +115,9 @@ class Application(Gtk.Application):
             data_file = os.path.join(DATA_DIR, 'gtg_data.xml')
             self.ds.load_file(data_file)
 
+            # TODO: Remove this once the new core is stable
+            self.ds.data_path = os.path.join(DATA_DIR, 'gtg_data2.xml')
+
             # Register backends
             datastore = DataStore()
 
@@ -652,11 +655,7 @@ class Application(Gtk.Application):
         """Callback when GTG is closed."""
 
         self.save_plugin_settings()
-
-        # TODO: Save and load from the same file once the
-        # new core is fully tested
-        data_file = os.path.join(DATA_DIR, 'gtg_data2.xml')
-        self.ds.save(data_file)
+        self.ds.save()
 
         if self.req is not None:
             # Save data and shutdown datastore backends

--- a/GTG/gtk/browser/delete_tag.py
+++ b/GTG/gtk/browser/delete_tag.py
@@ -18,6 +18,7 @@
 
 
 from gi.repository import Gtk
+from GTG.core.tasks2 import Filter
 
 from gettext import gettext as _, ngettext
 
@@ -37,6 +38,15 @@ class DeleteTagsDialog():
 
         for tag in self.tags_todelete:
             self.req.delete_tag(tag)
+
+            # TODO: New Core
+            the_tag = self.browser.app.ds.tags.find(tag)
+            tasks = self.browser.app.ds.tasks.filter(Filter.TAG, the_tag)
+
+            for t in tasks:
+                t.remove_tag(tag)
+
+            self.browser.app.ds.tags.remove(the_tag.id)
 
         self.tags_todelete = []
 

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -43,6 +43,7 @@ from GTG.gtk.browser.treeview_factory import TreeviewFactory
 from GTG.gtk.editor.calendar import GTGCalendar
 from GTG.gtk.tag_completion import TagCompletion
 from GTG.core.dates import Date
+from GTG.core.tasks2 import Filter
 from GTG.gtk.browser.adaptive_button import AdaptiveFittingWidget # Register type
 
 log = logging.getLogger(__name__)
@@ -943,6 +944,13 @@ class MainWindow(Gtk.ApplicationWindow):
             self.req.delete_tag(tagname)
             tag = self.req.get_tag(tagname)
             self.app.reload_opened_editors(tag.get_related_tasks())
+
+            # TODO: New core
+            self.app.ds.tags.remove(self.app.ds.tags.find(tagname).id)
+            tasks = self.app.ds.tasks.filter(Filter.TAG, tagname)
+            for t in tasks:
+                t.remove_tag(tagname)
+
         self.tagtreeview.set_cursor(0)
         self.on_select_tag()
 
@@ -1012,6 +1020,14 @@ class MainWindow(Gtk.ApplicationWindow):
         
         task = self.req.new_task(tags=tags, newtask=True)
         uid = task.get_id()
+
+        # TODO: New core
+        new_task = self.app.ds.tasks.new()
+        new_task.id = uid
+
+        for t in tags:
+            new_task.add_tag(self.app.ds.tags.new(t))
+
         self.app.open_task(uid, new=True)
 
     def on_add_subtask(self, widget=None):
@@ -1026,6 +1042,10 @@ class MainWindow(Gtk.ApplicationWindow):
             # if the parent task is recurring, its child must be also.
             task.inherit_recursion()
 
+            # TODO: New core
+            t = self.app.ds.tasks.new(parent=uid)
+            t.tags = self.app.ds.tasks.get(uid).tags
+
             self.app.open_task(task.get_id(), new=True)
 
     def on_add_parent(self, widget=None):
@@ -1037,19 +1057,36 @@ class MainWindow(Gtk.ApplicationWindow):
                 # Switch parents
                 for p_tid in parents:
                     par = self.req.get_task(p_tid)
+
+                    # TODO: New core
+                    new_p = self.app.ds.tasks.get(p_tid)
+
                     if par.get_status() == Task.STA_ACTIVE:
                         new_parent = par.new_subtask()
+                        nc_parent = self.app.ds.tasks.new(parent=p_tid)
+                        nc_parent.id = new_parent.tid
+
                         for uid_task in selected_tasks:
                             # Make sure the task doesn't get deleted
                             # while switching parents
                             self.req.get_task(uid_task).set_to_keep()
                             par.remove_child(uid_task)
                             new_parent.add_child(uid_task)
+
+                            # TODO: New Core
+                            self.app.ds.tasks.unparent(uid_task, p_tid)
+                            self.app.ds.tasks.parent(uid_task, nc_parent.id)
+
             else:
                 # If the tasks have no parent already, no need to switch parents
                 new_parent = self.req.new_task(newtask=True)
                 for uid_task in selected_tasks:
                     new_parent.add_child(uid_task)
+
+                    # TODO: New Core
+                    t = self.app.ds.tasks.new()
+                    t.id = new_parent.tid
+                    self.app.ds.tasks.parent(uid_task, new_parent.tid)
 
             self.app.open_task(new_parent.get_id(), new=True)
 
@@ -1077,6 +1114,10 @@ class MainWindow(Gtk.ApplicationWindow):
         log.debug("going to delete %r", tids_todelete)
         self.app.delete_tasks(tids_todelete, self)
 
+        # TODO: New core core
+        for tid in tids_todelete:
+            self.app.ds.tasks.remove(tid)
+
     def update_start_date(self, widget, new_start_date):
         tasks = [self.req.get_task(uid)
                  for uid in self.get_selected_tasks()
@@ -1087,6 +1128,12 @@ class MainWindow(Gtk.ApplicationWindow):
         # FIXME:If the task dialog is displayed, refresh its start_date widget
         for task in tasks:
             task.set_start_date(start_date)
+
+        # TODO: New core
+        for uid in self.get_selected_tasks():
+            if uid:
+                t = self.app.ds.tasks.get(uid)
+                t.date_start = start_date
 
     def update_start_to_next_day(self, day_number):
         """Update start date to N days from today."""
@@ -1160,6 +1207,12 @@ class MainWindow(Gtk.ApplicationWindow):
         # FIXME: If the task dialog is displayed, refresh its due_date widget
         for task in tasks:
             task.set_due_date(due_date)
+
+        # TODO: New core
+        for uid in self.get_selected_tasks():
+            if uid:
+                t = self.app.ds.tasks.get(uid)
+                t.date_due = due_date
 
     def on_set_due_today(self, action, param):
         self.update_due_date(None, "today")
@@ -1302,6 +1355,11 @@ class MainWindow(Gtk.ApplicationWindow):
                 self.close_all_task_editors(uid)
                 GObject.idle_add(self.emit, "task-marked-as-done", task.get_id())
 
+        # TODO: New core
+        for uid in tasks_uid:
+            t = self.app.ds.tasks.get(uid)
+            t.toggle_active()
+
     def on_dismiss_task(self, widget=None):
         tasks_uid = [uid for uid in self.get_selected_tasks()
                      if uid is not None]
@@ -1315,6 +1373,12 @@ class MainWindow(Gtk.ApplicationWindow):
             else:
                 task.set_status(Task.STA_DISMISSED)
                 self.close_all_task_editors(uid)
+
+        # TODO: New core
+        for uid in tasks_uid:
+            t = self.app.ds.tasks.get(uid)
+            t.toggle_dismiss()
+
 
     def on_reopen_task(self, widget=None):
         tasks_uid = [uid for uid in self.get_selected_tasks()
@@ -1332,6 +1396,12 @@ class MainWindow(Gtk.ApplicationWindow):
                     parent.modified()
             elif status == Task.STA_DISMISSED:
                 task.set_status(Task.STA_ACTIVE)
+
+        # TODO: New core
+        for uid in tasks_uid:
+            t = self.app.ds.tasks.get(uid)
+            t.toggle_active()
+
 
     def reapply_filter(self, current_pane: str = None):
         if current_pane is None:

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -273,7 +273,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.closed_pane.add(self.vtree_panes['closed'])
 
         tag_completion = TagCompletion(self.req.get_tag_tree())
-        self.modifytags_dialog = ModifyTagsDialog(tag_completion, self.req)
+        self.modifytags_dialog = ModifyTagsDialog(tag_completion, self.req, self.app)
         self.modifytags_dialog.dialog.set_transient_for(self)
         self.deletetags_dialog = DeleteTagsDialog(self.req, self)
         self.calendar = GTGCalendar()

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -853,6 +853,15 @@ class MainWindow(Gtk.ApplicationWindow):
 
             self.quickadd_entry.set_text('')
 
+            # TODO: New Core
+            new_t = self.app.ds.tasks.new(data['title'])
+            new_t.date_start = data['start']
+            new_t.date_due = data['due']
+
+            for tag in data['tags']:
+                _tag = self.app.ds.tags.new(tag)
+                new_t.add_tag(_tag)
+
             # signal the event for the plugins to catch
             GLib.idle_add(self.emit, "task-added-via-quick-add", task.get_id())
         else:
@@ -1074,6 +1083,7 @@ class MainWindow(Gtk.ApplicationWindow):
                             new_parent.add_child(uid_task)
 
                             # TODO: New Core
+                            self.app.ds.tasks.refresh_lookup_cache()
                             self.app.ds.tasks.unparent(uid_task, p_tid)
                             self.app.ds.tasks.parent(uid_task, nc_parent.id)
 
@@ -1086,6 +1096,7 @@ class MainWindow(Gtk.ApplicationWindow):
                     # TODO: New Core
                     t = self.app.ds.tasks.new()
                     t.id = new_parent.tid
+                    self.app.ds.tasks.refresh_lookup_cache()
                     self.app.ds.tasks.parent(uid_task, new_parent.tid)
 
             self.app.open_task(new_parent.get_id(), new=True)

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -857,6 +857,9 @@ class MainWindow(Gtk.ApplicationWindow):
             new_t = self.app.ds.tasks.new(data['title'])
             new_t.date_start = data['start']
             new_t.date_due = data['due']
+            new_t.id = task.tid
+            self.app.ds.tasks.refresh_lookup_cache()
+
 
             for tag in data['tags']:
                 _tag = self.app.ds.tags.new(tag)

--- a/GTG/gtk/browser/modify_tags.py
+++ b/GTG/gtk/browser/modify_tags.py
@@ -97,6 +97,18 @@ class ModifyTagsDialog():
                     task.remove_tag(tag)
             task.sync()
 
+        # TODO: New Core
+        for tid in self.tasks:
+            t = self.app.ds.tasks.get(tid)
+
+            for tag, is_positive in tags:
+                _tag = self.app.ds.tags.new(tag)
+
+                if is_positive:
+                    t.add_tag(_tag)
+                else:
+                    t.remove_tag(_tag)
+
         self.app.ds.save()
 
         # Rember the last actions

--- a/GTG/gtk/browser/modify_tags.py
+++ b/GTG/gtk/browser/modify_tags.py
@@ -29,8 +29,9 @@ class ModifyTagsDialog():
     Dialog for batch adding/removal of tags
     """
 
-    def __init__(self, tag_completion, req):
+    def __init__(self, tag_completion, req, app):
         self.req = req
+        self.app = app
         self.tasks = []
 
         self._init_dialog()
@@ -95,6 +96,8 @@ class ModifyTagsDialog():
                 else:
                     task.remove_tag(tag)
             task.sync()
+
+        self.app.ds.save()
 
         # Rember the last actions
         self.last_tag_entry = self.tag_entry.get_text()

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -844,6 +844,14 @@ class TaskEditor:
         if self.config is not None:
             self.config.save()
         self.time = time.time()
+
+        # TODO: New core, remove previous code once stable
+        t = self.app.ds.tasks.get(self.task.tid)
+        t.title = self.textview.get_title()
+        t.contents = self.textview.get_text()
+        self.app.ds.save()
+
+
     # light_save save the task without refreshing every 30seconds
     # We will reduce the time when the get_text will be in another thread
 

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -101,7 +101,7 @@ class TaskEditor:
 
         # TODO: Remove old code when new core is stable
         # If new add to new DS
-        if thisisnew:
+        if thisisnew and task.tid not in self.app.ds.tasks.lookup.keys():
             new_task = Task2(task.tid, task.get_title())
             self.app.ds.tasks.add(new_task)
 

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -192,8 +192,8 @@ class TaskEditor:
         self.textview.rename_subtask_cb = self.rename_subtask
         self.textview.open_subtask_cb = self.open_subtask
         self.textview.save_cb = self.light_save
-        self.textview.add_tasktag_cb = task.tag_added
-        self.textview.remove_tasktag_cb = task.remove_tag
+        self.textview.add_tasktag_cb = self.tag_added
+        self.textview.remove_tasktag_cb = self.tag_removed
         self.textview.refresh_cb = self.refresh_editor
         self.textview.get_tagslist_cb = task.get_tags_name
         self.textview.tid = task.tid
@@ -273,6 +273,21 @@ class TaskEditor:
         self.textview.set_editable(True)
         self.window.set_transient_for(self.app.browser)
         self.window.show()
+
+
+    def tag_added(self, name):
+
+        self.task.tag_added(name)
+        t = self.app.ds.tasks.get(self.task.tid)
+        t.add_tag(self.app.ds.tags.new(name))
+
+
+    def tag_removed(self, name):
+
+        self.task.remove_tag(name)
+        t = self.app.ds.tasks.get(self.task.tid)
+        t.remove_tag(name)
+
 
     def show_popover_start(self, widget, event):
         """Open the start date calendar popup."""

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -379,7 +379,7 @@ class TaskView(GtkSource.View):
             log.warn('Failed to toggle status for %s', tid)
             return
 
-        task.toggle_status()
+        task.toggle_active()
         self.process()
 
 

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -379,7 +379,7 @@ class TaskView(GtkSource.View):
             log.warn('Failed to toggle status for %s', tid)
             return
 
-        task.toggle_active()
+        task.toggle_status()
         self.process()
 
 

--- a/tests/core/test_task2.py
+++ b/tests/core/test_task2.py
@@ -50,7 +50,7 @@ class TestTask2(TestCase):
         self.assertEqual(task.excerpt, expected)
 
 
-    def test_status(self):
+    def test_toggle_active_single(self):
         task = Task2(id=uuid4(), title='A Task')
 
         self.assertEqual(task.status, Status.ACTIVE)
@@ -59,20 +59,12 @@ class TestTask2(TestCase):
         self.assertEqual(task.status, Status.DONE)
         self.assertEqual(task.date_closed, Date.today())
 
-        task.toggle_dismiss()
-        self.assertEqual(task.status, Status.DISMISSED)
-        self.assertEqual(task.date_closed, Date.today())
-
         task.toggle_active()
         self.assertEqual(task.status, Status.ACTIVE)
         self.assertEqual(task.date_closed, Date.no_date())
 
-        task.toggle_dismiss()
-        self.assertEqual(task.status, Status.DISMISSED)
-        self.assertEqual(task.date_closed, Date.no_date())
-
-        task.toggle_active()
-
+    def test_toggle_active_children(self):
+        task = Task2(id=uuid4(), title='A Task')
         task2 = Task2(id=uuid4(), title='A Child Task')
         task.children.append(task2)
         task2.parent = task
@@ -89,13 +81,32 @@ class TestTask2(TestCase):
         self.assertEqual(task2.status, Status.ACTIVE)
         self.assertEqual(task2.date_closed, Date.no_date())
 
+
+    def test_toggle_dismiss_single(self):
+        task = Task2(id=uuid4(), title='A Task')
+
         task.toggle_dismiss()
         self.assertEqual(task.status, Status.DISMISSED)
-        self.assertEqual(task.date_closed, Date.no_date())
-        self.assertEqual(task2.status, Status.DISMISSED)
-        self.assertEqual(task2.date_closed, Date.no_date())
+        self.assertEqual(task.date_closed, Date.today())
 
-        task2.toggle_active()
+        task.toggle_dismiss()
+        self.assertEqual(task.status, Status.ACTIVE)
+        self.assertEqual(task.date_closed, Date.no_date())
+
+
+    def test_toggle_dismiss_children(self):
+        task = Task2(id=uuid4(), title='A Task')
+        task2 = Task2(id=uuid4(), title='A Child Task')
+        task.children.append(task2)
+        task2.parent = task
+
+        task.toggle_dismiss()
+        self.assertEqual(task.status, Status.DISMISSED)
+        self.assertEqual(task.date_closed, Date.today())
+        self.assertEqual(task2.status, Status.DISMISSED)
+        self.assertEqual(task2.date_closed, Date.today())
+
+        task.toggle_dismiss()
         self.assertEqual(task.status, Status.ACTIVE)
         self.assertEqual(task.date_closed, Date.no_date())
         self.assertEqual(task2.status, Status.ACTIVE)

--- a/tests/core/test_task2.py
+++ b/tests/core/test_task2.py
@@ -55,47 +55,47 @@ class TestTask2(TestCase):
 
         self.assertEqual(task.status, Status.ACTIVE)
 
-        task.toggle_status()
+        task.toggle_active()
         self.assertEqual(task.status, Status.DONE)
         self.assertEqual(task.date_closed, Date.today())
 
-        task.dismiss()
+        task.toggle_dismiss()
         self.assertEqual(task.status, Status.DISMISSED)
         self.assertEqual(task.date_closed, Date.today())
 
-        task.toggle_status()
+        task.toggle_active()
         self.assertEqual(task.status, Status.ACTIVE)
         self.assertEqual(task.date_closed, Date.no_date())
 
-        task.dismiss()
+        task.toggle_dismiss()
         self.assertEqual(task.status, Status.DISMISSED)
         self.assertEqual(task.date_closed, Date.no_date())
 
-        task.toggle_status()
+        task.toggle_active()
 
         task2 = Task2(id=uuid4(), title='A Child Task')
         task.children.append(task2)
         task2.parent = task
 
-        task.toggle_status()
+        task.toggle_active()
         self.assertEqual(task.status, Status.DONE)
         self.assertEqual(task.date_closed, Date.today())
         self.assertEqual(task2.status, Status.DONE)
         self.assertEqual(task2.date_closed, Date.today())
 
-        task.toggle_status()
+        task.toggle_active()
         self.assertEqual(task.status, Status.ACTIVE)
         self.assertEqual(task.date_closed, Date.no_date())
         self.assertEqual(task2.status, Status.ACTIVE)
         self.assertEqual(task2.date_closed, Date.no_date())
 
-        task.dismiss()
+        task.toggle_dismiss()
         self.assertEqual(task.status, Status.DISMISSED)
         self.assertEqual(task.date_closed, Date.no_date())
         self.assertEqual(task2.status, Status.DISMISSED)
         self.assertEqual(task2.date_closed, Date.no_date())
 
-        task2.toggle_status()
+        task2.toggle_active()
         self.assertEqual(task.status, Status.ACTIVE)
         self.assertEqual(task.date_closed, Date.no_date())
         self.assertEqual(task2.status, Status.ACTIVE)
@@ -458,9 +458,9 @@ class TestTask2(TestCase):
         task3 = task_store.new('My Other Other Task')
         task4 = task_store.new('My Other Other Other Task')
 
-        task1.toggle_status()
-        task2.dismiss()
-        task3.toggle_status()
+        task1.toggle_active()
+        task2.toggle_dismiss()
+        task3.toggle_active()
 
         filtered = task_store.filter(Filter.STATUS, Status.ACTIVE)
         expected = [task4]


### PR DESCRIPTION
Another preparation step for a larger branch. This PR plugs the new core into the actual app. 
The new core works alongside the old one, it reads the `gtg_data.xml` file but saves to `gtg_data2.xml`. This lets us verify that both cores are producing the same files (or at least similar enough).

This PR also includes a few bug fixes and improvements to the core.
There's still _a lot_ to do, but this pull is a solid stepping stone. No changes in here are visible to users.

For now on, the new datastore can be accessed through `app.ds` in the developer console.