### PR TITLE
Prevent parsing the current word as a tag when editing a task

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -877,10 +877,12 @@ class TaskEditor(Gtk.Window):
     def is_new(self) -> bool:
         return (self.task.title == DEFAULT_TITLE 
                 and self.textview.get_text() == '')
-        
+
 
     def destruction(self, _=None):
         """Callback when closing the window."""
+        # process textview to make sure every tag is parsed
+        self.textview.process()
 
         # Save should be also called when buffer is modified
         # self.pengine.onTaskClose(self.plugin_api)


### PR DESCRIPTION
This fixes issue #605 (as promised in #1058).

- It solves the problem by masking out the currently edited word to prevent parsing half-typed tags. 
- It also ensures to parse everything when closing the window. 
- (Note that this does not eliminate already existing partial tags in the `gtg_data.xml`.)
