### PR TITLE
Add queue of ExceptionHandlerDialogs

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------------
 
 """ The main window for GTG, listing tags, and open and closed tasks """
+from __future__ import annotations
 
 import datetime
 import logging
@@ -113,19 +114,14 @@ class MainWindow(Gtk.ApplicationWindow):
         self.sidebar = Sidebar(app, app.ds, self)
         self.sidebar_vbox.append(self.sidebar)
 
-        self.panes = {
-            'active': None,
-            'workview': None,
-            'closed': None,
+        self.panes: dict[str, TaskPane] = {
+            'active': TaskPane(self, 'active'),
+            'workview': TaskPane(self, 'workview'),
+            'closed': TaskPane(self, 'closed')
         }
 
-        self.panes['active'] = TaskPane(self, 'active')
         self.open_pane.append(self.panes['active'])
-
-        self.panes['workview'] = TaskPane(self, 'workview')
         self.actionable_pane.append(self.panes['workview'])
-
-        self.panes['closed'] = TaskPane(self, 'closed')
         self.closed_pane.append(self.panes['closed'])
 
         self._init_context_menus()

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -35,7 +35,7 @@ class TaskBox(Gtk.Box):
 
     def __init__(self, config, is_actionable=False):
         self.config = config
-        super(TaskBox, self).__init__()
+        super().__init__()
 
         self.expander = Gtk.TreeExpander()
         self.expander.set_margin_end(6)


### PR DESCRIPTION
Fixes #1093.

This commit adds a queue of ExceptionHandlerDialogs, so we only show one at a time. This avoids the scenario where GTG creates dialogs in a loop, making them impossible to close.

If an exception happens while the dialog is opened, its own dialog will pop up when the current one gets closed.

First test with a repro of #1093, raising an exception in the TaskBox constructor. 3 dialogs pop up consecutively, and it's always possible to click on "Continue" to keep GTG running. After that, clicking on a different pane also makes 3 error dialogs pop up in sequence. Interestingly, GTG hangs on the click on the third Continue. I'm not too bothered about it because this emulates a rare case of the system being in a really bad state and it's probably a good idea to exit anyway.

We could consider setting `ignorable` to False when there is already an exception in the queue, forcing an exit in the "exception while handling an exception" scenario.

I'm also not sure why there are 3 dialogs and not 5 (the size of the queue) or however many times the exception is raised (it seems to stop at some point). But I don't think it matters much.

I also confirmed that I'm seeing "Caught AttributeError ('ListItem' object has no attribute 'bindings') but not showing dialog for it because too many exceptions are happening." in the logs.

Second test with the more common case of a single exception. I added an exception inside `on_search_toggled()`. GTG was working fine until I clicked on the magnifying glass, at which point the dialog popped up. I could click on Continue and keep using GTG.