### PR TITLE
Use Date.no_date() instead of None for Task.date_due

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -414,7 +414,7 @@ class Task(GObject.Object):
             Return a tuple of (bool, Date)
             """
             if recurring_term is None:
-                return False, None
+                return False, Date.no_date()
 
             try:
                 # If a start date is already set,
@@ -429,7 +429,7 @@ class Task(GObject.Object):
                 return True, newdate
 
             except ValueError:
-                return False, None
+                return False, Date.no_date()
 
         self._is_recurring = recurring
 

--- a/GTG/gtk/browser/quick_add.py
+++ b/GTG/gtk/browser/quick_add.py
@@ -61,7 +61,7 @@ def parse(text: str) -> Dict:
         'title': '',
         'tags': set(),
         'start': None,
-        'due': None,
+        'due': Date.no_date(),
         'recurring': None
     }
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -214,7 +214,7 @@ class TestTask(TestCase):
 
         # Test changing parent's due (None or nodate)
         task2.date_due = random_date
-        task1.date_due = None
+        task1.date_due = Date.no_date()
         self.assertEqual(task2.date_due, random_date)
 
 


### PR DESCRIPTION
Fixes #1068

In some cases, `None` was used instead of `Date.no_date()`, which caused a crash when sorting the task list. These changes follow the already existing type hints and comments.
