### PR TITLE
Inherit the parent's tags when creating a new subtask

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -763,6 +763,11 @@ class TaskStore(BaseStore):
 
         self.add(task, parent)
 
+        # add the tags of the parent
+        if parent is not None:
+            for tag in self.lookup[parent].tags:
+                task.add_tag(tag)
+
         return task
 
 


### PR DESCRIPTION
Fixes #1078

If a parent is provided during task creation, all tags of the parent are added to the newly created task.

