### PR TITLE
Properly maintain the task count in Tag.set_parent (fix #404)

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -222,7 +222,7 @@ class Datastore:
                 if not task.tags:
                     count['untagged'] += 1
 
-                for tag in task.tags:
+                for tag in { t for owned_tag in task.tags for t in [owned_tag] + owned_tag.get_ancestors() }:
                     val = count.get(tag.name, 0)
                     count[tag.name] = val + 1
 
@@ -244,6 +244,17 @@ class Datastore:
 
         count_tasks(self.task_count['actionable'], 
                     self.tasks.filter(Filter.ACTIONABLE))
+
+
+    def refresh_tag_stats(self) -> None:
+        """
+        Refresh the number of tasks for each tag.
+        """
+        self.refresh_task_count()
+        for tag_name in self.tags.get_all_tag_names():
+            tag = self.tags.find(tag_name)
+            self.refresh_task_for_tag(tag)
+            self.notify_tag_change(tag)
 
 
     def notify_tag_change(self, tag) -> None:

--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -27,7 +27,7 @@ import random
 import re
 
 from lxml.etree import Element, SubElement
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Set
 
 from GTG.core.base_store import BaseStore
 
@@ -163,6 +163,15 @@ class Tag(GObject.Object):
         self._task_count_closed = value
 
 
+    def get_ancestors(self) -> List['Tag']:
+        """Return all ancestors of this tag"""
+        ancestors = []
+        here = self
+        while here.parent:
+            here = here.parent
+            ancestors.append(here)
+        return ancestors
+
     def __hash__(self):
         return id(self)
         
@@ -207,6 +216,10 @@ class TagStore(BaseStore):
 
         return f'Tag Store. Holds {len(self.lookup)} tag(s)'
 
+    def get_all_tag_names(self) -> List[str]:
+        """Return all tag names."""
+        return list(self.lookup_names.keys())
+    
 
     def find(self, name: str) -> Tag:
         """Get a tag by name."""

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -586,7 +586,6 @@ class Sidebar(Gtk.ScrolledWindow):
 
     def drag_drop(self, target, value, x, y):
         """Callback when dropping onto a target"""
-
         dropped = target.get_widget().props.tag
 
         if not self.check_parent(value, dropped):
@@ -596,7 +595,10 @@ class Sidebar(Gtk.ScrolledWindow):
             self.ds.tags.unparent(value.id, value.parent.id)
         
         self.ds.tags.parent(value.id, dropped.id)
+        self.ds.refresh_tag_stats()
         self.ds.tags.tree_model.emit('items-changed', 0, 0, 0)
+        self.refresh_tags()
+        
 
 
     def drop_enter(self, target, x, y, user_data=None):
@@ -646,7 +648,8 @@ class Sidebar(Gtk.ScrolledWindow):
     def on_toplevel_tag_drop(self, drop_target, tag, x, y):
         if tag.parent:
             self.ds.tags.unparent(tag.id, tag.parent.id)
-
+            self.ds.refresh_tag_stats()
+            self.refresh_tags()
             try:
                 for expander in self.expanders:
                     expander.activate_action('listitem.toggle-expand')


### PR DESCRIPTION
Hi!

I am a newcomer. This PR fixes issue #404 .

Parent tag's task count was not updated when adding/removing children tags to them.
The problem is solved by overriding the `set_parent` method in the `Tag` class and introducing a `_get_ancestors`  helper method. 