### PR TITLE
Update models for subtasks upon changes

### DIFF
--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -629,8 +629,6 @@ class TaskPane(Gtk.ScrolledWindow):
 
         self.ds.tasks.parent(task.id, dropped.id)
         self.refresh()
-        self.emit('collapse-all')
-        self.emit('expand-all')
 
 
     def on_task_RMB_click(self, gesture, sequence) -> None:
@@ -663,11 +661,6 @@ class TaskPane(Gtk.ScrolledWindow):
             self.ds.tasks.unparent(task.id, task.parent.id)
             self.ds.tasks.tree_model.emit('items-changed', 0, 0, 0)
             self.refresh()
-
-            # Not pretty, but needed to force the update of
-            # the parent task and it's remaining children
-            self.emit('collapse-all')
-            self.emit('expand-all')
 
             return True
         else:


### PR DESCRIPTION
This fixes one of the problems listed in GitHub issue #1018:

> If you drag a child from one parent to another task (re-parent), it duplicates it in the view

The main changes are as follows:

- The `tid_to_subtask_model` field keeps track of the `ListStore`s created for subtasks. 
- The `_remove_from_parent_model` and `_append_to_model` helper functions update these models when a change happens. 
- Thanks to this new functionality, some GUI updates are simplified.

