### PR TITLE
Prevent reparenting a task to itself

### DIFF
--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -613,7 +613,10 @@ class TaskPane(Gtk.ScrolledWindow):
 
 
     def check_parent(self, value, target) -> bool:
-        """Check to parenting a parent to its own children"""
+        """Check for parenting a task to its own descendant or to itself."""
+
+        if value == target:
+            return False
 
         item = target
         while item.parent:


### PR DESCRIPTION
It was possible to reparent a task to itself using drag-and-drop. `TaskPane.check_parent` now checks if the drop target is the same task we are moving.

**Steps to reproduce the bug:**
1. Pick a task and start dragging it over another task.
2. Move it back over itself, and drop it.
3. Observe as the task disappears instead of not doing anything.

By repeating these steps, you can make all of your tasks disappear. They are still in the `gtg_data.xml`, but there is no way accesing them.