### PR TITLE
Fix deprecation warnings showing during testing

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -59,8 +59,8 @@ class BaseStore(GObject.Object):
         """Add an existing item to the store."""
 
         if item.id in self.lookup.keys():
-            log.warn('Failed to add item with id %s, already added!',
-                     item.id)
+            log.warning('Failed to add item with id %s, already added!',
+                        item.id)
 
             raise KeyError
 
@@ -70,8 +70,8 @@ class BaseStore(GObject.Object):
                 item.parent = self.lookup[parent_id]
 
             except KeyError:
-                log.warn(('Failed to add item with id %s to parent %s, '
-                         'parent not found!'), item.id, parent_id)
+                log.warning(('Failed to add item with id %s to parent %s, '
+                            'parent not found!'), item.id, parent_id)
                 raise
 
         else:

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -378,7 +378,7 @@ class TaskView(GtkSource.View):
         task = self.req.get_task(tid)
 
         if not task:
-            log.warn('Failed to toggle status for %s', tid)
+            log.warning('Failed to toggle status for %s', tid)
             return
 
         task.toggle_status()


### PR DESCRIPTION
https://github.com/getting-things-gnome/gtg/actions/runs/3289608770/jobs/5421351329#step:5:39

=============================== warnings summary =============================== tests/core/test_saved_search.py::TestSavedSearch::test_add_simple
  /home/runner/work/gtg/gtg/GTG/core/base_store.py:62: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn('Failed to add item with id %s, already added!',

tests/core/test_saved_search.py::TestSavedSearch::test_new_tree
  /home/runner/work/gtg/gtg/GTG/core/base_store.py:73: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn(('Failed to add item with id %s to parent %s, '

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html ======================= 169 passed, 2 warnings in 1.23s ========================