### PR TITLE
Add Snap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,58 @@
+name: getting-things-gnome
+base: core20
+compression: lzo
+grade: stable
+license: GPL-3.0
+adopt-info: gtg
+confinement: strict
+
+apps:
+  gtg:
+    command: usr/bin/gtg
+    extensions: [gnome-3-38]
+    environment:
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+    common-id: org.gnome.GTG
+    plugs: [network]
+    slots: [dbus-service]
+ 
+slots:
+  dbus-service:
+    interface: dbus
+    name: org.gnome.GTG
+    bus: session
+
+parts:
+  gtg:
+    source: .
+    plugin: meson
+    build-environment: [PYTHONPATH: '']
+    build-packages: [gettext, itstool]
+    meson-parameters: [--prefix=/usr]
+    parse-info: [usr/share/metainfo/org.gnome.GTG.appdata.xml]
+    stage-packages:
+      - python3-caldav
+      - python3-dateutil
+      - python3-dbus
+      - python3-lxml
+      - python3-vobject
+    stage:
+        - usr/bin/gtg
+        - usr/lib/python3/
+        - usr/share/
+        - -usr/share/doc/
+        - -usr/share/lintian/
+        - -usr/share/man/
+
+  liblarch:
+    source: https://github.com/getting-things-gnome/liblarch
+    source-tag: v3.2.0
+    source-type: git    
+    plugin: python
+    build-environment:
+      - SNAPCRAFT_PYTHON_INTERPRETER: python3.8
+      - PATH: $SNAPCRAFT_PART_INSTALL/bin:$PATH
+      - PYTHONPATH: ''
+    organize:
+      lib/python3.8/site-packages/liblarch*: usr/lib/python3/dist-packages/
+    stage: [usr/lib/python3/dist-packages, -usr/lib/python3/dist-packages/liblarch*/__pycache__]


### PR DESCRIPTION
Add Snap support

The Snap uses metadata from AppData, so it always gets the latest version, summary, description and so on, so no need to edit the file each new release.

The version of liblarch is hard-coded.

To generate the .snap file, you just have to clone the repository with my PR in it and execute `snapcraft` command in the project root directory.

The last remain question about the support is how to publish in the Snap Store in an official way, similarly to how Flatpak is published.

Please help me to test. I don't have a CalDAV server to test CalDAV backend, for instance. I allowed network communication so I think it will be enough.

Closes #872