### PR TITLE
Fix the mixed-use of UUID and str for task IDs

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -49,7 +49,7 @@ class BaseStore(GObject.Object):
         raise NotImplemented
 
 
-    def get(self, key: str) -> Any:
+    def get(self, key: UUID) -> Any:
         """Get an item by id."""
 
         return self.lookup[key]

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -753,7 +753,7 @@ class TaskStore(BaseStore):
         return new_task
 
 
-    def new(self, title: str = None, parent: UUID = None) -> Task:
+    def new(self, title: str = None, parent: Optional[UUID] = None) -> Task:
         """Create a new task and add it to the store."""
 
         tid = uuid4()
@@ -777,7 +777,7 @@ class TaskStore(BaseStore):
         elements = list(xml.iter(self.XML_TAG))
 
         for element in elements:
-            tid = element.get('id')
+            tid = UUID(element.get('id'))
             title = element.find('title').text
             status = element.get('status')
 
@@ -841,11 +841,11 @@ class TaskStore(BaseStore):
 
         # All tasks have been added, now we parent them
         for element in elements:
-            parent_tid = element.get('id')
+            parent_tid = UUID(element.get('id'))
             subtasks = element.find('subtasks')
 
             for sub in subtasks.findall('sub'):
-                self.parent(sub.text, parent_tid)
+                self.parent(UUID(sub.text), parent_tid)
 
 
     def to_xml(self) -> Element:
@@ -934,7 +934,7 @@ class TaskStore(BaseStore):
         if not pos[0]: model.append(item)
 
 
-    def add(self, item: Any, parent_id: UUID = None) -> None:
+    def add(self, item: Any, parent_id: Optional[UUID] = None) -> None:
         """Add a task to the taskstore."""
 
         super().add(item, parent_id)

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -21,7 +21,7 @@
 
 import re
 from time import time
-from uuid import uuid4
+from uuid import uuid4, UUID
 import logging
 
 from gi.repository import Gtk, GLib, Gdk, GObject, GtkSource
@@ -417,7 +417,7 @@ class TaskView(GtkSource.View):
         self.process()
 
 
-    def add_checkbox(self, tid: int, start: Gtk.TextIter) -> None:
+    def add_checkbox(self, tid: UUID, start: Gtk.TextIter) -> None:
         """Add a checkbox for a subtask."""
 
         task = self.ds.tasks.lookup[tid]
@@ -483,7 +483,7 @@ class TaskView(GtkSource.View):
             url_start.forward_chars(match.start())
             url_end.forward_chars(match.end())
 
-            tid = match.group(0).replace('gtg://', '')
+            tid = UUID(match.group(0).replace('gtg://', ''))
             task = self.ds.tasks.lookup[tid]
 
             if task:
@@ -769,7 +769,7 @@ class TaskView(GtkSource.View):
             # Find the subtasks and store their lines
             if line.lstrip().startswith('{!'):
                 # Get the Task ID
-                tid = line.replace('{! ', '').replace(' !}', '').strip()
+                tid = UUID(line.replace('{! ', '').replace(' !}', '').strip())
 
                 # Remember there's a line for the title at the top
                 real_index = index + 1

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -430,7 +430,7 @@ class TestTask(TestCase):
         task_store.from_xml(parsed_xml, None)
         self.assertEqual(task_store.count(), 4)
         self.assertEqual(task_store.count(root_only=True), 1)
-        self.assertEqual(len(task_store.get(str(TASK_ID_1)).children), 2)
+        self.assertEqual(len(task_store.get(TASK_ID_1).children), 2)
 
 
     def test_xml_load_bad(self):
@@ -478,7 +478,7 @@ class TestTask(TestCase):
         </tasklist>
         ''')
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             task_store.from_xml(parsed_xml, None)
 
 


### PR DESCRIPTION
Fixes #1077

The cause of the (seemingly) extra empty line was that existing subtasks were [not correctly detected](https://github.com/getting-things-gnome/gtg/blob/b32ec933ba61ba2c6e3de563c5fa79dc3abd1f61/GTG/gtk/editor/taskview.py#L792) and thus moved to the end of the text. This happened because of the mixed use of strings and UUIDs for task IDs.

This PR converts strings to UUIDs when necessary and fixes the related type hints.