### PR TITLE
Fix (almost) every type hint in tags.py

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -824,7 +824,7 @@ class TaskStore(BaseStore):
             if taglist is not None:
                 for t in taglist.iter('tag'):
                     try:
-                        tag = tag_store.get(t.text)
+                        tag = tag_store.get(UUID(t.text))
                         task.add_tag(tag)
                     except KeyError:
                         pass

--- a/tests/core/test_tag_store.py
+++ b/tests/core/test_tag_store.py
@@ -57,7 +57,7 @@ class TestTagStore(TestCase):
         <taglist>
             <tag id="e2503866-3ebb-4ede-9e72-ff0afa1c2e74" name="to_pay"/>
             <tag id="df4db599-63f8-4fc8-9f3d-5454dcadfd78" name="money" icon="😗️"/>
-            <tag id="ef4db599-73f8-4fc8-9f3d-5454dcadfd78" name="errands" color="767BDC" parent="money"/>
+            <tag id="ef4db599-73f8-4fc8-9f3d-5454dcadfd78" name="errands" color="767BDC" parent="df4db599-63f8-4fc8-9f3d-5454dcadfd78"/>
         </taglist>
             ''')
 


### PR DESCRIPTION
The main changes are as follows:
- Use the _Element class instead of the Element factory for typing.
- Convert tag IDs to UUID during XML parsing. (The same thing caused many problems for tasks.)
- During XML parsing, the `parent` property contains a UUID in the new format. This allowed for some simplifications. A related test case is also fixed.