### PR TITLE
Suppress mismatched signature errors in type-checking

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -53,6 +53,9 @@ class BaseStore(GObject.Object,Generic[S]):
     # --------------------------------------------------------------------------
 
     def new(self) -> S:
+        """Creates a new item in the store.
+        NOTE: Subclasses may override the signature of this method.
+        """
         raise NotImplementedError
 
 
@@ -177,6 +180,9 @@ class BaseStore(GObject.Object,Generic[S]):
     # --------------------------------------------------------------------------
 
     def from_xml(self, xml: _Element) -> None:
+        """Load data from XML.
+        NOTE: Subclasses may override the signature of this method.
+        """
         raise NotImplementedError
 
 

--- a/GTG/core/saved_searches.py
+++ b/GTG/core/saved_searches.py
@@ -162,7 +162,7 @@ class SavedSearchStore(BaseStore):
         return root
 
 
-    def new(self, name: str, query: str, parent: Optional[UUID] = None) -> SavedSearch:
+    def new(self, name: str, query: str, parent: Optional[UUID] = None) -> SavedSearch: # type: ignore[override]
         """Create a new saved search and add it to the store."""
 
         search_id = uuid4()

--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -245,7 +245,7 @@ class TagStore(BaseStore[Tag]):
         return self.lookup_names[name]
 
 
-    def new(self, name: str, parent: Optional[UUID] = None) -> Tag:
+    def new(self, name: str, parent: Optional[UUID] = None) -> Tag: # type: ignore[override]
         """Create a new tag and add it to the store."""
 
         name = name if not name.startswith('@') else name[1:]

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -766,7 +766,7 @@ class TaskStore(BaseStore):
         return new_task
 
 
-    def new(self, title: str = '', parent: Optional[UUID] = None) -> Task:
+    def new(self, title: str = '', parent: Optional[UUID] = None) -> Task: # type: ignore[override]
         """Create a new task and add it to the store."""
 
         tid = uuid4()
@@ -784,7 +784,7 @@ class TaskStore(BaseStore):
         return task
 
 
-    def from_xml(self, xml: _Element, tag_store: TagStore) -> None:
+    def from_xml(self, xml: _Element, tag_store: TagStore) -> None: # type: ignore[override]
         """Load up tasks from a lxml object."""
 
         elements = list(xml.iter(self.XML_TAG))


### PR DESCRIPTION
The only purpose of the `BaseStore.new` and `BaseStore.from_xml` methods is to provide an overview of how to use the subclasses. However, the mismatched signatures caused typing errors. Suppressing these errors instead of simply deleting the base class methods can still provide this "educational" benefit.

Other options would be:
- to use an extra generic parameter in these methods (looks a bit over-complicated...)
- to use composition instead of inheritance (more elegant, but this would probably break existing code and established interfaces)