### PR TITLE
Fix collaborative calendar tags

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -39,7 +39,7 @@ from vobject import iCalendar
 
 logger = logging.getLogger(__name__)
 # found elsewhere, should be factorized
-TAG_REGEX = re.compile(r'\B@\w+[-_\w]*')
+TAG_REGEX = re.compile(r'\B@\w+[-_()\w]*')
 MAX_CALENDAR_DEPTH = 500
 DAV_TAG_PREFIX = 'DAV_'
 


### PR DESCRIPTION
Since CalDav sync is still very wonky and in fact deleted all of my tasks (luckily I managed to restore all of them) I decided to only connect GTG to shared calendar and log with separate account (very easy to set up in Nextcloud).

The problem that I noticed was, that for shared calendars the identifying tag would be of format `@DAV_NAME_(user)` and with every sync the part `(user)` would be multiplied to the next line effecting in absolute madness of a spam at the top of every task.

This should fix the issue.