### PR TITLE
Add standard Python virtualenv names to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ flatpak/bundles
 
 # src/ usually has development version of liblarch
 src/
+
+# Python virtual environments
+venv*/


### PR DESCRIPTION
I do my dev work using virtual environments, like venv/ or venv38/ to test different versions of Python.

This removes them and the many files they contain, from git.