### PR TITLE
Add parent to `self.add`

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -752,10 +752,7 @@ class TaskStore(BaseStore):
         task = Task(id=tid, title=title)
         task.date_added = Date.now()
 
-        if parent:
-            self.add(task, parent)
-        else:
-            self.add(task)
+        self.add(task, parent)
 
         return task
 


### PR DESCRIPTION
Since the default value for `UUID` is `None`, we can safely avoid unnecessarily checking if `UUID` exists.