### PR TITLE
Require GTK 4.10

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,13 +9,16 @@ on:
     branches: [ master ]
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+
+    # The minimum supported Python version is actually 3.8, but it's not
+    # available on GitHub's ubuntu-24.04 images.
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     # Note: we could try and cache the pre-commit environment
     # See the pre-commit docs at https://pre-commit.com/#github-actions-example
@@ -42,5 +45,5 @@ jobs:
 
     - name: Run unit tests with Pytest
       run: |
-        export PYTHONPATH=${PWD}/inst/lib/python3.8/site-packages
+        export PYTHONPATH=${PWD}/inst/lib/python3.9/site-packages
         pytest

--- a/.github/workflows/weekly_flatpak.yml
+++ b/.github/workflows/weekly_flatpak.yml
@@ -8,7 +8,9 @@ name: Weekly Development Flatpak
 jobs:
   flatpak:
     name: "Flatpak"
-    runs-on: ubuntu-latest
+    # Need to specify 24.04 until it becomes stable and we can use "latest"
+    # again
+    runs-on: ubuntu-24.04
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged

--- a/meson.build
+++ b/meson.build
@@ -52,10 +52,11 @@ configure_file(
   configuration: wrapper_config,
 )
 
+dep_gtk4 = dependency('gtk4', version: '>= 4.10')
+
 # Check for some runtime dependencies so they are displayed with an "NO"
 # when building which could give the user an idea what could be missing.
 dep_glib = dependency('glib-2.0', required: false)
-dep_gtk = dependency('gtk+-3.0', required: false)
 dep_libsecret = dependency('libsecret-1', required: false)
 dep_gtksourceview = dependency('gtksourceview-4', required: false)
 


### PR DESCRIPTION
Relates to #1093

GTK 4.10 has been required since
https://github.com/getting-things-gnome/gtg/commit/23a986847a61f4744a1e9a323a4f5b353358d2e5

Tested by setting the requirement to 4.13, and getting
```
Run-time dependency gtk4 found: NO (tried cmake)

../meson.build:55:11: ERROR: Dependency lookup for gtk4 with method 'pkgconfig' failed: Invalid version, need 'gtk4' ['>= 4.13'] found '4.12.3'.
```