### PR TITLE
Fix check for empty excerpts in popups

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -307,16 +307,19 @@ class Task(GObject.Object):
 
     @GObject.Property(type=str)
     def excerpt(self) -> str:
-        if not self.content:
-            return ''
-
         # Strip tags
         txt = TAG_REGEX.sub('', self.content)
 
         # Strip subtasks
         txt = SUB_REGEX.sub('', txt)
 
-        return f'{txt.strip()[:80]}…'
+        # Strip whitespace
+        txt = txt.strip()
+
+        if not txt:
+            return ''
+
+        return f'{txt[:80]}…'
 
 
     def add_tag(self, tag: Tag) -> None:

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 # REGEXES
 # ------------------------------------------------------------------------------
 
-TAG_REGEX = re.compile(r'^\B\@\w+(\-\w+)*\,*')
+TAG_LINE_REGEX = re.compile(r'^\B\@\w+(\-\w+)*\,*.*')
 SUB_REGEX = re.compile(r'\{\!.+\!\}')
 
 
@@ -308,7 +308,7 @@ class Task(GObject.Object):
     @GObject.Property(type=str)
     def excerpt(self) -> str:
         # Strip tags
-        txt = TAG_REGEX.sub('', self.content)
+        txt = TAG_LINE_REGEX.sub('', self.content)
 
         # Strip subtasks
         txt = SUB_REGEX.sub('', txt)

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -35,7 +35,7 @@ class TestTask(TestCase):
         self.assertEqual(task.title, 'My Title')
 
 
-    def test_excerpt(self):
+    def test_excerpt_normal(self):
         task = Task(id=uuid4(), title='A Task')
 
         self.assertEqual(task.excerpt, '')
@@ -49,6 +49,38 @@ class TestTask(TestCase):
                     'extra text for padding. I cou…')
 
         self.assertEqual(task.excerpt, expected)
+
+
+    def test_excerpt_empty_task(self):
+        task = Task(id=uuid4(), title='A Task')
+
+        self.assertEqual(task.excerpt, '')
+
+        task.content = ''
+
+        self.assertEqual(task.excerpt, '')
+
+
+    def test_excerpt_only_tags(self):
+        task = Task(id=uuid4(), title='A Task')
+
+        self.assertEqual(task.excerpt, '')
+
+        task.content = '@sometag, @someother'
+
+        self.assertEqual(task.excerpt, '')
+
+
+    def test_excerpt_only_whitespace(self):
+        task = Task(id=uuid4(), title='A Task')
+
+        self.assertEqual(task.excerpt, '')
+
+        task.content = ('     '
+                        ''
+                        '   ')
+
+        self.assertEqual(task.excerpt, '')
 
 
     def test_toggle_active_single(self):


### PR DESCRIPTION
If the content had some whitespace the if-guard would fail, creating a tooltip with just "...".
It would also fail because it would include tags and subtasks. So now we first process the content properly and then check.

Also fixes the regex to remove tags in a comma list properly from the excerpt

fixes #1010