### PR TITLE
Use the appropriate type of date in `show_popover_closed`

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -285,7 +285,7 @@ class TaskEditor(Gtk.Window):
     def show_popover_closed(self, _=None):
         """Open the closed date calendar popup."""
 
-        closed_date = self.task.date_closed
+        closed_date = self.task.date_closed.date()
 
         with signal_handler_block(self.closed_calendar, self.closed_handle):
             gtime = GLib.DateTime.new_local(closed_date.year, closed_date.month, closed_date.day, 0, 0, 0)


### PR DESCRIPTION
The `show_popover_closed` method of the task editor used the wrong type of date.  (The `show_popover_due` method serves as a  [reference for correct usage](https://github.com/getting-things-gnome/gtg/blob/c501ff800e4517f66b3254f373d41bf9afd861fa/GTG/gtk/editor/editor.py#L277).)

Fixes GitHub issue #1116