### PR TITLE
Avoid deleting an unedited new task twice

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -864,15 +864,6 @@ class TaskEditor(Gtk.Window):
             elif focus == self.closed_entry:
                 self.show_popover_closed()
 
-    # We define dummy variable for when close is called from a callback
-    def close(self, action=None, param=None):
-
-        # We should also destroy the whole taskeditor object.
-        if self:
-            self.destruction()
-            super().close()
-            self = None
-
 
     def is_new(self) -> bool:
         return (self.task.title == DEFAULT_TITLE 


### PR DESCRIPTION
Fixes #1026

The crash happened because the program tried to delete the same unmodified new task twice. After hitting `Escape`, the `TaskEditor`'s `close` method was called. This override called `self.destruction()`, thus deleting the new task. After that, `super().close()` was also called emitting a `close-request` signal. This `close-request` signal was also [connected](https://github.com/getting-things-gnome/gtg/blob/b2dec14ca98db5453bd74ca524ded6d0a0a8bc3e/GTG/gtk/editor/editor.py#L241) to the `destruction` method, thus trying to delete the same task the second time.

The `TaskEditor`'s `close()` override is now removed. Its only function was to call the `destruction()` method. However, the `destruction()` method was already connected to the `close-request` signal.

