### PR TITLE
Check if search is already saved to avoid duplicates 

### DIFF
--- a/GTG/core/saved_searches.py
+++ b/GTG/core/saved_searches.py
@@ -166,9 +166,10 @@ class SavedSearchStore(BaseStore):
         search_id = uuid4()
         search = SavedSearch(id=search_id, name=name, query=query)
 
-        self.data.append(search)
-        self.lookup[search_id] = search
-        self.model.append(search)
+        if not self.find(name):
+            self.data.append(search)
+            self.lookup[search_id] = search
+            self.model.append(search)
 
         return search
     


### PR DESCRIPTION
Fixes 1. problem from #1044

Saves search only if this name (=query) is not already saved to avoid duplicate searches.