### PR TITLE
Add simple pre-commit hook

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,15 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.8"
+
+    # Note: we could try and cache the pre-commit environment
+    # See the pre-commit docs at https://pre-commit.com/#github-actions-example
+    - name: Run pre-commit hooks
+      run: |
+        python -m pip install --upgrade pip
+        pip install pre-commit
+        pre-commit run --all-files
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -23,12 +32,14 @@ jobs:
         sudo apt install -y meson gettext itstool libgirepository1.0-dev gir1.2-gtk-4.0 libgtksourceview-5-dev libportal-dev
         pip install --user -e git+https://github.com/getting-things-gnome/liblarch.git#egg=liblarch
         pip install --user pytest pycairo PyGObject caldav lxml
+
     - name: Build and install GTG
       run: |
         meson setup --prefix=${PWD}/inst ./build
         cd build
         meson compile
         sudo meson install
+
     - name: Run unit tests with Pytest
       run: |
         export PYTHONPATH=${PWD}/inst/lib/python3.8/site-packages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -159,6 +159,29 @@ No data should be lost since it is just re-generateable build files.
 [pudb]: https://pypi.org/project/pudb/
 [gtk-interactive]: https://developer.gnome.org/gtk3/stable/gtk-running.html#interactive-debugging
 
+## Setting up a development environment
+
+Now that you have installed all the dependencies and know how to run the tests,
+it's possible that you would like to make code changes and submit them for
+review.
+
+We use [pre-commit](https://pre-commit.com) to run some checks that ensure that
+our codebase is clean and consistent.
+
+Install it with `pip install pre-commit`, and install the pre-commit hooks with
+`pre-commit install`.
+
+The checks will now run every time you make a commit, and fix files if
+necessary. It's generally a good idea to always run them, but you can also
+bypass them by running `git commit --no-verify`, if necessary.
+
+The CI system runs the checks on each commit to master, and on each pull
+request. If you want to make sure they pass before opening your PR, you can run
+them locally with `pre-commit run --all-files`.
+
+For more guidelines about contributing, see
+[CONTRIBUTING.md](./CONTRIBUTING.md).
+
 # "Where is my user data and config stored?"
 
 It depends:


### PR DESCRIPTION
Relates to #237

This adds a simple configuration for [pre-commit](https://pre-commit.com) and runs it on GHA. It doesn't do very much; mostly removing trailing whitespaces.

My next step would be to add pylint or pyflakes to this, and tell it to ignore every warning that GTG currently breaks. This would:
* prevent us from breaking any more
* allow us to fix the warnings one at a time, when we can

I tested the GHA on a fork.

This commit doesn't contain the changes that fix the pre-commit check, so GHA will fail. To fix it, we'll just need to run `pre-commit run --all-files` and commit the result.