### PR TITLE
Fix TypeError when unparenting

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -939,7 +939,7 @@ class TaskStore(BaseStore):
         parent = self.lookup[parent_id]
 
         # remove inline references to the former subtask
-        parent.content = re.sub(r'\{\!\s*'+item_id+'\s*\!\}','',parent.content)
+        parent.content = re.sub(r'\{\!\s*'+str(item_id)+'\s*\!\}','',parent.content)
 
         self.model.append(item)
         parent.notify('has_children')


### PR DESCRIPTION
This fixes the test suite again, which fixes #1053

I think #1036 was merged without rebasing, and https://github.com/getting-things-gnome/gtg/commit/4ed9bc88067d5efdb48d4e262e7e6a7872095c9c was committed in between and [broke a test](https://github.com/getting-things-gnome/gtg/actions/runs/8512039052/job/23312837322):
```
 >       parent.content = re.sub(r'\{\!\s*'+item_id+'\s*\!\}','',parent.content)
E       TypeError: can only concatenate str (not "UUID") to str
```
I'm not entirely sure how this line was supposed to work, given that item_id's type hint is UUID and there is no `+` operation between UUID and str. I'm guessing a caller was passing a string? I didn't manage to trigger the TypeError from the GUI.

But even if the type hint is wrong and a string can be passed, running `str()` on it won't hurt.

cc @nekohayo who opened #1029 (is it still fixed?) and @gycsaba96 who fixed it.