### PR TITLE
chore: move snap to core24 and GNOME 46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ flatpak/cache
 flatpak/.flatpak-builder
 flatpak/bundles
 
+# Snap files and remote-build logs
+getting-things-gnome_*.snap
+snapcraft-getting-things-gnome-*.txt
+
 # src/ usually has development version of liblarch
 src/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: getting-things-gnome
-base: core20
+base: core24
 compression: lzo
 grade: stable
 license: GPL-3.0
@@ -9,12 +9,14 @@ confinement: strict
 apps:
   gtg:
     command: usr/bin/gtg
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     environment:
-      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PYTHONPATH: $SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages
     common-id: org.gnome.GTG
-    plugs: [network]
-    slots: [dbus-service]
+    plugs:
+      - network
+    slots:
+      - dbus-service
 
 slots:
   dbus-service:
@@ -26,33 +28,31 @@ parts:
   gtg:
     source: .
     plugin: meson
-    build-environment: [PYTHONPATH: '']
-    build-packages: [gettext, itstool]
-    meson-parameters: [--prefix=/usr]
-    parse-info: [usr/share/metainfo/org.gnome.GTG.appdata.xml]
-    stage-packages:
-      - python3-caldav
-      - python3-dateutil
-      - python3-dbus
-      - python3-lxml
-      - python3-vobject
+    meson-parameters:
+      - --prefix=/usr
+    build-packages:
+      - gettext
+      - itstool
+      - meson
+    parse-info:
+      - usr/share/metainfo/org.gnome.GTG.appdata.xml
     stage:
-        - usr/bin/gtg
-        - usr/lib/python3/
-        - usr/share/
-        - -usr/share/doc/
-        - -usr/share/lintian/
-        - -usr/share/man/
+      - usr/bin/gtg
+      - usr/lib/python3/
+      - usr/share/
+    override-build: |
+      craftctl default
+      sed -i $CRAFT_PART_INSTALL/usr/share/applications/org.gnome.GTG.desktop \
+        -e 's|Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/org.gnome.GTG.svg|'
+    after:
+      - python-deps
 
-  liblarch:
-    source: https://github.com/getting-things-gnome/liblarch
-    source-tag: v3.2.0
-    source-type: git
+  python-deps:
+    source: https://github.com/getting-things-gnome/liblarch.git
     plugin: python
-    build-environment:
-      - SNAPCRAFT_PYTHON_INTERPRETER: python3.8
-      - PATH: $SNAPCRAFT_PART_INSTALL/bin:$PATH
-      - PYTHONPATH: ''
-    organize:
-      lib/python3.8/site-packages/liblarch*: usr/lib/python3/dist-packages/
-    stage: [usr/lib/python3/dist-packages, -usr/lib/python3/dist-packages/liblarch*/__pycache__]
+    build-packages:
+      - python3-dbus
+    python-packages:
+      - lxml==5.1.0
+      - caldav==1.3.9
+      - Cheetah3


### PR DESCRIPTION
- move snap to core24 which brings GNOME 46
- simplify how liblarch is built
- setup gitignore for expected output