### PR TITLE
index backends by id, not by name

### DIFF
--- a/GTG/backends/__init__.py
+++ b/GTG/backends/__init__.py
@@ -138,8 +138,8 @@ class BackendFactory(Borg):
         config = CoreConfig()
         backends = []
 
-        for backend in config.get_all_backends():
-            settings = config.get_backend_config(backend)
+        for backend_id in config.get_all_backends():
+            settings = config.get_backend_config(backend_id)
             module = self.get_backend(settings.get('module'))
 
             # Skip this backend if it doesn't have a module
@@ -167,7 +167,11 @@ class BackendFactory(Borg):
                     # Parameter not found in config
                     pass
 
-            backend_data['backend'] = module.Backend(backend_data)
+            backend = backend_data['backend'] = module.Backend(backend_data)
+
+            # Rename configuration sections created by older versions of GTG
+            config.rename_backend_section(backend.get_name(), backend.get_id())
+
             backends.append(backend_data)
 
         return backends

--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -203,10 +203,14 @@ class SectionConfig(GObject.Object):
         self._save_function()
 
 
-class CoreConfig:
+class CoreConfig_:
     """ Class holding configuration to all systems and tasks """
 
+    _instance = None
+
     def __init__(self):
+        assert self._instance is None
+
         self._conf_path = os.path.join(CONFIG_DIR, 'gtg.conf')
         self._conf = open_config_file(self._conf_path)
 
@@ -215,6 +219,11 @@ class CoreConfig:
 
         self._backends_conf_path = os.path.join(CONFIG_DIR, 'backends.conf')
         self._backends_conf = open_config_file(self._backends_conf_path)
+
+    @classmethod
+    def get_instance(cls):
+        cls._instance = cls._instance or cls()
+        return cls._instance
 
     def save_gtg_config(self):
         self._conf.write(open(self._conf_path, 'w'))
@@ -254,3 +263,6 @@ class CoreConfig:
             self._backends_conf[backend],
             DEFAULTS['backend'],
             self.save_backends_config)
+
+def CoreConfig():
+    return CoreConfig_.get_instance()

--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -251,16 +251,25 @@ class CoreConfig_:
             DEFAULTS['task'],
             self.save_task_config)
 
+    def rename_backend_section(self, backend_name, backend_id):
+        """Rename section `backend_name` to `backend_id` if it exists."""
+        if backend_name in self._backends_conf:
+            assert backend_id not in self._backends_conf
+            self._backends_conf.add_section(backend_id)
+            for (k, v) in self._backends_conf[backend_name].items():
+                self._backends_conf.set(backend_id, k, v)
+            self._backends_conf.remove_section(backend_name)
+
     def get_all_backends(self):
         return self._backends_conf.sections()
 
-    def get_backend_config(self, backend):
-        if backend not in self._backends_conf:
-            self._backends_conf.add_section(backend)
+    def get_backend_config(self, backend_id):
+        if backend_id not in self._backends_conf:
+            self._backends_conf.add_section(backend_id)
 
         return SectionConfig(
-            f'Backend {backend}',
-            self._backends_conf[backend],
+            f'Backend {backend_id}',
+            self._backends_conf[backend_id],
             DEFAULTS['backend'],
             self.save_backends_config)
 


### PR DESCRIPTION
This allows GTG to have multiple backends of one kind at the same time.

* GTG/backends/__init__.py (BackendFactory.get_saved_backends_list): Rename
`backend` to `backend_id` for clarity.  Call `config.rename_backend_section` on
each backend for compatibility with previous versions of GTG.
* GTG/core/config.py (CoreConfig_.rename_backend_section): New function to
rename a config section (from backend name to backend ID).
(CoreConfig_.get_all_backends): Rename `backend` to `backend_id` for clarity.
* GTG/core/datastore.py (DataStore.save): Retrieve config section by backend id,
not by backend name.

Fixes #930.