### PR TITLE
Update meson.build

### DIFF
--- a/GTG/core/meson.build
+++ b/GTG/core/meson.build
@@ -23,7 +23,7 @@ info_config.set('VCS_TAG', version)
 
 infodir = python3.get_install_dir()
 info_py = configure_file(
-            input : 'info.py.in',
+            input : 'info.py',
             output :'info.py',
             configuration: info_config,
             install : true,


### PR DESCRIPTION
As a follow-up to issue #1141, we've successfully renamed info.py.in to info.py. This change has resolved the automated test failures we were experiencing.