### PR TITLE
Disable config parser interpolation

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -81,7 +81,7 @@ def open_config_file(config_file):
         raise Exception("File " + config_file + " is a configuration file "
                         "for gtg, but it cannot be read or written. "
                         "Please check it")
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     try:
         config.read(config_file)
     except configparser.Error as e:

--- a/GTG/gtk/errorhandler.py
+++ b/GTG/gtk/errorhandler.py
@@ -161,7 +161,7 @@ def _collect_flatpak_info() -> Optional[dict]:
     Returns None if not running in a flatpak.
     """
     try:
-        fconfig = configparser.ConfigParser()
+        fconfig = configparser.ConfigParser(interpolation=None)
         if fconfig.read('/.flatpak-info') == []:
             return None
         d = {}


### PR DESCRIPTION
Fixes trying to store values which contains a percent sign (%).
For example, for some reason Task IDs could contain those and this would
throw an error when trying to assign to the configuration value for
currently opened tasks.

Also done for errorhandler reading flatpak info just in case.

See https://docs.python.org/3/library/configparser.html#interpolation-of-values

Fixes #914
