### PR TITLE
Fixes for 'filter_tag'

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -179,6 +179,15 @@ class Tag(GObject.Object):
             ancestors.append(here)
         return ancestors
 
+
+    def get_matching_tags(self) -> List['Tag']:
+        """Return the tag with its descendants."""
+        matching = [self]
+        for c in self.children:
+            matching += c.get_matching_tags()
+        return matching
+
+
     def __hash__(self):
         return id(self)
 

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -1035,14 +1035,8 @@ class TaskStore(BaseStore):
 
             output = []
 
-            for t in self.data:
-                tags = [_tag for _tag in t.tags]
-
-                # Include the tag's children
-                for _tag in t.tags:
-                    for child in _tag.children:
-                        tags.append(child)
-
+            for t in self.lookup.values():
+                tags = { matching_tag for own_tag in t.tags for matching_tag in own_tag.get_matching_tags() }
                 if tag in tags:
                     output.append(t)
 


### PR DESCRIPTION
This PR has two main changes:
- Iterate over all tasks, not just the root elements.
- Consider all descendants of a tag, not just the immediate children.

Because of these bugs, it was impossible to get rid of the `money` tag in the default dataset:
1. Start the program with the default dataset. 
2. Delete the `money` tag in the sidebar.
3. Restart the application.
4. Observe that the `money` tag is absent from the sidebar.
5. Open the _"Learn How to Use Tags and Enable the Sidebar"_ task.
6. Observe the `money` tag reappearing in the sidebar. 

(I discovered this bug while investigating Issue #1115. They might be related, but the described anomaly is different.)