### PR TITLE
Quote SOURCEFILE in script_pocketmod to handle spaces in path

### DIFF
--- a/GTG/plugins/export/export_templates/script_pocketmod
+++ b/GTG/plugins/export/export_templates/script_pocketmod
@@ -22,8 +22,8 @@
 
 TMPFOLDER=`mktemp -d /tmp/pocketmod.XXXXXXXXXX`
 OUTFILE=`mktemp /tmp/pockemod.XXXXXXXXXXXXX`.pdf
-SOURCEFILE=$1
-pdflatex -interaction nonstopmode -output-directory $TMPFOLDER -jobname temp $SOURCEFILE  1>&2
+SOURCEFILE="$1"
+pdflatex -interaction nonstopmode -output-directory $TMPFOLDER -jobname temp "$SOURCEFILE"  1>&2
 PDFFILE=$TMPFOLDER/temp.pdf
 pdftk $PDFFILE cat 6 7 8 1 output $TMPFOLDER/seite6781.pdf   1>&2
 pdftk $PDFFILE cat 5 4 3 2 output $TMPFOLDER/seite5432.pdf   1>&2


### PR DESCRIPTION
The export script `GTG/plugins/export/export_templates/script_pocketmod` does not quote the input parameter `SOURCEFILE` which make it fails with spaces in this path.

This pull request adds quotes when reading the input argument and when using the variable as command argument.

Patch from the Debian package team:
https://salsa.debian.org/python-team/packages/gtg/-/blob/debian/master/debian/patches/quote_source_file_in_script_pocketmod.patch