### PR TITLE
Fix most of the typing errors in datastore.py

### DIFF
--- a/GTG/core/dirs.py
+++ b/GTG/core/dirs.py
@@ -20,7 +20,7 @@ Information where various resources like config, icons, etc. are stored
 """
 import os
 
-from gi.repository import GLib
+from gi.repository import GLib # type: ignore[import-untyped]
 
 # Folder where core GTG data is stored like services information, tags, etc
 DATA_DIR = os.path.join(GLib.get_user_data_dir(), 'gtg')


### PR DESCRIPTION
The main changes are the following:
- use the `_Element`/`_ElementTree` class instead of the `Element`/`ElementTree` factory for typing,
- expect `None` values returned by lxml,
- expect `None` values in case the methods are used in the wrong order,
- fix the use of undefined variables in `do_first_run_versioning`.

(Please note that `do_first_run_versioning` is never called. Maybe it is a bug or something to be removed.)
