### PR TITLE
Fix tests

### DIFF
--- a/tests/core/test_tag.py
+++ b/tests/core/test_tag.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 
-from GTG.core.tag import Tag
+from GTG.core.tags import Tag
 
 
 class TestTag(TestCase):

--- a/tests/tools/test_tags.py
+++ b/tests/tools/test_tags.py
@@ -16,9 +16,10 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
+import unittest
 from unittest import TestCase
 
-from GTG.core.tag import extract_tags_from_text, parse_tag_list
+from GTG.core.tags import extract_tags_from_text
 
 
 class TestExtractTags(TestCase):
@@ -74,6 +75,8 @@ class TestExtractTags(TestCase):
         self.assertTags("@home&work", ["@home&work"])
 
 
+@unittest.skip('TODO these need to move now that parse_tag_list is inside'
+               ' ModifyTagsDialog')
 class TestParseTagList(TestCase):
     """ parse_tag_list """
 


### PR DESCRIPTION
Or start to..

Tests are very broken, with some test files not even importing https://github.com/getting-things-gnome/gtg/actions/runs/7966225770/job/21747114127

I'd like to first get to a point where the test suite is green again so we can add new tests when fixing bugs etc. Even if it means temporarily skipping a bunch of them - it's still better than having a test suite that's perpetually red :)

It isn't much right now, but I thought I'd share in case someone with more free time than me wants to give it a go as well.