### PR TITLE
Fix exception during tag removal

### DIFF
--- a/GTG/gtk/browser/adaptive_button.py
+++ b/GTG/gtk/browser/adaptive_button.py
@@ -276,7 +276,7 @@ class AdaptiveFittingWidget(Gtk.Container):
                 except Exception as e:
                     log.warning("Silenced exception: %r", e)
         except AttributeError as e: # ... object has no attribute '_children'
-            log.warning("Got error in for but it should've stay valid: %r", e)
+            log.warning("Got error in for but it should have stayed valid: %r", e)
 
     def do_child_type(self):
         log.debug("returning %r", Gtk.Widget.__gtype__)
@@ -293,4 +293,3 @@ class AdaptiveFittingWidget(Gtk.Container):
         # We don't have any child properties anyway
         log.debug("Unimplemented child=%r, property_id=%r, value=%r, pspec=%r",
                   child, property_id, value, pspec)
-

--- a/GTG/gtk/browser/modify_tags.py
+++ b/GTG/gtk/browser/modify_tags.py
@@ -107,7 +107,7 @@ class ModifyTagsDialog():
                 if is_positive:
                     t.add_tag(_tag)
                 else:
-                    t.remove_tag(_tag)
+                    t.remove_tag(_tag.name)
 
         self.app.ds.save()
 

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -14,7 +14,7 @@ Because of that, you may need to update the translation files manually.
 # Updating the translation files
 
 1. Follow the [readme][readme] to pull GTG and install the dependencies, especially meson and gettext.
-2. Run `./launch.sh` in the repository root at least once. The folder `.local_build` should've been generated and GTG should run. Exit GTG.
+2. Run `./launch.sh` in the repository root at least once. The folder `.local_build` should have been generated and GTG should run. Exit GTG.
 3. Run `ninja -C .local_build gtg-pot gtg-update-po` to update the translation files.
 
 [readme]: ../../README.md

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -272,7 +272,7 @@ class CalDAVTest(TestCase):
                 ('CHILD-PARENT', ['ROOT'], ['GRAND-CHILD'])):
             task = datastore.get_task(uid)
             self.assertEqual(children, CHILDREN_FIELD.get_dav(get_todo(uid)),
-                             "children should've been written by sync down")
+                             "children should have been written by sync down")
             self.assertEqual(children, task.get_children(),
                              "children missing from task")
             self.assertEqual(parents, PARENT_FIELD.get_dav(get_todo(uid)),


### PR DESCRIPTION
Task2.remove_tag() expects a string, not a tag object.

Also fix grammar in error message shown when this bug is triggered.  I think "should've" is not very easy for non-native English speakers, so I replaced all instances of it with the non-contracted form.