### PR TITLE
Add libsecret to dependencies readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ git pull --rebase
 * lxml
 * itstool
 * gettext
+* GtkSourceView (>= 4.0)
 * libsecret
 * Introspection (GIR) files and libraries from:
   - GLib

--- a/README.md
+++ b/README.md
@@ -46,22 +46,24 @@ git pull --rebase
 * lxml
 * itstool
 * gettext
+* libsecret
 * Introspection (GIR) files and libraries from:
   - GLib
   - pango
   - gdk-pixbuf
   - GTK 3
   - GtkSourceView 4
+  - secret
 
 You can get most of those from your distribution packages:
 
 ```sh
 # On Fedora:
-sudo dnf install meson python3-cairo python3-gobject gtk3 itstool gettext python3-lxml
+sudo dnf install meson python3-cairo python3-gobject gtk3 itstool gettext python3-lxml libsecret
 # On Debian 10 (buster), you need to install the backported version, activate it with:
 echo 'deb http://deb.debian.org/debian buster-backports main' | sudo tee -a /etc/apt/sources.list
 # On Debian/Ubuntu:
-sudo apt install meson python3-gi-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml libgirepository1.0-dev
+sudo apt install meson python3-gi-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml libgirepository1.0-dev libsecret-1.0 gir1.2-secret-1
 ```
 
 liblarch may be harder to come by until distributions package the python3 version of it, alongside GTG 0.6+ itself.
@@ -73,7 +75,8 @@ pip3 install --user -e git+https://github.com/getting-things-gnome/liblarch.git#
 
 Alternatively, if you had checked out a specific version of liblarch that you want to test, in a parent folder for example (`../liblarch`), you could do: `pip3 install --user ../liblarch/` (you can later remove that with `pip3 uninstall liblarch` if you need to).
 
-Optional Dependencies:
+#### Optional Dependencies
+
 * [setproctitle](https://pypi.org/project/setproctitle/)
   (to set the process title when listing processes like `ps`)
 

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,13 @@ configure_file(
   configuration: wrapper_config,
 )
 
+# Check for some runtime dependencies so they are displayed with an "NO"
+# when building which could give the user an idea what could be missing.
+dep_glib = dependency('glib-2.0', required: false)
+dep_gtk = dependency('gtk+-3.0', required: false)
+dep_libsecret = dependency('libsecret-1', required: false)
+dep_gtksourceview = dependency('gtksourceview-4', required: false)
+
 subdir('GTG')
 subdir('data')
 subdir('po')


### PR DESCRIPTION
Technically not required, but typically desired so passwords work (such as when using CalDav backend).

Fixes #902