### PR TITLE
Fix calendar selection for repeating tasks

### DIFF
--- a/GTG/gtk/data/recurring_menu.ui
+++ b/GTG/gtk/data/recurring_menu.ui
@@ -102,13 +102,11 @@
         <!-- without, it covers the section heading -->
         <property name="margin-top">6</property>
         <property name="show-heading">False</property>
-        <signal name="day-selected" handler="_on_monthly_selected"/>
       </object>
     </child>
     <child type="_year_calendar">
       <object class="GtkCalendar" id="_year_calendar">
         <property name="margin-top">6</property>
-        <signal name="day-selected" handler="_on_yearly_selected"/>
       </object>
     </child>
   </template>


### PR DESCRIPTION
Fixes #1015

After selecting the desired day in the yearly calendar, the `_update_calendar` method synced the monthly calendar, thus triggering the `_on_monthly_selected` callback. The bug also worked the other way around. 

Now, the `_update_calendar` blocks these callbacks using a `with` statement to prevent the issue.