### PR TITLE
Create a dummy button in the sidebar

### DIFF
--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -74,6 +74,12 @@ class Sidebar(Gtk.ScrolledWindow):
         wrap_box.set_vexpand(True)
         wrap_box.set_hexpand(True)
 
+        # Create an invisible dummy button to catch focus in some edge cases
+        self.dummy = Gtk.Button()
+        self.dummy.set_size_request(0, 0)
+        self.dummy.add_css_class('dummy')
+        wrap_box.append(self.dummy)
+
         # -------------------------------------------------------------------------------
         # General Filters
         # -------------------------------------------------------------------------------

--- a/GTG/gtk/data/style.css
+++ b/GTG/gtk/data/style.css
@@ -10,6 +10,16 @@
     border-top: 1px solid rgb(213, 208, 204);
 }
 
+.dummy {
+  background: transparent;
+  border: none;
+  color: transparent;
+  font-size: 0.001px;
+  margin: -100px;
+  opacity: 0;
+  padding: 0;
+}
+
 /*
     We have to get move the padding into the boxes
     so the background color of the rows reaches all


### PR DESCRIPTION
Fixes #1017 and the following points of #1018:
> - If you drag a child out of a parent, the selected tag in the sidebar resets to "All Tasks" view
> - If you drag a standalone task into a parent (turning the task into a child), the selected tag in the sidebar resets to "All Tasks" view

Based on [a forum discussion](https://discourse.gnome.org/t/list-box-first-row-is-always-selected/14840/2), if the currently focused widget is removed, Gtk.Window selects the first suitable children. This is the "All Tasks" row in our case, thus causing a view reset. Other cases can also reproduce the anomaly: reparenting a tag, deleting a task, etc.

Now, an invisible button catches the focus instead of the "All Tasks" row. Thanks to this button, unintended view resets can be avoided when the focused widget is removed.

Theoretically, we could define a focus grab for each of these special cases. However, we would risk that we miss one and the bug comes back. Moreover, this change doesn't affect the complexity of other code parts.

