### PR TITLE
Prevent reparenting a tag to itself

### DIFF
--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -591,7 +591,10 @@ class Sidebar(Gtk.ScrolledWindow):
 
 
     def check_parent(self, value, target) -> bool:
-        """Check to parenting a parent to its own children"""
+        """Check for parenting a tag to its own descendant or to itself."""
+
+        if value == target:
+            return False
 
         item = target
         while item.parent:


### PR DESCRIPTION
Similarly to PR #1149, it was possible to reparent a tag to itself using drag-and-drop. `Sidebar.check_parent` now checks if the drop target is the same tag we are moving.

**Steps to reproduce the bug:**

1. Pick a tag and start dragging it over another tag.
2. Move it back over itself, and drop it.
3. Observe the program freezing and eventually running out of memory.

(If it is not against any current plans, I would be happy to experiment with a common `StoreItem` base class or something similar to prevent such duplicated bugs.)

