### PR TITLE
Fix tag expansion in TaskPaneFilter

### DIFF
--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -80,7 +80,7 @@ class TaskPaneFilter(Gtk.Filter):
                 result.add(child)
 
                 if child.children:
-                    return get_children(child.children)
+                    get_children(child.children)
 
 
         result = set()


### PR DESCRIPTION
The removed return statement prevented the inclusion of certain tags if there was a previous sibling with children.

(As far as I know, there is no open issue for this bug.)