### PR TITLE
Fix alignment in hierarchical views

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -80,6 +80,13 @@ class Tag(GObject.Object):
         return self.id == other.id
 
 
+    @GObject.Property(type=int)
+    def children_count(self) -> str:
+        """Read only property."""
+
+        return len(self.children)
+
+
     @GObject.Property(type=str)
     def name(self) -> str:
         """Read only property."""
@@ -362,6 +369,7 @@ class TagStore(BaseStore):
             self.model.append(item)
 
         self.emit('added', item)
+        if parent_id: self.lookup[parent_id].notify('children_count')
 
 
     def parent(self, item_id: UUID, parent_id: UUID) -> None:
@@ -370,6 +378,7 @@ class TagStore(BaseStore):
         item = self.lookup[item_id]
         pos = self.model.find(item)
         self.model.remove(pos[1])
+        if parent_id: self.lookup[parent_id].notify('children_count')
 
 
 
@@ -378,3 +387,4 @@ class TagStore(BaseStore):
         super().unparent(item_id, parent_id)
         item = self.lookup[item_id]
         self.model.append(item)
+        if parent_id: self.lookup[parent_id].notify('children_count')

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -282,6 +282,8 @@ class Sidebar(Gtk.ScrolledWindow):
 
         expander.set_margin_end(6)
         expander.add_css_class('arrow-only-expander')
+        expander.set_indent_for_icon(True)
+        expander.set_indent_for_depth(True)
         icon.set_margin_end(6)
         color.set_margin_end(6)
         color.set_size_request(16, 16)
@@ -375,30 +377,14 @@ class Sidebar(Gtk.ScrolledWindow):
             item.bind_property('task_count_open', open_count_label, 'label', BIND_FLAGS),
             item.bind_property('task_count_actionable', actionable_count_label, 'label', BIND_FLAGS),
             item.bind_property('task_count_closed', closed_count_label, 'label', BIND_FLAGS),
+
+            item.bind_property('children_count',expander,'hide-expander',BIND_FLAGS, lambda _,x: x==0),
         ]
         
         self.browser.bind_property('is_pane_open', open_count_label, 'visible', BIND_FLAGS)
         self.browser.bind_property('is_pane_actionable', actionable_count_label, 'visible', BIND_FLAGS)
         self.browser.bind_property('is_pane_closed', closed_count_label, 'visible', BIND_FLAGS)
         
-
-        if item.parent:
-            parent = item
-            depth = 0
-
-            while parent.parent:
-                depth += 1
-                parent = parent.parent
-
-            box.set_margin_start((18 * depth) + 16)
-        else:
-            box.set_margin_start(18)
-
-        if not item.children:
-            expander.set_visible(False)
-        else:
-            expander.set_visible(True)
-
 
     def tags_unbind_cb(self, signallistitem, listitem, user_data=None) -> None:
         """Clean up bindings made in tags_bind_cb"""

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -40,6 +40,8 @@ class TaskBox(Gtk.Box):
         self.expander = Gtk.TreeExpander()
         self.expander.set_margin_end(6)
         self.expander.add_css_class('arrow-only-expander')
+        self.expander.set_indent_for_icon(True)
+        self.expander.set_indent_for_depth(True)
 
         self.check = Gtk.CheckButton() 
         self.check.set_margin_end(6)
@@ -60,30 +62,6 @@ class TaskBox(Gtk.Box):
 
         if self.is_actionable:
             value = False
-
-        self.expander.set_visible(value)
-
-        if value:
-            widget = self.expander 
-        else:
-            widget = self.check
-
-        check_width = 21
-        margin = 6
-
-        indent = margin if value else (check_width + margin)
-
-        if self.task.parent and not self.is_actionable:
-            parent = self.task
-            depth = 0
-
-            while parent.parent:
-                depth += 1
-                parent = parent.parent
-
-            widget.set_margin_start(indent + (21 * depth))
-        else:
-            widget.set_margin_start(indent)
         
 
     @GObject.Property(type=bool, default=True)
@@ -533,6 +511,7 @@ class TaskPane(Gtk.ScrolledWindow):
 
         listitem.bindings = [
             item.bind_property('has_children', box, 'has_children', BIND_FLAGS),
+            item.bind_property('has_children', expander, 'hide-expander', BIND_FLAGS,lambda _,x: not x),
 
             item.bind_property('title', label, 'label', BIND_FLAGS),
             item.bind_property('excerpt', box, 'tooltip-text', BIND_FLAGS),

--- a/GTG/gtk/data/style.css
+++ b/GTG/gtk/data/style.css
@@ -98,10 +98,6 @@ textview check {
   border-spacing: 0;
 }
 
-.arrow-only-expander indent {
-  -gtk-icon-size: 0px;
-}
-
 .closed-task {
     opacity: 0.5;
 }


### PR DESCRIPTION
Fixes #1042

The new code leverages `GtkTreeExpander`'s ability to handle indentation both for tags in the sidebar and tasks in the task list. I also created a `children_count` property for the Tag class so that the expander can bind to it.

