### PR TITLE
Update flatpak runtime

### DIFF
--- a/.github/workflows/weekly_flatpak.yml
+++ b/.github/workflows/weekly_flatpak.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-41
+      image: bilelmoussaoui/flatpak-github-actions:gnome-45
       options: --privileged
     steps:
     - uses: actions/checkout@v2

--- a/flatpak/org.gnome.GTG.json
+++ b/flatpak/org.gnome.GTG.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTGDevel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "40",
+  "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "tags": ["devel", "development", "nightly"],

--- a/flatpak/python3-requirements-dev.yaml
+++ b/flatpak/python3-requirements-dev.yaml
@@ -1,4 +1,4 @@
-# Generated with flatpak-pip-generator --runtime=org.gnome.Sdk//40 --requirements-file requirements-dev.txt --yaml --ignore-installed=lxml --output python3-requirements-dev
+# Generated with flatpak-pip-generator --runtime=org.gnome.Sdk//45 --requirements-file requirements-dev.txt --yaml --ignore-installed=lxml --output python3-requirements-dev
 build-commands: []
 buildsystem: simple
 modules:
@@ -15,52 +15,67 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "lxml==4.5.2" --ignore-installed --no-build-isolation
+        --prefix=${FLATPAK_DEST} "lxml==4.9.4" --ignore-installed --no-build-isolation
     sources:
       - &id001
         type: file
-        url: https://files.pythonhosted.org/packages/2c/4d/3ec1ea8512a7fbf57f02dee3035e2cce2d63d0e9c0ab8e4e376e01452597/lxml-4.5.2.tar.gz
-        sha256: cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6
+        url: https://files.pythonhosted.org/packages/84/14/c2070b5e37c650198de8328467dd3d1681e80986f81ba0fea04fc4ec9883/lxml-4.9.4.tar.gz
+        sha256: b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e
   - name: python3-caldav
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "caldav==0.8.0" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "caldav==1.3.9" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/6a/99/6e7da5ea21e6d4aaa6c948e69bf76bc3d5ab2821cdec47c775b8059c206e/caldav-0.8.0-py3-none-any.whl
-        sha256: 378a57eebe96a33d8cdcec4a11229c5b959904c7a81b65f9354025a2ecbc5dab
+        url: https://files.pythonhosted.org/packages/f1/e0/0a3762eea7b1d4d855639f7eaee3a0006169fd79d86ae0c660ae5d1d4c60/caldav-1.3.9-py3-none-any.whl
+        sha256: 7c38f1def110809bd50acd3d648f6115b33b8f5395c457215b3b1147c70564d9
       - type: file
-        url: https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl
-        sha256: 4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+        url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+        sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
       - type: file
-        url: https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz
-        sha256: 34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5
+        url: https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz
+        sha256: f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5
       - type: file
-        url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
-        sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+        url: https://files.pythonhosted.org/packages/56/df/da62437403ceafea8e5b6a03ca08d4c574eb4d13eec6b5dc7018200696e5/icalendar-5.0.11-py3-none-any.whl
+        sha256: 81864971ac43a1b7d0a555dc1b667836ce59fc719a7f845a96f2f03205fb83b9
+      - type: file
+        url: https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl
+        sha256: c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
       - *id001
       - type: file
         url: https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl
         sha256: 961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
       - type: file
-        url: https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl
-        sha256: 64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
+        url: https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl
+        sha256: 328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319
       - type: file
-        url: https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl
-        sha256: aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
+        url: https://files.pythonhosted.org/packages/50/2e/840094f0635bab147fb429ab07352c9e9de142aeec82672ee3c6bdd7befa/recurring_ical_events-2.1.2-py3-none-any.whl
+        sha256: b510d6d46e54381df1d6b35fcf2a727b71ecc510c85701b15c57312a5f172eff
+      - type: file
+        url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl
+        sha256: 58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
+      - type: file
+        url: https://files.pythonhosted.org/packages/97/3f/c4c51c55ff8487f2e6d0e618dba917e3c3ee2caae6cf0fbb59c9b1876f2e/tzlocal-5.2-py3-none-any.whl
+        sha256: 49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8
+      - type: file
+        url: https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl
+        sha256: 450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
       - type: file
         url: https://files.pythonhosted.org/packages/da/ce/27c48c0e39cc69ffe7f6e3751734f6073539bf18a0cfe564e973a3709a52/vobject-0.9.6.1.tar.gz
         sha256: 96512aec74b90abb71f6b53898dd7fe47300cc940104c4f79148f0671f790101
+      - type: file
+        url: https://files.pythonhosted.org/packages/f0/e0/bb85ef1170f3d7fc6b5d14452426e14e0f6ec2e0650bb882895cbc8c43db/x_wr_timezone-0.0.6-py3-none-any.whl
+        sha256: 26d98b5f5ae190b68df8b9b9856c4867389956f5b295e0e14f632d7341b60f67
   - name: python3-dbus-python
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "dbus-python==1.2.8" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "dbus-python==1.2.18" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/3f/e7/4edb582d1ffd5ac3c84188deea32e960b5c8c0fe1da56ce70224f85ce542/dbus-python-1.2.8.tar.gz
-        sha256: abf12bbb765e300bf8e2a1b2f32f85949eab06998dbda127952c31cb63957b6f
+        url: https://files.pythonhosted.org/packages/b1/5c/ccfc167485806c1936f7d3ba97db6c448d0089c5746ba105b6eb22dba60e/dbus-python-1.2.18.tar.gz
+        sha256: 92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260
   - name: python3-pytest
     buildsystem: simple
     build-commands:
@@ -68,24 +83,15 @@ modules:
         --prefix=${FLATPAK_DEST} "pytest" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl
-        sha256: 29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836
-      - type: file
-        url: https://files.pythonhosted.org/packages/61/97/17ed81b7a8d24d8f69b62c0db37abbd8c0042d4b3fc429c73dab986e7483/exceptiongroup-1.1.1-py3-none-any.whl
-        sha256: 232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e
-      - type: file
         url: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
         sha256: b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
       - type: file
-        url: https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl
-        sha256: 714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2
+        url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl
+        sha256: 8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
       - type: file
-        url: https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl
-        sha256: 74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
+        url: https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl
+        sha256: 7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981
       - type: file
-        url: https://files.pythonhosted.org/packages/b2/68/5321b5793bd506961bd40bdbdd0674e7de4fb873ee7cab33dd27283ad513/pytest-7.2.2-py3-none-any.whl
-        sha256: 130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e
-      - type: file
-        url: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
-        sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
+        url: https://files.pythonhosted.org/packages/a7/ea/d0ab9595a0d4b2320483e634123171deaf50885e29d442180efcbf2ed0b2/pytest-8.0.2-py3-none-any.whl
+        sha256: edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096
 name: python3-requirements-dev

--- a/flatpak/requirements-dev.txt
+++ b/flatpak/requirements-dev.txt
@@ -1,5 +1,5 @@
-lxml==4.5.2
-caldav==0.8.0
-dbus-python==1.2.8
+lxml==4.9.4
+caldav==1.3.9
+dbus-python==1.2.18
 git+https://github.com/getting-things-gnome/liblarch.git#egg=liblarch
 pytest


### PR DESCRIPTION
This updates the runtime to Gnome Platform 45.
It required an update of a dependency (I forgot which one) so I updated them all.

Summary of version changes:

* Platform:       40 ->    45
* lxml:        4.5.2 -> 4.9.4
* caldav:      0.8.0 -> 1.3.9
* dbus-python: 1.2.8 -> 1.2.18