### PR TITLE
Show parent's title & children count in "Open Parent" button tooltip

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -471,8 +471,17 @@ class TaskEditor(Gtk.Window):
         if self.task.parent:
             # Translators: Button label to open the parent task
             self.parent_button.set_label(_('Open Parent'))
-            # TODO: preview the parent task's title here:
-            self.parent_button.set_tooltip_markup(_('View the Parent Task'))
+            __tip_contents = _('View the Parent Task:')
+            __tip_contents += f'\n<small><i>{self.task.parent.title}</i></small>'
+            __nb_siblings = len(self.task.parent.children) - 1
+            if __nb_siblings > 0:
+                __tip_contents += "\n\n"
+                __tip_contents += ngettext('That parent task also has <b>%(nb)d</b> other child.',
+                                           'That parent task also has <b>%(nb)d</b> other children.',
+                                           __nb_siblings) % {'nb': __nb_siblings}
+
+            self.parent_button.set_tooltip_markup(__tip_contents)
+
         else:
             # Translators: Button label to add an new parent task
             self.parent_button.set_label(_('Add Parent'))


### PR DESCRIPTION
This allows checking at a glance if the current task blocks a project:

![Screenshot from 2024-02-28 02-34-09](https://github.com/getting-things-gnome/gtg/assets/479401/689198b8-bd49-40c7-aaa3-0062dfa4f0a9)

![Screenshot from 2024-02-28 02-02-19](https://github.com/getting-things-gnome/gtg/assets/479401/220a49e5-7255-42ef-af72-7f5323e62250)

![Screenshot from 2024-02-28 02-02-34](https://github.com/getting-things-gnome/gtg/assets/479401/614780b9-31a8-4629-9ed3-e02daa1fac68)

Fixes https://github.com/getting-things-gnome/gtg/issues/1027

---

Potentially, I could maybe also add another commit on top that recursively counts how many parent levels there are, and adds an extra line to say something like:

> In total, %d parent tasks are blocked by the current task.

…what do you think, would that extra info be helpful too, or too much?