### PR TITLE
Improve version name

### DIFF
--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -1,14 +1,19 @@
-# Append short commit hash and put it in
-# info.py when using development profile.
-# Use git rev-parse --short HEAD if available.
-
 git = find_program('git', required : false, disabler : true)
 
 if git.found() and get_option('profile') == 'development'
-    version = meson.project_version() + '-' + run_command(
+    base_version = meson.project_version()
+    commit = run_command(
             ['git', 'rev-parse', '--short', 'HEAD'],
             check: true
         ).stdout().strip()
+    version = base_version + '-' + commit
+elif get_option('profile') == 'flatpak_snapshot'
+    base_version = meson.project_version()
+    date = run_command(
+            ['date', '--utc', '+%Y%m%d'],
+            check: true
+        ).stdout().strip()
+    version = base_version + '-' + date
 else
     version = meson.project_version()
 endif

--- a/build-aux/org.gnome.GTG.Devel.json
+++ b/build-aux/org.gnome.GTG.Devel.json
@@ -66,7 +66,7 @@
     {
       "name": "gtg",
       "config-opts" : [
-          "-Dprofile=development"
+          "-Dprofile=flatpak_snapshot"
       ],
       "buildsystem": "meson",
       "sources": [{

--- a/data/org.gnome.GTG.appdata.xml.in.in
+++ b/data/org.gnome.GTG.appdata.xml.in.in
@@ -51,6 +51,11 @@
     <update_contact>nekohayo+gtg@gmail.com</update_contact>
 
     <releases>
+        <!-- Snapshot version is shown as the version of the weekly flatpak -->
+        <!-- It needs a timestamp or date attribute, otherwise flatpak-builder ignores it -->
+        <!-- So we set the date attribute, to any day after the last stable release -->
+        <release version="0.7-dev" date="2022-03-03" type="snapshot"/>
+
         <release version="0.6" date="2022-03-02" type="stable">
             <url>https://fortintam.com/blog/gtg-0-6-released</url>
         </release>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gtg',
-  version: '0.6.0',
+  version: '0.7-dev',
   meson_version: '>= 0.51.0'
 )
 
@@ -25,7 +25,7 @@ pythondir = python3.get_path('purelib')
 rdnn_name = 'org.gnome.GTG'
 application_id = rdnn_name
 
-if get_option('profile') == 'development'
+if get_option('profile') == 'development' or get_option('profile') == 'flatpak_snapshot'
   application_id = rdnn_name + '.Devel'
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,8 @@ option(
   type: 'combo',
   choices: [
     'default',
-    'development'
+    'development',
+    'flatpak_snapshot'
   ],
   value: 'default',
   description: 'Changes App ID'


### PR DESCRIPTION
Update base version from 0.6.0 to 0.7-dev.

The idea is that when we're ready to release 0.7, we'll create a 0.7  branch. We'll then update the version to "0.7" on that branch, and "0.8-dev" on master.

Append the short commit hash in development mode (as before)

Append the date in flatpak mode, to help keep track of versions when using the weekly flatpak. Tested the flatpak by running the GHA workflow on my fork.