### PR TITLE
Look for parent in due date binding

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -564,7 +564,7 @@ class Task(GObject.Object):
     @GObject.Property(type=bool, default=False)
     def has_date_due(self) -> bool:
         if not self._has_date_due and self.parent:
-            return self.parent._has_date_due
+            return self.parent.has_date_due
         else:
             return self._has_date_due
 

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -563,7 +563,10 @@ class Task(GObject.Object):
 
     @GObject.Property(type=bool, default=False)
     def has_date_due(self) -> bool:
-        return self._has_date_due
+        if not self._has_date_due and self.parent:
+            return self.parent._has_date_due
+        else:
+            return self._has_date_due
 
 
     @has_date_due.setter
@@ -593,7 +596,10 @@ class Task(GObject.Object):
 
     @GObject.Property(type=str)
     def date_due_str(self) -> str:
-        return self._date_due_str
+        if not self._date_due_str and self.parent:
+            return self.parent._date_due_str
+        else:
+            return self._date_due_str
 
 
     @date_due_str.setter


### PR DESCRIPTION
If the task's parent has a due date then we should show sub-tasks as having that due date.

Fix #1072