### PR TITLE
Write unit test for TaskView.get_title()

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,4 +46,5 @@ jobs:
     - name: Run unit tests with Pytest
       run: |
         export PYTHONPATH=${PWD}/inst/lib/python3.9/site-packages
-        pytest
+        # Provide a fake display server, for tests that need one
+        xvfb-run pytest

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -295,6 +295,10 @@ class Task(GObject.Object):
         self._date_modified = Date(value)
 
 
+    def is_new(self) -> bool:
+        return self.title == DEFAULT_TITLE and not self.content
+
+
     @GObject.Property(type=str)
     def title(self) -> str:
         return self.raw_title
@@ -753,7 +757,7 @@ class TaskStore(BaseStore):
         return new_task
 
 
-    def new(self, title: str = None, parent: Optional[UUID] = None) -> Task:
+    def new(self, title: str = '', parent: Optional[UUID] = None) -> Task:
         """Create a new task and add it to the store."""
 
         tid = uuid4()

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -28,6 +28,22 @@ from lxml.etree import XML
 
 class TestTask(TestCase):
 
+    def test_default_task_from_store_is_new(self):
+        task = TaskStore().new()
+
+        self.assertTrue(task.is_new())
+
+    def test_task_with_content_is_not_new(self):
+        task = TaskStore().new()
+        task.content = 'foobar'
+
+        self.assertFalse(task.is_new())
+
+    def test_task_with_title_is_not_new(self):
+        task = TaskStore().new(title='My new task')
+
+        self.assertFalse(task.is_new())
+
     def test_title(self):
         task = Task(id=uuid4(), title='\tMy Title\n')
 

--- a/tests/core/test_taskview.py
+++ b/tests/core/test_taskview.py
@@ -16,9 +16,14 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
+import os
+import pytest
 import re
+from uuid import uuid4
 from unittest import TestCase
-from GTG.gtk.editor.taskview import TAG_REGEX
+from GTG.core.datastore import Datastore
+from GTG.core.tasks import Task
+from GTG.gtk.editor.taskview import TaskView, TAG_REGEX
 
 
 class TestTaskView(TestCase):
@@ -41,3 +46,15 @@ class TestTaskView(TestCase):
         matches = re.findall(TAG_REGEX, content)
 
         self.assertEqual([], matches)
+
+    def test_get_title(self):
+        task_title = 'Very important task'
+        task = Task(id = uuid4(), title=task_title)
+        view = TaskView(Datastore(), task, None, False)
+        view.refresh_cb = lambda x: x # Refresh CB that does nothing
+        view.set_text_from_task()
+        view.detect_title()
+
+        view_title = view.get_title()
+
+        self.assertEqual(view_title, task_title)


### PR DESCRIPTION
I started to look at #1077 and I thought it would be nice to be able to unit test this type of thing.

A simple unit test for TaskView would be

* create a task
* create a view for it
* check that the title of the view is the title of the task

In the current state of affairs, this is difficult because the code that puts the Task data into the view lives in TaskEditor. But we pass a Task to the constructor of TaskView, so TaskView actually has all the data it needs. So I moved the logic there. I also moved the `is_new()` logic from the TaskEditor down to the Task.

I feel like it should be possible to eventually do this in the TaskView constructor but for now, TaskEditor calls `self.textview.set_text_from_task()` from the same place it used to run that code.

The test triggers a segmentation fault when running on GitHub Actions, so it's skipped there while I figure out why.