### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1418,7 +1418,7 @@ class MainWindow(Gtk.ApplicationWindow):
         if self.tagtreeview:
             taglist = self.tagtreeview.get_selected_nodes()
         # If no selection, we display all
-        if not nospecial and (not taglist or len(taglist) < 0):
+        if not nospecial and (not taglist):
             taglist = ['gtg-tags-all']
         if nospecial:
             special = ['gtg-tags-all', 'gtg-tags-none',

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1418,7 +1418,7 @@ class MainWindow(Gtk.ApplicationWindow):
         if self.tagtreeview:
             taglist = self.tagtreeview.get_selected_nodes()
         # If no selection, we display all
-        if not nospecial and (not taglist):
+        if not nospecial and not taglist:
             taglist = ['gtg-tags-all']
         if nospecial:
             special = ['gtg-tags-all', 'gtg-tags-none',


### PR DESCRIPTION
In file: main_window.py, the comparison of Collection length creates a logical short circuit. I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.