### PR TITLE
Use GNOME 46 in weekly flatpak

### DIFF
--- a/.github/workflows/weekly_flatpak.yml
+++ b/.github/workflows/weekly_flatpak.yml
@@ -12,11 +12,11 @@ jobs:
     # again
     runs-on: ubuntu-24.04
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: actions/checkout@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: org.gnome.GTG.Devel.flatpak
         manifest-path: build-aux/org.gnome.GTG.Devel.json

--- a/build-aux/org.gnome.GTG.Devel.json
+++ b/build-aux/org.gnome.GTG.Devel.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTG.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "master",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "tags": ["devel", "development", "nightly"],


### PR DESCRIPTION
Relates to #708

This fixes the following error:
```
$ flatpak install org.gnome.GTG.Devel_20240530.flatpak
error: The application org.gnome.GTG.Devel/x86_64/master requires the runtime org.gnome.Platform/x86_64/master which was not found
```
by using the latest GNOME runtime, as opposed to the "master" one, which doesn't seem to exist.

Tested by running the workflow on my fork, downloading the artifact from GHA, installing and running the flatpak.