### PR TITLE
Fix deprecation warning

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -939,7 +939,7 @@ class TaskStore(BaseStore):
         parent = self.lookup[parent_id]
 
         # remove inline references to the former subtask
-        parent.content = re.sub(r'\{\!\s*'+str(item_id)+'\s*\!\}','',parent.content)
+        parent.content = re.sub(r'\{\!\s*'+str(item_id)+r'\s*\!\}','',parent.content)
 
         self.model.append(item)
         parent.notify('has_children')


### PR DESCRIPTION
pytest with Python 3.11 shows `DeprecationWarning: invalid escape sequence '\s'`. Use a raw string to fix this.