### PR TITLE
Update the pane's filter when updating the start date of a task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ flatpak/bundles
 
 # src/ usually has development version of liblarch
 src/
+
+# Python virtual environments
+venv*/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,3 @@ flatpak/bundles
 
 # src/ usually has development version of liblarch
 src/
-
-# Python virtual environments
-venv*/

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1036,7 +1036,7 @@ class MainWindow(Gtk.ApplicationWindow):
         # Changing the start date of a task may take it out of the current pane
         # (e.g. setting the start date of an Actionable task to tomorrow)
         # See #1039
-        self.get_pane().task_filter.changed(Gtk.FilterChange.DIFFERENT)
+        self.get_pane().refresh()
 
     def update_start_to_next_day(self, day_number):
         """Update start date to N days from today."""
@@ -1049,7 +1049,7 @@ class MainWindow(Gtk.ApplicationWindow):
         # Changing the start date of a task may take it out of the current pane
         # (e.g. setting the start date of an Actionable task to tomorrow)
         # See #1039
-        self.get_pane().task_filter.changed(Gtk.FilterChange.DIFFERENT)
+        self.get_pane().refresh()
 
 
     def on_mark_as_started(self, action, param):

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1033,6 +1033,11 @@ class MainWindow(Gtk.ApplicationWindow):
         for task in self.get_pane().get_selection():
             task.date_start = new_start_date
 
+        # Changing the start date of a task may take it out of the current pane
+        # (e.g. setting the start date of an Actionable task to tomorrow)
+        # See #1039
+        self.get_pane().task_filter.changed(Gtk.FilterChange.DIFFERENT)
+
     def update_start_to_next_day(self, day_number):
         """Update start date to N days from today."""
 
@@ -1040,6 +1045,11 @@ class MainWindow(Gtk.ApplicationWindow):
 
         for task in self.get_pane().get_selection():
             task.date_start = next_day
+
+        # Changing the start date of a task may take it out of the current pane
+        # (e.g. setting the start date of an Actionable task to tomorrow)
+        # See #1039
+        self.get_pane().task_filter.changed(Gtk.FilterChange.DIFFERENT)
 
 
     def on_mark_as_started(self, action, param):

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -900,6 +900,9 @@ class TaskEditor(Gtk.Window):
         except KeyError:
             log.debug('Task %s was already removed from the open list', tid)
 
+        # Refresh current pane in case task needs to be added to/removed from it
+        self.app.browser.get_pane().refresh()
+
 
     def get_task(self):
         return self.task


### PR DESCRIPTION
Fixes #1039

Updating the start date of a task may influence whether or not it needs to be visible. For example, if you're on the Actionable pane and you set the start date of a task to some time in the future, then the task is no longer actionable and needs to disappear from that view.

Testing by having some tasks in the Actionable pane, then verifying that the following make the task disappear from the pane:
* click on a task and then on Start Tomorrow
* right-click on a task > Set Start Date > "anything in the future"
* double-click on a task > modify "Starts on" to a date in the future > close task editor
* create a new task > without closing the editor, add a child to it > click on child > click on Open Parent