### PR TITLE
Always show tags with zero tasks

### DIFF
--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -42,19 +42,20 @@ class TagEmptyFilter(Gtk.Filter):
         super(TagEmptyFilter, self).__init__()
         self.ds = ds
         self.pane = pane
+        self.show_zero = True
 
 
     def do_match(self, item) -> bool:
         tag = unwrap(item, Tag)
 
-        if self.pane == 'open':
-            return tag.task_count_open > 0
+        if self.pane == 'open_view':
+            return self.show_zero or tag.task_count_open > 0
 
-        elif self.pane == 'closed':
-            return tag.task_count_closed > 0
+        elif self.pane == 'closed_view':
+            return self.show_zero or tag.task_count_closed > 0
 
-        elif self.pane == 'workview':
-            return tag.task_count_actionable > 0 and tag.actionable
+        elif self.pane == 'actionable_view':
+            return (self.show_zero or tag.task_count_actionable > 0) and tag.actionable
 
         else:
             return True

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -146,7 +146,7 @@ class Sidebar(Gtk.ScrolledWindow):
         # -------------------------------------------------------------------------------
         # Tags Section
         # -------------------------------------------------------------------------------
-        self.tags_filter = TagEmptyFilter(ds, 'open')
+        self.tags_filter = TagEmptyFilter(ds, 'open_view')
         self.filtered_tags = Gtk.FilterListModel()
         self.filtered_tags.set_model(ds.tags.tree_model)
         self.filtered_tags.set_filter(self.tags_filter)


### PR DESCRIPTION
Fixes #1007

The anomaly was caused by a lucky bug. `TagEmptyFilter` was checking for the wrong `self.pane` values except when `Sidebar.__init__` created the object, thus filtering the tags with zero tasks only after startup.  

Now, `TagEmptyFilter` checks for the correct `self.pane` values and considers the newly introduced `show_zero` field. (This field could be used in the future to show and hide tags with zero tasks.)
