### PR TITLE
migrate from external mock package to stdlib unittest.mock

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,7 @@
 # Run unit tests script
 
 name: Unit Tests
-  
+
 on:
   push:
     branches: [ master ]
@@ -22,8 +22,7 @@ jobs:
         sudo apt-get update
         sudo apt install -y libgirepository1.0-dev gir1.2-gtk-3.0 libgtksourceview-4-dev
         pip install --user -e git+https://github.com/getting-things-gnome/liblarch.git#egg=liblarch
-        pip install --user pytest pycairo PyGObject caldav mock lxml
+        pip install --user pytest pycairo PyGObject caldav lxml
     - name: Run unit tests with Pytest
       run: |
         ./run-tests
-

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ To run the current testsuite, you need some additional packages (this list may b
 
 ```sh
 # On Fedora:
-sudo dnf install python3-pytest python3-pyflakes python3-spec python3-pycodestyle python3-mock
+sudo dnf install python3-pytest python3-pyflakes python3-spec python3-pycodestyle
 # On Ubuntu/Debian:
-sudo apt install python3-pytest python3-pyflakes python3-pep8 python3-pycodestyle python3-mock python3-caldav
+sudo apt install python3-pytest python3-pyflakes python3-pep8 python3-pycodestyle python3-caldav
 ```
 
 You will currently also need the optional plugin dependencies, as the tests don't automatically skip them. (Help welcome improving that!)

--- a/flatpak/python3-requirements-dev.yaml
+++ b/flatpak/python3-requirements-dev.yaml
@@ -88,13 +88,4 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
         sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
-  - name: python3-mock
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "mock" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/e6/88/8a05e7ad0bb823246b2add3d2e97f990c41c71a40762c8db77a4bd78eedf/mock-5.0.1-py3-none-any.whl
-        sha256: c41cfb1e99ba5d341fbcc5308836e7d7c9786d302f995b2c271ce2144dece9eb
 name: python3-requirements-dev

--- a/flatpak/requirements-dev.txt
+++ b/flatpak/requirements-dev.txt
@@ -3,4 +3,3 @@ caldav==0.8.0
 dbus-python==1.2.8
 git+https://github.com/getting-things-gnome/liblarch.git#egg=liblarch
 pytest
-mock

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -11,7 +11,7 @@ from GTG.backends.backend_caldav import (CATEGORIES, CHILDREN_FIELD,
 from GTG.core.datastore import DataStore
 from GTG.core.dates import LOCAL_TIMEZONE, Date
 from GTG.core.task import Task
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from tests.test_utils import MockTimer
 
 NAMESPACE = 'unittest'

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -19,7 +19,7 @@
 from unittest import TestCase
 import configparser
 
-from mock import patch, mock_open, Mock
+from unittest.mock import patch, mock_open, Mock
 
 from GTG.core.config import open_config_file, SectionConfig
 

--- a/tests/core/test_timer.py
+++ b/tests/core/test_timer.py
@@ -18,7 +18,7 @@
 
 import datetime
 
-from mock import patch
+from unittest.mock import patch
 from unittest import TestCase
 
 from GTG.core.timer import Timer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 
 class MockThread(Mock):


### PR DESCRIPTION
It was moved to the stdlib in python 3.3, and the PyPI version is a backport for python versions less than 3.3.