### PR TITLE
flatpak: Use currently checked out source for devel manifest

### DIFF
--- a/flatpak/org.gnome.GTG.json
+++ b/flatpak/org.gnome.GTG.json
@@ -39,8 +39,8 @@
       ],
       "buildsystem": "meson",
       "sources": [{
-        "type": "git",
-        "url": "https://github.com/getting-things-gnome/gtg"
+        "type": "dir",
+        "path": ".."
       }
       ]
     }


### PR DESCRIPTION
Currently the devel flatpak manifest "hardcodes" the git master branch as source.
This leads to the surprising effect that freshly hand-crafted flatpaks exclude the hottest local changes of the sources.

This change makes it easier to build and run all the hacks with the cli. 😎