### PR TITLE
Unknown macro .bu in man page

### DIFF
--- a/docs/gtg.1
+++ b/docs/gtg.1
@@ -8,15 +8,15 @@ for the GNOME desktop environment
 "Getting Things GNOME" (GTG) is a personal tasks and ToDo list organizer inspired by the "Getting Things Done" (GTD) methodology.
 .PP
 GTG is intended to help you track everything you need to do and need to know, from small tasks to large projects. GTG's user interface is designed to accommodate many workflows, with features such as:
-.bu
+.IP \(bu 2
 a very flexible tagging and searching system;
-.bu
+.IP \(bu 2
 natural language parsing and a free-form task text editor;
-.bu
+.IP \(bu 2
 projects/task dependencies (infinite sub-tasks), start dates and due dates;
-.bu
+.IP \(bu 2
 an "Actionable" tasks view mode to help you stay focused during your work;
-.bu
+.IP \(bu 2
 the ability to effortlessly defer tasks to common upcoming days, or to a custom date.
 .PP
 GTG is intended to help you track everything you need to do and need to know,


### PR DESCRIPTION
This pull request changes unknown macro .bu to valid groff syntax for bullet lists.

From the downstream debian package:
https://salsa.debian.org/python-team/packages/gtg/-/blob/debian/master/debian/patches/fix_man_page_bullet_list.patch