### PR TITLE
Remove tests from checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 PEP8=pycodestyle
 PYFLAKES=pyflakes
 
-check: tests pep8 pyflakes
+check: pep8 pyflakes
 
 # Run all of the tests.
 tests:


### PR DESCRIPTION
Running tests locally has become a bit more involved recently. We can keep them out of "make check" for now, so that we can at least get some basic style checks running again.

Fixes #838

(actually the error in that issue was fixed with the new core, but there was a new error related to `run-tests`)