### PR TITLE
Apply simple Ruff fixes

### DIFF
--- a/GTG/backends/generic_backend.py
+++ b/GTG/backends/generic_backend.py
@@ -418,7 +418,7 @@ class GenericBackend():
                 the_list = [the_list]
             return the_list
         else:
-            raise NotImplemented(f"I don't know what type is '{param_type}'")
+            raise NotImplementedError(f"I don't know what type is '{param_type}'")
 
     def cast_param_type_to_string(self, param_type, param_value):
         """

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -46,7 +46,7 @@ class BaseStore(GObject.Object):
     # --------------------------------------------------------------------------
 
     def new(self) -> Any:
-        raise NotImplemented
+        raise NotImplementedError
 
 
     def get(self, key: UUID) -> Any:
@@ -170,11 +170,11 @@ class BaseStore(GObject.Object):
     # --------------------------------------------------------------------------
 
     def from_xml(self, xml: Element) -> Any:
-        raise NotImplemented
+        raise NotImplementedError
 
 
     def to_xml(self) -> Element:
-        raise NotImplemented
+        raise NotImplementedError
 
 
     # --------------------------------------------------------------------------

--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -165,7 +165,7 @@ class SectionConfig():
         if value is None and default_value is None:
             raise ValueError(
                 'No valid configuration value or default value was '
-                'found for %s in %s'.format(option, self._section_name))
+                f'found for {option} in {self._section_name}')
         elif value is None:
             return default_value
         else:

--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -18,7 +18,7 @@
 
 """Filters for tags and tasks"""
 
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk
 from GTG.core.tags import Tag
 from GTG.core.tasks import Task, Status
 from GTG.core import search

--- a/GTG/core/sorters.py
+++ b/GTG/core/sorters.py
@@ -18,7 +18,7 @@
 
 """Sorters for tags and tasks."""
 
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk
 from GTG.core.tasks import Task
 
 def unwrap(row, expected_type):

--- a/GTG/core/system_info.py
+++ b/GTG/core/system_info.py
@@ -15,8 +15,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from datetime import date
-import gi
 import os
 import platform
 import importlib

--- a/GTG/core/versioning.py
+++ b/GTG/core/versioning.py
@@ -25,7 +25,6 @@ from uuid import uuid4
 from lxml import etree as et
 from GTG.core.dates import Date
 from GTG.core.dirs import DATA_DIR
-from uuid import uuid4, UUID
 
 from datetime import date
 from typing import Optional, Tuple

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -153,7 +153,7 @@ class Application(Gtk.Application):
             self.browser.restore_editor_windows()
 
             log.debug("Application activation finished")
-        except Exception as e:
+        except Exception:
             log.exception("Exception during activation")
             dialog = do_error_dialog(self._exception, "Activation", ignorable=False)
             dialog.set_application(self)  # Keep application alive to show it
@@ -185,7 +185,7 @@ class Application(Gtk.Application):
                     log.info("Unknown task to open: %s", file.get_uri())
 
             log.debug("Application opening finished")
-        except Exception as e:
+        except Exception:
             log.exception("Exception during opening")
             dialog = do_error_dialog(self._exception, "Opening", ignorable=False)
             dialog.set_application(self)  # Keep application alive to show it

--- a/GTG/gtk/backends/backendstree.py
+++ b/GTG/gtk/backends/backendstree.py
@@ -18,7 +18,7 @@
 
 from gi.repository import Gtk
 
-from GTG.gtk.colors import get_colored_tags_markup, rgba_to_hex
+from GTG.gtk.colors import get_colored_tags_markup
 from GTG.backends.backend_signals import BackendSignals
 
 ALLTASKS_TAG = 'gtg-tags-all'

--- a/GTG/gtk/browser/delete_task.py
+++ b/GTG/gtk/browser/delete_task.py
@@ -20,7 +20,6 @@
 from gi.repository import Gtk
 
 from gettext import gettext as _, ngettext
-from GTG.gtk import ViewConfig
 
 
 class DeletionUI:

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -32,7 +32,6 @@ from GTG.core import info
 from GTG.core.system_info import SystemInfo
 from GTG.backends.backend_signals import BackendSignals
 from GTG.core.dirs import ICONS_DIR
-from GTG.core.search import parse_search_query, InvalidQuery
 from gettext import gettext as _
 from GTG.gtk.browser import GnomeConfig
 from GTG.gtk.browser import quick_add
@@ -45,7 +44,6 @@ from GTG.gtk.editor.calendar import GTGCalendar
 from GTG.gtk.tag_completion import TagCompletion
 from GTG.core.dates import Date
 from GTG.core.tasks import Filter, Status, Task
-from GTG.gtk.browser.adaptive_button import AdaptiveFittingWidget # Register type
 
 log = logging.getLogger(__name__)
 PANE_STACK_NAMES_MAP = {

--- a/GTG/gtk/browser/search_editor.py
+++ b/GTG/gtk/browser/search_editor.py
@@ -20,10 +20,9 @@
 This module contains the SearchEditor class which is a window that allows the
 user to edit a saved search properties.
 """
-from gi.repository import GObject, Gtk, Gdk, GdkPixbuf, GLib
+from gi.repository import GObject, Gtk, GLib
 
 import logging
-import random
 from gettext import gettext as _
 from GTG.gtk.browser import GnomeConfig
 

--- a/GTG/gtk/browser/sidebar_context_menu.py
+++ b/GTG/gtk/browser/sidebar_context_menu.py
@@ -28,7 +28,6 @@ like a color picker).
 from gi.repository import Gtk, Gio
 
 from gettext import gettext as _
-from GTG.gtk.colors import generate_tag_color, color_add, color_remove
 from GTG.gtk.browser import GnomeConfig
 
 

--- a/GTG/gtk/browser/tag_editor.py
+++ b/GTG/gtk/browser/tag_editor.py
@@ -20,12 +20,11 @@
 This module contains the TagEditor class which is a window that allows the
 user to edit a tag properties.
 """
-from gi.repository import GObject, Gtk, Gdk, GdkPixbuf, GLib
+from gi.repository import GObject, Gtk, Gdk, GLib
 
 import logging
-import random
 from gettext import gettext as _
-from GTG.gtk.colors import color_add, color_remove, RGBA, rgb_to_hex, random_color
+from GTG.gtk.colors import color_add, color_remove, rgb_to_hex
 from GTG.gtk.browser import GnomeConfig
 
 log = logging.getLogger(__name__)

--- a/GTG/gtk/colors.py
+++ b/GTG/gtk/colors.py
@@ -16,7 +16,7 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk
 from functools import reduce
 import random
 

--- a/GTG/gtk/editor/calendar.py
+++ b/GTG/gtk/editor/calendar.py
@@ -18,7 +18,7 @@
 
 import datetime
 
-from gi.repository import GObject, GLib, Gdk, Gtk
+from gi.repository import GObject, GLib, Gtk
 
 from GTG.gtk.editor import GnomeConfig
 from GTG.core.dates import Date

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -28,9 +28,9 @@ import os
 import time
 from gettext import gettext as _, ngettext
 
-from gi.repository import Gdk, Gtk, GLib, Pango
+from gi.repository import Gdk, Gtk, GLib
 from gi.repository.GObject import signal_handler_block
-from GTG.core.dates import Accuracy, Date
+from GTG.core.dates import Date
 from GTG.core.dirs import UI_DIR
 from GTG.core.plugins.api import PluginAPI
 from GTG.core.plugins.engine import PluginEngine
@@ -38,7 +38,6 @@ from GTG.gtk.editor import GnomeConfig
 from GTG.gtk.editor.calendar import GTGCalendar
 from GTG.gtk.editor.recurring_menu import RecurringMenu
 from GTG.gtk.editor.taskview import TaskView
-from GTG.gtk.tag_completion import tag_filter
 from GTG.gtk.colors import rgb_to_hex
 from GTG.core.tasks import Task, Status, DEFAULT_TITLE
 
@@ -430,7 +429,7 @@ class TaskEditor(Gtk.Window):
         if size:
             try:
                 self.set_default_size(int(size[0]), int(size[1]))
-            except ValueError as e:
+            except ValueError:
                 log.warning('Invalid size configuration for task %s: %s',
                             self.task.id, size)
 

--- a/GTG/gtk/errorhandler.py
+++ b/GTG/gtk/errorhandler.py
@@ -1,15 +1,12 @@
 
-from gi.repository import GObject, GLib, Gtk
+from gi.repository import GObject, Gtk
 from gettext import gettext as _
-from typing import Optional
 import traceback
 import sys
 import os
-import platform
 import functools
 import enum
 import logging
-import configparser
 
 from GTG.core import info
 from GTG.core.system_info import SystemInfo

--- a/GTG/gtk/general_preferences.py
+++ b/GTG/gtk/general_preferences.py
@@ -22,7 +22,7 @@ It enables user to set the most general settings of GTG."""
 
 import os
 
-from gi.repository import Gtk, Gdk, GLib
+from gi.repository import Gtk, GLib
 
 from GTG.core.dirs import UI_DIR
 from gettext import gettext as _

--- a/GTG/gtk/plugins.py
+++ b/GTG/gtk/plugins.py
@@ -20,7 +20,6 @@
 
 from gi.repository import Gtk, Pango
 
-from GTG.core import info
 from GTG.core.plugins import GnomeConfig
 from GTG.core.plugins.engine import PluginEngine
 from gettext import gettext as _

--- a/GTG/plugins/export/templates.py
+++ b/GTG/plugins/export/templates.py
@@ -27,7 +27,7 @@ import threading
 from GTG.core.dirs import plugin_configuration_dir
 
 from Cheetah.Template import Template as CheetahTemplate
-from gi.repository import GObject, GLib
+from gi.repository import GLib
 
 TEMPLATE_PATHS = [
     os.path.join(plugin_configuration_dir('export'), "export_templates"),

--- a/GTG/plugins/gamify/gamify.py
+++ b/GTG/plugins/gamify/gamify.py
@@ -4,7 +4,6 @@ from datetime import date
 from collections import defaultdict
 import logging
 
-from gi.repository import Gio
 from gi.repository import Gtk
 
 from gettext import gettext as _

--- a/GTG/plugins/send_email/sendEmail.py
+++ b/GTG/plugins/send_email/sendEmail.py
@@ -20,7 +20,6 @@
 """
 
 from gi.repository import Gio
-from gi.repository import Gtk
 import urllib.request
 import urllib.parse
 import urllib.error

--- a/GTG/plugins/unmaintained/bugzilla/bugzilla.py
+++ b/GTG/plugins/unmaintained/bugzilla/bugzilla.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject, GLib
+from gi.repository import GLib
 import re
 import threading
 import xmlrpc.client

--- a/tests/core/test_tag_store.py
+++ b/tests/core/test_tag_store.py
@@ -17,10 +17,9 @@
 # -----------------------------------------------------------------------------
 
 from unittest import TestCase
-from uuid import uuid4
 
 from GTG.core.tags import Tag, TagStore
-from lxml.etree import Element, SubElement, XML
+from lxml.etree import XML
 
 
 class TestTagStore(TestCase):

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -16,7 +16,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-import unittest
 from unittest import TestCase
 from uuid import uuid4
 

--- a/tests/tools/test_tags.py
+++ b/tests/tools/test_tags.py
@@ -16,7 +16,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-import unittest
 from unittest import TestCase
 
 from GTG.core.tags import extract_tags_from_text


### PR DESCRIPTION
Relates to #237

With one exception, this is the output of `ruff lint --fix`. The changes look minor - it mostly removes unused imports.

Ruff reports a lot of other errors, including a fair amount of "Undefined name" that indicate broken code paths. We can tackle those separately, and decide whether we want to add Ruff to the pre-commit hook.

This commit in itself is still a good quality of life improvement.

I also did some smoke testing to make sure nothing is obviously broken.