### PR TITLE
Tag regex refinement

### DIFF
--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 # Regex to find GTG's tags.
 # GTG Tags start with @ and can contain alphanumeric
 # characters and/or dashes
-TAG_REGEX = re.compile(r'\B\@\w+(\.*[\-\w+\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
+TAG_REGEX = re.compile(r'(?<!\/|\w)\@\w+(\.*[\-\w+\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
 
 # Regex to find internal links
 # Starts with gtg:// followed by a UUID.


### PR DESCRIPTION
Fixes #987

After replacing string `\B` with `(?<!\/|\w)` addresses like https://wikis.world/@announcements (@ inside URL) are not treated as tags any more.