### PR TITLE
Fix the collection of parents in TagStore's XML export

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -314,7 +314,7 @@ class TagStore(BaseStore):
 
         parent_map = {}
 
-        for tag in self.data:
+        for tag in self.lookup.values():
             for child in tag.children:
                 parent_map[child.id] = tag.id
 


### PR DESCRIPTION
The original XML export for tags looped over only the root elements when collecting parent-child relations. Now, the code uses the `lookup` dictionary containing every tag.

As far as I know, there is no open issue for this bug.

**Detailed steps to reproduce the bug:** 

1. Create a deep tag structure with four levels.
    ```
    - a
        - b
            - c
                - d
     ```
  
2. Close the program.

3. You can already see the faulty export in the `gtg_data.xml` file.
    ```
   <taglist>
     <tag id="e21eac43-35d2-480e-8818-5b86dc48b20d" name="a" nonactionable="False"/>
     <tag id="b5a629bc-b146-42b8-a6d0-26a651285d7b" name="b" nonactionable="False" parent="e21eac43-35d2-480e-8818-5b86dc48b20d"/>
     <tag id="cece686c-607d-4388-9bd1-11560d8b32ac" name="c" nonactionable="False"/>
     <tag id="76422fdf-09c0-4902-bbf3-609fe446c08f" name="d" nonactionable="False"/>
   </taglist>
    ```
4. If you reopen the program, you can see the tag tree has only two levels instead of four. 

    ```
    - a
        - b
    - c
    - d
     ```
