### PR TITLE
Remove inline references when unparenting a task

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -939,6 +939,9 @@ class TaskStore(BaseStore):
         item = self.lookup[item_id]
         parent = self.lookup[parent_id]
 
+        # remove inline references to the former subtask
+        parent.content = re.sub(r'\{\!\s*'+item_id+'\s*\!\}','',parent.content)
+
         self.model.append(item)
         parent.notify('has_children')
 


### PR DESCRIPTION
Fixes #1029

When unparenting a task, inline references of the old subtask must be removed from the old parent's content.
(Otherwise, the reference is parsed again and removed unsuccessfully, causing the crash described in the issue.)