### PR TITLE
Prepare to switch to `main` branch

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,9 +4,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ yelp docs/user_manual/C/index.page
 
 We need help bringing the test suite back online with updated tests (before the badge below can be moved back up in this readme file). Get in touch if you'd like to work on this.
 
-[![Build Status](https://travis-ci.org/getting-things-gnome/gtg.svg?branch=master)](https://travis-ci.org/getting-things-gnome/gtg)
+[![Build Status](https://travis-ci.org/getting-things-gnome/gtg.svg?branch=main)](https://travis-ci.org/getting-things-gnome/gtg)

--- a/docs/contributors/becoming a developer or maintainer.md
+++ b/docs/contributors/becoming a developer or maintainer.md
@@ -4,19 +4,19 @@ There are three levels of insanity: contributors (anyone), developers (addicts!)
 
 You don't need to be a "developer" or "maintainer" to contribute to the project.
 
-* With decentralized version control systems like Git, you don't need direct commit access to the main master branch to land your patches; you tell us about your plans/ideas and then work on them on your own branch, then simply ask for your branch to be reviewed when it's ready; if it indeed improves things and respects the standards mentioned in our coding style document, then it can get merged fairly quickly.
+* With decentralized version control systems like Git, you don't need direct commit access to the main main branch to land your patches; you tell us about your plans/ideas and then work on them on your own branch, then simply ask for your branch to be reviewed when it's ready; if it indeed improves things and respects the standards mentioned in our coding style document, then it can get merged fairly quickly.
 
 * If you end up doing this so often and with such high quality contributions that we can't be bothered to review your changes anymore, then we'll be happy to give you developer "direct commit" access.
 
 * Maintainers are pretty much the same thing as regular developers, just that they have administrative rights over the project's infrastructure (boring stuff, really). Pretty much nobody needs to be a maintainer/administrator, except those who intend to stick around for years and have a gluttony for pain.
 
-So if you simply want to contribute to the project, get started with [CONTRIBUTING.md](https://github.com/getting-things-gnome/gtg/blob/master/CONTRIBUTING.md) and read the contents of the docs/contributors/ folder.
+So if you simply want to contribute to the project, get started with [CONTRIBUTING.md](https://github.com/getting-things-gnome/gtg/blob/main/CONTRIBUTING.md) and read the contents of the docs/contributors/ folder.
 
 # Abilities of GTG developers (a.k.a. frequent contributors)
 
 GTG developers are frequent contributors who have requested more hands-on project management powers and responsibilities, such as:
 
- * "direct commit" access to the main "master" branch (and any other branch) of GTG;
+ * "direct commit" access to the main "main" branch (and any other branch) of GTG;
  * full admin powers on the bugs database (assigning, targetting, changing statuses, etc.);
  * ability to make releases;
  * ability to review and approve/reject merge requests from contributors and developers;
@@ -27,7 +27,7 @@ GTG developers are frequent contributors who have requested more hands-on projec
 
 You are contributing more and more to GTG and you think that having those superpowers would improve your ability to help the project move faster? Then find one of the GTG maintainers and ask them.
 
-Of course, we have to know you and trust you for your contributions. If you contribute code, we should have confidence that you are now a GTG master and that you've fully understood our coding rules. It usually means that your latest patches were all merged without any need to resubmit them.
+Of course, we have to know you and trust you for your contributions. If you contribute code, we should have confidence that you are now a GTG main and that you've fully understood our coding rules. It usually means that your latest patches were all merged without any need to resubmit them.
 
 Also, it has to make sense for you.
 

--- a/docs/contributors/bug reporting and triaging.md
+++ b/docs/contributors/bug reporting and triaging.md
@@ -19,7 +19,7 @@ Below are some clarifications on how we use it.
 
 First, see the dynamic [list of issue labels](https://github.com/getting-things-gnome/gtg/labels) and their descriptions. They serve to indicate statuses, components, priorities, etc. They are mostly self-explanatory, and that page allows you to easily click and search for related issues.
 
-In particular, "[low-hanging-fruit](https://github.com/getting-things-gnome/gtg/labels/low-hanging-fruit)" and "[patch-or-wont-happen](https://github.com/getting-things-gnome/gtg/labels/patch-or-wont-happen)" are labels that indicate issues that require new contributors to step in, or the issue is unlikely to get fixed. See [CONTRIBUTING.md](https://github.com/getting-things-gnome/gtg/blob/master/CONTRIBUTING.md) for an explanation and tips to get started.
+In particular, "[low-hanging-fruit](https://github.com/getting-things-gnome/gtg/labels/low-hanging-fruit)" and "[patch-or-wont-happen](https://github.com/getting-things-gnome/gtg/labels/patch-or-wont-happen)" are labels that indicate issues that require new contributors to step in, or the issue is unlikely to get fixed. See [CONTRIBUTING.md](https://github.com/getting-things-gnome/gtg/blob/main/CONTRIBUTING.md) for an explanation and tips to get started.
 
 ## "Priority" labels
 

--- a/docs/contributors/coding best practices.md
+++ b/docs/contributors/coding best practices.md
@@ -103,7 +103,7 @@ Obviously none of these are great situations to be in, but it happens.
 
 Ideally, commenting out a line of code should be a signal to yourself
 that one of these things has happened, that you probably should ask for help
-before merging it to master, and it should stay in a branch for now.
+before merging it to main, and it should stay in a branch for now.
 
 But that may not always be possible.  So more practically, when
 commenting out code please ALWAYS explain why you commented it out.

--- a/docs/contributors/contributing to the user manual.md
+++ b/docs/contributors/contributing to the user manual.md
@@ -13,7 +13,7 @@ The user manual is written in American English and can be translated to other la
 The best way to get started is to actually use the app. Test new features, become familiar with the UI and the names of each feature (Taskview, Task Editor, etc.), and think about how documentation can help make the user's experience even better. As a potential first-time user, review the documentation while you are using the app. If something seems confusing, or you think that you can improve what is written, then that is a good place to start!
 
 ## Submitting PRs
-Follow the same pull request (PR) process [that is documented here](https://github.com/getting-things-gnome/gtg/blob/master/docs/contributors/git%20workflow%20tips.md). Remember to use good, concise commit messages so that it is clear what you are updating. If your updates are due to an enhancement or bug that has an existing issue number, ensure that you reference that item in your PR.
+Follow the same pull request (PR) process [that is documented here](https://github.com/getting-things-gnome/gtg/blob/main/docs/contributors/git%20workflow%20tips.md). Remember to use good, concise commit messages so that it is clear what you are updating. If your updates are due to an enhancement or bug that has an existing issue number, ensure that you reference that item in your PR.
 
 # Updating the User Manual for a Release
 About a month prior to a release, start reviewing PRs and closed issues to see if the new features affect anything in the user manual. You can review [release milestones](https://github.com/getting-things-gnome/gtg/milestones) to help you view updates in a concise list. Review closed PRs and issues in the milestone for that release. You should look for anything that affects the UI, new plugins or sync services, and new keyboard shortcuts.
@@ -119,7 +119,7 @@ Any page that uses this `ui` element should include all of the following schemas
 ```
 
 ## Updating `meson.build`
-The [meson.build](https://github.com/getting-things-gnome/gtg/blob/master/docs/user_manual/meson.build) file that resides in the `user_manual` folder needs to contain all of the pages and media (e.g., images and videos) contained in the user manual. Ensure that all .page and .png files are listed in the `sources` or `media` sections accordingly. 
+The [meson.build](https://github.com/getting-things-gnome/gtg/blob/main/docs/user_manual/meson.build) file that resides in the `user_manual` folder needs to contain all of the pages and media (e.g., images and videos) contained in the user manual. Ensure that all .page and .png files are listed in the `sources` or `media` sections accordingly. 
 ## Building HTML Files
 Use the following command to build an HTML version for use outside of the packaged help project (e.g., in a blog):
 ```

--- a/docs/contributors/git workflow tips.md
+++ b/docs/contributors/git workflow tips.md
@@ -3,7 +3,7 @@ GTG uses [Git](https://git-scm.com) for versioning. It might be useful to take a
 
 # Getting the code
 
-Get the latest version of the GTG code [on GitHub](https://github.com/getting-things-gnome/gtg). We suggest forking the master branch at first (you can do this with the GitHub web interface). Then clone the forked repository from GitHub to your local computer:
+Get the latest version of the GTG code [on GitHub](https://github.com/getting-things-gnome/gtg). We suggest forking the main branch at first (you can do this with the GitHub web interface). Then clone the forked repository from GitHub to your local computer:
 
     $ git clone https://github.com/YOUR_GITHUB_USERNAME/gtg.git
 
@@ -20,7 +20,7 @@ You have your local copy of the code, so now, create a local branch of your loca
     $ cd path/to/gtg
     $ git checkout -b cool_new_feature
 
-When working with GitHub, it's a good idea to keep your local *master* branch as a pristine copy of master on GitHub.
+When working with GitHub, it's a good idea to keep your local *main* branch as a pristine copy of main on GitHub.
 
 Work on your desired improvements.
 You can then "add" (choose) and "commit" (save) your changes:
@@ -42,21 +42,21 @@ If your branch is solving specific reported issue, please include the number of 
 Refer to https://chris.beams.io/posts/git-commit/ (for example) for best practices for writing great Git commit messages.
 
 
-# What if the original master branch has changed?
+# What if the original main branch has changed?
 
-If the "master" branch has been updated while you were hacking, you can update your local master branch every now and then:
+If the "main" branch has been updated while you were hacking, you can update your local main branch every now and then:
 
-    $ git checkout master  # switch to your local master branch
-    $ git pull --rebase origin master  # update your local master branch to match
+    $ git checkout main  # switch to your local main branch
+    $ git pull --rebase origin main  # update your local main branch to match
     $ git checkout cool_new_feature  # go back to your branch
 
-You can then merge modifications from your local "master" branch to your local feature branch (while you are inside "cool_new_feature") with:
+You can then merge modifications from your local "main" branch to your local feature branch (while you are inside "cool_new_feature") with:
 
-    $ git merge master
+    $ git merge main
 
 Or if you know what you're doing,
 
-    $ git rebase -i master
+    $ git rebase -i main
 
 You may be interested in this video to understand how Git's interactive rebase works: https://youtube.com/watch?v=6WU4jKti_vo
 
@@ -69,6 +69,6 @@ Afterwards, you need to push your work to your own fork on GitHub (where cool_ne
 
     $ git push origin cool_new_feature
 
-When you have pushed your changes to your own repository on GitHub, you can do a pull request to merge your work with the original GTG master. To do this, go to your account on GitHub and click on "New Pull Request". Create a pull request and comment on the corresponding bug (open one at https://github.com/getting-things-gnome/gtg/issues/new if there wasn't one already).
+When you have pushed your changes to your own repository on GitHub, you can do a pull request to merge your work with the original GTG main. To do this, go to your account on GitHub and click on "New Pull Request". Create a pull request and comment on the corresponding bug (open one at https://github.com/getting-things-gnome/gtg/issues/new if there wasn't one already).
 
-See also our "coding best practices" guide included in our docs/contributors/ folder, as well as the [Git tips & tricks from the Pitivi project](https://gitlab.gnome.org/GNOME/pitivi/-/blob/master/docs/Git.md) as complementary reading.
+See also our "coding best practices" guide included in our docs/contributors/ folder, as well as the [Git tips & tricks from the Pitivi project](https://gitlab.gnome.org/GNOME/pitivi/-/blob/main/docs/Git.md) as complementary reading.

--- a/docs/contributors/profiling GTG for performance.md
+++ b/docs/contributors/profiling GTG for performance.md
@@ -78,4 +78,4 @@ shows what GTG does over time.
 flameprof -o gtg.svg gtg.prof
 ```
 
-![Generated image (not GTG)](https://raw.githubusercontent.com/brendangregg/FlameGraph/master/example-perf.svg)
+![Generated image (not GTG)](https://raw.githubusercontent.com/brendangregg/FlameGraph/main/example-perf.svg)

--- a/docs/contributors/release process and checklist.md
+++ b/docs/contributors/release process and checklist.md
@@ -13,7 +13,7 @@
 
 Tip: You can prepare the release commit in advance by setting both the authorship and commit date to the future planned release date and time, and keeping the commit sitting in your personal fork's branch, with a command such as: `GIT_AUTHOR_DATE='the date and time' GIT_COMMITTER_DATE='the date and time' git commit` (note that if you rebase the branch, you should also reuse that `GIT_COMMITTER_DATE` environment variable, otherwise your resulting rebased commit will have the rebase time set as the new commit date).
 
-Git accepts various dates formats (including ISO 8601), see its [documentation on date formats](https://github.com/git/git/blob/master/Documentation/date-formats.txt).
+Git accepts various dates formats (including ISO 8601), see its [documentation on date formats](https://github.com/git/git/blob/main/Documentation/date-formats.txt).
 
 
 # Release tagging (usually done by maintainers)

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -61,9 +61,9 @@ Update the repository to get the newest changes:
 
 Create a new branch (assumes that origin is the upstream repository, which is the default if you clone the upstream repository):
 
-    git switch -c my-translation-branch origin/master
+    git switch -c my-translation-branch origin/main
     # If git switch isn't available, use:
-    git branch my-translation-branch origin/master
+    git branch my-translation-branch origin/main
     git checkout my-translation-branch
 
 Add and commit the translation file:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ Contents
 ========
 
 * `User level documentation: <http://www.gtgnome.net/html/user_manual/>`_
-* `Documentation for developers: <https://github.com/getting-things-gnome/gtg/tree/master/docs/contributors/>`_
+* `Documentation for developers: <https://github.com/getting-things-gnome/gtg/tree/main/docs/contributors/>`_
 
 Man pages
 =========

--- a/docs/user_manual/C/gtg-create-sync.page
+++ b/docs/user_manual/C/gtg-create-sync.page
@@ -31,7 +31,7 @@
 
 <p><link href="https://github.com/getting-things-gnome/gtg/tree/64d535aee2c59e78fdc269ddd4baaecf257b64b4/GTG/backends"><app>GTG</app> Backends</link></p>
 
-<p><link href="https://github.com/getting-things-gnome/gtg/blob/master/docs/contributors/DBus%20API%20v1.md">DBus</link></p>
+<p><link href="https://github.com/getting-things-gnome/gtg/blob/main/docs/contributors/DBus%20API%20v1.md">DBus</link></p>
 
 </page>
 

--- a/docs/user_manual/C/gtg-developer-resources.page
+++ b/docs/user_manual/C/gtg-developer-resources.page
@@ -20,9 +20,9 @@
 
   <title>Developer Resources and Contributing to <app>GTG</app></title>
 
-<p>If you want more information about associated application dependencies, running <app>GTG</app> from the command line, or running the development version, visit <app>GTG's</app> <link href="https://github.com/getting-things-gnome/gtg">GitHub repository</link>. You can also report bugs and issues through GitHub. Ensure that you read the <link href="https://github.com/getting-things-gnome/gtg/blob/master/docs/contributors/bug%20reporting%20and%20triaging.md">Bug Reporting and Triaging</link> documentation before opening an issue.</p>
+<p>If you want more information about associated application dependencies, running <app>GTG</app> from the command line, or running the development version, visit <app>GTG's</app> <link href="https://github.com/getting-things-gnome/gtg">GitHub repository</link>. You can also report bugs and issues through GitHub. Ensure that you read the <link href="https://github.com/getting-things-gnome/gtg/blob/main/docs/contributors/bug%20reporting%20and%20triaging.md">Bug Reporting and Triaging</link> documentation before opening an issue.</p>
 
-<p>If you are interested in contributing to <app>GTG</app> to fix bugs or code, or work on enhancements, view the <link href="https://github.com/getting-things-gnome/gtg/blob/master/CONTRIBUTING.md">Contributor Documentation</link>.</p>
+<p>If you are interested in contributing to <app>GTG</app> to fix bugs or code, or work on enhancements, view the <link href="https://github.com/getting-things-gnome/gtg/blob/main/CONTRIBUTING.md">Contributor Documentation</link>.</p>
 
 
 


### PR DESCRIPTION
Closes https://github.com/getting-things-gnome/gtg/issues/1038

TODO:

- [ ] Document `master` → `main` migration