### PR TITLE
Uniformizing error message and error message formatting

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -224,7 +224,7 @@ class Backend(PeriodicImportBackend):
             BackendSignals().interaction_requested(
                 self.get_id(), f"{message} {error!r}",
                 BackendSignals().INTERACTION_INFORM, "on_continue_clicked")
-            raise error
+            raise
         for calendar in principal.calendars():
             self._cache.set_calendar(calendar)
 

--- a/GTG/backends/generic_backend.py
+++ b/GTG/backends/generic_backend.py
@@ -406,7 +406,7 @@ class GenericBackend():
             elif param_value == "False":
                 return False
             else:
-                raise Exception(f"Unrecognized bool value '{param_type}'")
+                raise Exception(f"Unrecognized bool value {param_type!r}")
         elif param_type == cls.TYPE_PASSWORD:
             if param_value == -1:
                 return None
@@ -417,7 +417,7 @@ class GenericBackend():
                 the_list = [the_list]
             return the_list
         else:
-            raise NotImplemented(f"I don't know what type is '{param_type}'")
+            raise NotImplementedError(f"I don't know what type is {param_type!r}")
 
     def cast_param_type_to_string(self, param_type, param_value):
         """

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -46,7 +46,7 @@ class BaseStore(GObject.Object):
     # --------------------------------------------------------------------------
 
     def new(self) -> Any:
-        raise NotImplemented
+        raise NotImplementedError()
 
 
     def get(self, key: str) -> Any:
@@ -62,7 +62,7 @@ class BaseStore(GObject.Object):
             log.warn('Failed to add item with id %s, already added!',
                      item.id)
 
-            raise KeyError
+            raise KeyError(item.id)
 
         if parent_id:
             try:
@@ -156,7 +156,7 @@ class BaseStore(GObject.Object):
                           self.lookup[parent_id])
                 return
 
-        raise KeyError
+        raise KeyError()
 
 
     # --------------------------------------------------------------------------
@@ -164,11 +164,11 @@ class BaseStore(GObject.Object):
     # --------------------------------------------------------------------------
 
     def from_xml(self, xml: Element) -> Any:
-        raise NotImplemented
+        raise NotImplementedError()
 
 
     def to_xml(self) -> Element:
-        raise NotImplemented
+        raise NotImplementedError()
 
 
     # --------------------------------------------------------------------------

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -59,8 +59,8 @@ class BaseStore(GObject.Object):
         """Add an existing item to the store."""
 
         if item.id in self.lookup.keys():
-            log.warn('Failed to add item with id %s, already added!',
-                     item.id)
+            log.warning('Failed to add item with id %s, already added!',
+                        item.id)
 
             raise KeyError(item.id)
 
@@ -70,8 +70,8 @@ class BaseStore(GObject.Object):
                 item.parent = self.lookup[parent_id]
 
             except KeyError:
-                log.warn(('Failed to add item with id %s to parent %s, '
-                         'parent not found!'), item.id, parent_id)
+                log.warning('Failed to add item with id %s to parent %s, '
+                            'parent not found!', item.id, parent_id)
                 raise
 
         else:

--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -78,7 +78,7 @@ def open_config_file(config_file):
     if not os.path.exists(config_file):
         open(config_file, "w").close()
     if not os.access(config_file, os.R_OK | os.W_OK):
-        raise Exception("File " + config_file + " is a configuration file "
+        raise Exception(f"File {config_file} is a configuration file "
                         "for gtg, but it cannot be read or written. "
                         "Please check it")
     config = configparser.ConfigParser()
@@ -159,9 +159,8 @@ class SectionConfig():
                         error)
 
         if value is None and default_value is None:
-            raise ValueError(
-                'No valid configuration value or default value was '
-                'found for %s in %s'.format(option, self._section_name))
+            raise ValueError("No valid configuration value or default value "
+                             f"was found for {option} in {self._section_name}")
         elif value is None:
             return default_value
         else:

--- a/GTG/core/datastore2.py
+++ b/GTG/core/datastore2.py
@@ -216,13 +216,13 @@ class Datastore2:
             'closed': {'all': 0, 'untagged': 0},
         }
 
-        count_tasks(self.task_count['open'], 
+        count_tasks(self.task_count['open'],
                     self.tasks.filter(Filter.ACTIVE))
 
-        count_tasks(self.task_count['closed'], 
+        count_tasks(self.task_count['closed'],
                     self.tasks.filter(Filter.CLOSED))
 
-        count_tasks(self.task_count['actionable'], 
+        count_tasks(self.task_count['actionable'],
                     self.tasks.filter(Filter.ACTIONABLE))
 
 
@@ -357,7 +357,7 @@ class Datastore2:
                 self.first_run(path)
 
             except IOError:
-                raise SystemError(f'Could not write a file at {path}')
+                raise SystemError(f"Could not write a file at {path}")
 
 
     def purge(self, max_days: int) -> None:

--- a/GTG/core/dates.py
+++ b/GTG/core/dates.py
@@ -132,7 +132,7 @@ class Date:
         elif value in LOOKUP:
             self.dt_value = LOOKUP[value]
         if self.dt_value is None:
-            raise ValueError(f"Unknown value for date: '{value}'")
+            raise ValueError(f"Unknown value for date: {value!r}")
 
     @staticmethod
     def __parse_dt_str(string):
@@ -215,7 +215,7 @@ class Date:
         """
         if isinstance(other, timedelta):
             if is_comparison:
-                raise ValueError("can't compare with %r" % other)
+                raise ValueError(f"can't compare with {other!r}")
             return self.dt_value, other
         if not isinstance(other, self.__class__):
             other = self.__class__(other)
@@ -459,7 +459,7 @@ class Date:
         if result is not None:
             return cls(result)
         else:
-            raise ValueError(f"Can't parse date '{string}'")
+            raise ValueError(f"Can't parse date {string!r}")
 
     @staticmethod
     def date_in_the_next_month(mday, dt):
@@ -595,7 +595,7 @@ class Date:
         if result is not None:
             return Date(result)
         else:
-            raise ValueError(f"Can't parse date '{string}'")
+            raise ValueError(f"Can't parse date {string!r}")
 
     def to_readable_string(self):
         """ Return nice representation of date.

--- a/GTG/core/search.py
+++ b/GTG/core/search.py
@@ -151,8 +151,8 @@ def _tokenize_query(query):
         if token_type != 'space':
             yield token_type, token_value
     if pos != len(query):
-        raise InvalidQuery('tokenizer stopped at pos %r of %r left of "%s"' % (
-            pos, len(query), query[pos:pos + 10]))
+        raise InvalidQuery(f"tokenizer stopped at pos {pos!} of {len(query)} "
+                           f"left of {query[pos:pos + 10]!r}")
 
 
 def parse_search_query(query):
@@ -176,13 +176,14 @@ def parse_search_query(query):
 
         if require_date:
             if token not in ['date', 'word', 'literal']:
-                raise InvalidQuery(f"Unexpected token '{token}' after '{require_date}'")
+                raise InvalidQuery(f"Unexpected token {token!r} "
+                                   f"after {require_date!r}")
 
             value = value.strip('"')
             try:
                 date = Date.parse(value)
             except ValueError:
-                raise InvalidQuery(f"Date '{value}' in wrong format")
+                raise InvalidQuery(f"Date {value!r} in wrong format")
 
             cmd = (require_date, not_count % 2 == 0, date)
             require_date = None
@@ -216,7 +217,7 @@ def parse_search_query(query):
                 found = True
                 break
             if not found:
-                raise InvalidQuery(f"Unknown command !{value}")
+                raise InvalidQuery(f"Unknown command! {value!r}")
 
         elif token == 'tag':
             cmd = (token, not_count % 2 == 0, value.replace('@', ''))
@@ -238,7 +239,7 @@ def parse_search_query(query):
         raise InvalidQuery("Or is not allowed at the end of query")
 
     if require_date:
-        raise InvalidQuery(f"Required date after '{require_date}'")
+        raise InvalidQuery(f"Required date after {require_date!r}")
 
     return {'q': commands}
 

--- a/GTG/core/search.py
+++ b/GTG/core/search.py
@@ -151,7 +151,7 @@ def _tokenize_query(query):
         if token_type != 'space':
             yield token_type, token_value
     if pos != len(query):
-        raise InvalidQuery(f"tokenizer stopped at pos {pos!} of {len(query)} "
+        raise InvalidQuery(f"tokenizer stopped at pos {pos!r} of {len(query)} "
                            f"left of {query[pos:pos + 10]!r}")
 
 

--- a/GTG/core/tag.py
+++ b/GTG/core/tag.py
@@ -165,8 +165,7 @@ class Tag(TreeNode):
         """
         modified = False
         if att_name == "name":
-            raise KeyError(
-                "The name of tag cannot be set manually")
+            raise KeyError("The name of tag cannot be set manually")
         elif att_name == "parent":
             self.add_parent(att_value)
             modified = True

--- a/GTG/core/task.py
+++ b/GTG/core/task.py
@@ -50,7 +50,7 @@ class Task(TreeNode):
         # the id of this task in the project should be set
         # tid is a string ! (we have to choose a type and stick to it)
         if not isinstance(task_id, str):
-            raise ValueError("Wrong type for task_id %r", type(task_id))
+            raise ValueError(f"Wrong type for task_id {type(task_id)!r}")
         self.tid = task_id
         self.set_uuid(task_id)
         self.remote_ids = {}

--- a/GTG/core/tasks2.py
+++ b/GTG/core/tasks2.py
@@ -261,7 +261,7 @@ class Task2(GObject.Object):
             if tag not in self.tags:
                 self.tags.append(tag)
         else:
-            raise ValueError
+            raise ValueError(tag)
 
 
     def remove_tag(self, tag_name: str) -> None:

--- a/GTG/core/timer.py
+++ b/GTG/core/timer.py
@@ -142,8 +142,8 @@ class Timer(GObject.GObject):
             if not invalid_format:
                 return datetime.time(int(hour), int(minute))
             else:
-                raise ValueError('This time value or format\
-                                 is not allowed: {0}'.format(time))
+                raise ValueError("This time value or format "
+                                 f"is not allowed: {time!r}")
         else:
             # The final attempt to parse the input
             return datetime.datetime.strptime(time, '%X')

--- a/GTG/core/xml.py
+++ b/GTG/core/xml.py
@@ -77,7 +77,7 @@ def task_from_element(task, element: etree.Element):
     # Retrieving all dates
     dates = element.find('dates')
     done_date = None
-            
+
     # supporting old ways of salvaging fuzzy dates
     for key, get_date, set_date in (
             ('fuzzyDue', task.get_due_date, task.set_due_date),
@@ -95,7 +95,7 @@ def task_from_element(task, element: etree.Element):
         value = dates.find(key)
         if value is not None and value.text:
             set_date(Date(value.text))
-            
+
     return task
 
 
@@ -251,7 +251,7 @@ def open_file(xml_path: str, root_tag: str) -> etree.ElementTree:
             return open_file(xml_path, root_tag)
 
         except IOError:
-            raise SystemError(f'Could not write a file at {xml_path}')
+            raise SystemError(f"Could not write a file at {xml_path}")
 
 
 def write_backups(filepath: str) -> None:

--- a/GTG/gtk/errorhandler.py
+++ b/GTG/gtk/errorhandler.py
@@ -198,9 +198,8 @@ def errorhandler(func, context: str = None, ignorable: bool = True, reraise: boo
                 do_error_dialog(e, context, ignorable)
             except Exception:
                 log.exception("Exception occured while trying to show it")
-
             if reraise:
-                raise e
+                raise
             else:
                 log.debug("Not re-raising exception because it has been explicitly disabled: %r", e)
     return inner

--- a/GTG/plugins/export/export.py
+++ b/GTG/plugins/export/export.py
@@ -40,7 +40,7 @@ for dependence in "pdflatex", "pdftk", "pdfjam":
                              stderr=subprocess.DEVNULL,)
     if retval != 0:
         log.debug('Missing command %r', dependence)
-        raise ImportError(f'Missing command "{dependence}"')
+        raise ImportError(f"Missing command {dependence!r}")
 
 
 def get_desktop_dir():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,5 +19,5 @@ class MockTimer(MockThread):
         elif len(args) >= 2:
             super().__init__(target=args[1])
         else:
-            raise AssertionError("%s couldn't find delayed function call"
-                                 % self.__class__.__name__)
+            raise AssertionError(f"{self.__class__.__name__} couldn't find "
+                                 "delayed function call")


### PR DESCRIPTION
After launching GTG from flatpak I got an ill formatted error (showing `%s` instead of the proper values). It's due to a `raise ValueError` in `GTG/core/config.py`. After looking at that I started just fixing and uniformizing the error message formatting across GTG. Here's what's in the PR : 
* uniformizing error message formating :
  * using the same string formatting mechanism
* raise `NotImplementedError` not `NotImplemented` which isn't an exception
```
>>> raise NotImplemented
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: exceptions must derive from BaseException
```
* do not explicitly reraise current error in an `except:` block, juste use bare `raise` statement
* raise error objects, not classes

Edit: encountered same error than #877