### PR TITLE
Fix AttributeError when setting start date

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -544,7 +544,7 @@ class TaskEditor(Gtk.Window):
                                "Completed %(days)d days early", abs_delay) % \
                     {'days': abs_delay}
         else:
-            due_date = self.task.get_due_date()
+            due_date = self.task.date_due
             result = due_date.days_left()
             if due_date.is_fuzzy():
                 txt = ""


### PR DESCRIPTION
Fixes #1075 

It seems that `main_window.py` still has a significant amount of GTK3 code. For example, `self.req` is mentioned a lot in `main_window.py`, but `MainWindow` doesn't have that attribute.

Once concerning thing is that now, when setting a Start Date or Due date via `Right click on a task > Set Start Date > Pick a Date`, GTK logs a warning:
```
(gtg:27345): Gtk-WARNING **: 18:22:45.883: Broken accounting of active state for widget 0x223b9e0(GtkWindow)
```
I didn't dig into that.