### PR TITLE
Register pytest test with meson

### DIFF
--- a/GTG/gtg.in
+++ b/GTG/gtg.in
@@ -70,10 +70,8 @@ if __name__ == "__main__":
     except ImportError:
         pass
 
-import gi
-gi.require_version('Gdk', '4.0')
-gi.require_version('Gtk', '4.0')
-gi.require_version('GtkSource', '5')
+from GTG import gi_version_requires
+gi_version_requires()
 
 
 # Monkey patch Gtk.CssProvider.load_from_data for backwards compatibility.

--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,13 @@ dep_gtk = dependency('gtk+-3.0', required: false)
 dep_libsecret = dependency('libsecret-1', required: false)
 dep_gtksourceview = dependency('gtksourceview-4', required: false)
 
+test(
+	'pytest',
+	python3,
+	args : ['-m', 'pytest', 'tests'],
+	workdir : meson.source_root()
+)
+
 subdir('GTG')
 subdir('data')
 subdir('po')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=append",
+]
+testpaths = [
+    "tests",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,8 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-import gi
+from GTG import gi_version_requires
 
+def pytest_collection(session):
+    gi_version_requires()
 
-def gi_version_requires():
-    """Load all required GObject introspection libraries. """
-    gi.require_version('Gdk', '4.0')
-    gi.require_version('Gtk', '4.0')
-    gi.require_version('GtkSource', '5')


### PR DESCRIPTION
This lets us run tests using the build system.
It also makes GNOME Builder display the test in its tests list so we can execute them from there.
