### PR TITLE
flatpak: Use currently checked out source for devel manifest

### DIFF
--- a/flatpak/org.gnome.GTG.json
+++ b/flatpak/org.gnome.GTG.json
@@ -127,8 +127,8 @@
       ],
       "buildsystem": "meson",
       "sources": [{
-        "type": "git",
-        "url": "https://github.com/getting-things-gnome/gtg"
+        "type": "dir",
+        "path": ".."
       }
       ]
     }


### PR DESCRIPTION
This makes it easier to run a dev build from the current source.