### PR TITLE
Simple typing fixes for tasks.py

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -24,7 +24,7 @@ from gettext import gettext as _
 
 from uuid import uuid4, UUID
 import logging
-from typing import Callable, Any, List, Optional, Set, Dict, Tuple
+from typing import Callable, Any, List, Optional, Set, Dict, Tuple, Union
 from enum import Enum
 import re
 import datetime
@@ -1027,7 +1027,7 @@ class TaskStore(BaseStore):
         parent.notify('has_children')
 
 
-    def filter(self, filter_type: Filter, arg: Tag | List[Tag] | None = None) -> List[Task]:
+    def filter(self, filter_type: Filter, arg: Union[Tag,List[Tag],None] = None) -> List[Task]:
         """Filter tasks according to a filter type."""
 
         def filter_tag(tag: Tag) -> List[Task]:


### PR DESCRIPTION
The main changes are as follows:
- use the `_Element` class instead of the `Element` factory for typing
- expect `None` values often used by lxml
- rename the `title` setter to `set_title`
- fix default value for `duplicate_cb`

This fixes every typing error mypy indicates except for the signature errors of some overrides. (I want to investigate the saved searches before looking into those.)