### PR TITLE
Add README section to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ them locally with `pre-commit run --all-files`.
 For more guidelines about contributing, see
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+### Running the tests
+
+Tests are run using `pytest`.
+
+We first need some files to be pre-processed by meson, which is done by the
+following one-time step:
+```sh
+meson setup ./build
+cd GTG/core/ && ln -s ../../.build/GTG/core/info.py .
+```
+
+Then you can run the tests with `pytest` in the repository root.
+
+
 # "Where is my user data and config stored?"
 
 It depends:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ We first need some files to be pre-processed by meson, which is done by the
 following one-time step:
 ```sh
 meson setup ./build
-cd GTG/core/ && ln -s ../../.build/GTG/core/info.py .
+cd GTG/core/ && ln -s ../../build/GTG/core/info.py .
 ```
 
 Then you can run the tests with `pytest` in the repository root.


### PR DESCRIPTION
Describe a simple way to get the tests running. This should help clear the confusion around the `ModuleNotFoundError: No module named 'GTG.core.info'` type of errors you get when just running `pytest` (see #1141).

Adapted from the explanation at #1036

We can close #1141 and #1142