### PR TITLE
Rework About dialog

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         sudo apt-get update
-        sudo apt install -y meson gettext itstool libgirepository1.0-dev gir1.2-gtk-4.0 libgtksourceview-5-dev
+        sudo apt install -y meson gettext itstool libgirepository1.0-dev gir1.2-gtk-4.0 libgtksourceview-5-dev libportal-dev
         pip install --user -e git+https://github.com/getting-things-gnome/liblarch.git#egg=liblarch
         pip install --user pytest pycairo PyGObject caldav lxml
     - name: Build and install GTG

--- a/GTG/__init__.py
+++ b/GTG/__init__.py
@@ -24,3 +24,4 @@ def gi_version_requires():
     gi.require_version('Gdk', '4.0')
     gi.require_version('Gtk', '4.0')
     gi.require_version('GtkSource', '5')
+    gi.require_version('Xdp', '1.0')

--- a/GTG/core/info.py.in
+++ b/GTG/core/info.py.in
@@ -30,41 +30,60 @@ from gettext import gettext as _
 # These variables get used by main_window.py to set the About dialog's metadata.
 # Translator credits are set dynamically in main_window.py, not hardcoded.
 NAME = "Getting Things GNOME!"
+AUTHORS = _("GTG contributors")
+COPYRIGHT = _(f"Copyright © 2008-%d {AUTHORS}") \
+                % date.today().year
 SHORT_DESCRIPTION = _("""A personal productivity tool for GNOME,
 inspired by the GTD methodology.""") # A manual line break looks better in the About dialog.
 URL = "https://wiki.gnome.org/Apps/GTG"
-TRANSLATE_URL = "https://github.com/getting-things-gnome/gtg/"
+CHAT_URL = "https://matrix.to/#/#gtg:gnome.org"
+SOURCE_CODE_URL = "https://github.com/getting-things-gnome/gtg/"
+OPENHUB_URL = "https://www.openhub.net/p/gtg/contributors"
 REPORT_BUG_URL = "https://github.com/getting-things-gnome/gtg/issues/"
 EMAIL = "gtg-contributors@lists.launchpad.net"
 VERSION = '@VCS_TAG@'
 
-AUTHORS_MAINTAINERS = """
-• Diego Garcia Gangl
-• Jean-François Fortin Tam
-"""
+AUTHORS_MAINTAINERS = [
+    "Diego Garcia Gangl",
+    "Jean-François Fortin Tam",
+]
+
 # Per-release stats generated as per the "release process and checklist.md" file.
 # Including contributors with 2 or more commits.
-# No need to add extra line breaks between commas, Python/GTK handles them.
-# Don't indend lines inside a multi-line string, or it'll show in the About dialog.
-AUTHORS_RELEASE_CONTRIBUTORS = """
-• "Neui"
-• Mohieddine Drissi
-• "odoood"
-• Diego Garcia Gangl
-• Jean-François Fortin Tam
-• Jacob Anderson
-• Raidro Manchester
-• Daniel Koć
-• François Schmidts
-• Sebastian Grabowski
-• Fridolin Weisser
-• Tommy Priest 
-• Laurent Combe
-• Smitty
-• Tiziana Sellitto
-• "unsupported-transceiver"
-"""
+AUTHORS_RELEASE_CONTRIBUTORS = [
+    "Neui",
+    "Mohieddine Drissi",
+    "“odoood”",
+    "Diego Garcia Gangl",
+    "Jean-François Fortin Tam",
+    "Jacob Anderson",
+    "Raidro Manchester",
+    "Daniel Koć",
+    "François Schmidts",
+    "Sebastian Grabowski",
+    "Fridolin Weisser",
+    "Tommy Priest",
+    "Laurent Combe",
+    "Smitty",
+    "Tiziana Sellitto",
+    "“unsupported-transceiver”",
+]
 
-ARTISTS = ["Diego Garcia Gangl (2021 logo)", "Tobias Bernard (2021 logo)", "Kalle Persson (2009 logo)", "Bertrand Rousseau (UX)", "Jean-François Fortin Tam (UX)"]
+ARTISTS = [
+    "Diego Garcia Gangl (2021 logo)",
+    "Tobias Bernard (2021 logo)",
+    "Kalle Persson (2009 logo)",
+    "Bertrand Rousseau (UX)",
+    "Jean-François Fortin Tam (UX)"
+]
+
+DOCUMENTERS = [
+    "Danielle Vansia",
+    "Radina Matic",
+    "Jean-François Fortin Tam"
+]
+
+AUTHORS_MAINTAINERS.sort()
+AUTHORS_RELEASE_CONTRIBUTORS.sort()
 ARTISTS.sort()
-DOCUMENTERS = [ "Danielle Vansia", "Radina Matic", "Jean-François Fortin Tam"]
+DOCUMENTERS.sort()

--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -48,6 +48,7 @@ gtg_core_sources = [
   'datastore.py',
   'filters.py',
   'sorters.py',
+  'system_info.py',
 ]
 
 gtg_core_plugin_sources = [

--- a/GTG/core/system_info.py
+++ b/GTG/core/system_info.py
@@ -1,0 +1,117 @@
+# system_info.py: Collect system information
+# Copyright (C) 2024 GTG Contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from datetime import date
+import gi
+import os
+import platform
+import importlib
+
+from GTG.core import info
+
+from gi.repository import Gdk, Gtk, GObject, GLib, Xdp
+
+
+class SystemInfo:
+    def get_system_info(self, report: bool = False) -> str:
+        """
+        Get system information based on their
+        availability and installed version.
+        """
+        self.report = report
+
+        sys_info = ""
+        sys_info += self.__format_info("GTG", info.VERSION)
+
+        if Xdp.Portal.running_under_flatpak():
+            sys_info += self.__format_info("Flatpak", self.__get_flatpak_version())
+        else:
+            sys_info += self.__format_info("Flatpak", "False")
+
+        sys_info += self.__format_info("Snap", Xdp.Portal.running_under_snap())
+        sys_info += self.__format_info("Display Name", Gdk.Display.get_default().get_name())
+        sys_info += self.__format_info("Desktop", os.environ.get("XDG_CURRENT_DESKTOP"))
+
+        sys_info += "\n"
+        sys_info += self.__format_info("lxml", self.__get_python_module("lxml"))
+        sys_info += self.__format_info("caldav", self.__get_python_module("caldav"))
+        sys_info += self.__format_info("liblarch", self.__get_python_module("liblarch"))
+        sys_info += self.__format_info("Cheetah3", self.__get_python_module("Cheetah"))
+        sys_info += self.__format_info("dbus-python", self.__get_python_module("dbus"))
+        sys_info += self.__format_info("pdflatex", self.__get_python_module("pdflatex"))
+        sys_info += self.__format_info("pypdftk", self.__get_python_module("pdftk"))
+
+        # Only display OS info when user isn't running as Flatpak/Snap
+        if not Xdp.Portal.running_under_sandbox():
+            sys_info += "\n"
+            sys_info += self.__format_info("OS", GLib.get_os_info("PRETTY_NAME"))
+
+            sys_info += self.__format_info(
+                "Python", f"{platform.python_implementation()} {platform.python_version()}"
+            )
+
+            sys_info += self.__format_info("GLib", self.__version_to_string(GLib.glib_version))
+            sys_info += self.__format_info("PyGLib", self.__version_to_string(GLib.pyglib_version))
+
+            sys_info += self.__format_info(
+                "PyGObject", self.__version_to_string(GObject.pygobject_version)
+            )
+
+            sys_info += self.__format_info("GTK", self.__version_to_string(self.__get_gtk_version()))
+
+        return sys_info
+
+
+    def __version_to_string(self, version: tuple) -> str:
+        """
+        Convert version tuple (major, micro, minor)
+        version to string (major.micro.minor).
+        """
+        return ".".join(map(str, version))
+
+
+    def __format_info(self, lib: str, getter) -> str:
+        """
+        Pretty-format library and availability
+        """
+        if self.report:
+            return f"**{lib}:** {getter}\n"
+        else:
+            return f"{lib}: {getter}\n"
+
+
+    def __get_flatpak_version(self) -> str:
+        """Get Flatpak version."""
+        with open("/.flatpak-info") as flatpak_info:
+            for line in flatpak_info:
+                if line.startswith("flatpak-version"):
+                    flatpak_version = line.split("=")[1].strip()
+                    return flatpak_version
+
+
+    def __get_gtk_version(self) -> str:
+        """Get GTK version."""
+        return (
+            Gtk.get_major_version(),
+            Gtk.get_micro_version(),
+            Gtk.get_minor_version(),
+        )
+
+
+    def __get_python_module(self, module: str) -> bool:
+        """Check if Python module is installed."""
+        return bool(importlib.util.find_spec(module))

--- a/build-aux/org.gnome.GTG.Devel.json
+++ b/build-aux/org.gnome.GTG.Devel.json
@@ -46,6 +46,24 @@
       ]
     },
     {
+      "name": "libportal",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dtests=false",
+        "-Dbackend-gtk3=disabled",
+        "-Dbackend-gtk4=enabled",
+        "-Dbackend-qt5=disabled",
+        "-Ddocs=false"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz",
+          "sha256": "297b90b263fad22190a26b8c7e8ea938fe6b18fb936265e588927179920d3805"
+        }
+      ]
+    },
+    {
       "name": "gtg",
       "config-opts" : [
           "-Dprofile=development"


### PR DESCRIPTION
This makes a few changes and additions:
- This adds a new dependency on libportal. It's used to detect if it's sandboxed.
- Various `GtkButton`s are added to provide external links.
- The Credits section has been reworked to prevent the about dialog from increasing.
- New System section was added to help users copy and paste system information for troubleshooting purposes.
- The about dialog is now a modal window.

Screenshots:

| About | System |
|--------|--------|
| ![image](https://github.com/getting-things-gnome/gtg/assets/50847364/ae9afd21-33a2-4d3c-84ff-b6c914c27ff4) | ![image](https://github.com/getting-things-gnome/gtg/assets/50847364/00f00c95-3160-497c-9e71-ef6a289478e8) |
