### PR TITLE
Clicking on a saved search updates the search bar to match the saved search.

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1431,6 +1431,12 @@ class MainWindow(Gtk.ApplicationWindow):
         if current_pane is None:
             current_pane = self.get_selected_pane()
         filters = self.get_selected_tags()
+        # find all filters that are saved searches
+        filter_searched = [filter_name for filter_name in filters if filter_name.find('__SAVED_SEARCH_') != -1]
+        # if there are any saved search filters
+        if filter_searched:
+            # change the current search to match the first saved search text
+            self.search_entry.set_text(filter_searched[0][15:])
         filters.append(current_pane)
         vtree = self.req.get_tasks_tree(name=current_pane, refresh=False)
         # Re-applying search if some search is specified


### PR DESCRIPTION
Fixes issue #390

The approach is to have all saved searches act as restoring the search bar to when it was saved.