### PR TITLE
Switch Dismiss/Undismiss buttons

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -342,7 +342,7 @@ class TaskEditor(Gtk.Window):
             )
             # this might cause problems with localization if it isn't translated
             # here the same
-            if name == (_("Undismiss") if dismissable else _("Dismiss")):
+            if name == (_("Dismiss") if dismissable else _("Undismiss")):
                 editor_menu_con_sec.remove(i)
                 return
             i += 1


### PR DESCRIPTION
Fixes #1043.

`Dismiss`/`Undismiss` buttons display is currently switched: active tasks have `Undismiss` button, while closed tasks have `Dismiss` button visible.

This is a problem with menu preparing logic - we are REMOVING items here instead of adding them, so we should reverse checking process:
- if state is dismissable and we find `Dismiss` item, all is good, so we should ignore it, not remove it
- the same if state is NOT dismissable and we find `Undismiss` item, all is good, so we should ignore it, not remove it

Simply swaping both item checks allows to remove proper item.