### PR TITLE
Minor type fixes for core

### DIFF
--- a/GTG/backends/generic_backend.py
+++ b/GTG/backends/generic_backend.py
@@ -28,6 +28,7 @@ import os
 import pickle
 import threading
 import logging
+from typing import Dict, Any
 
 from GTG.backends.backend_signals import BackendSignals
 from GTG.core.dirs import SYNC_DATA_DIR
@@ -66,7 +67,7 @@ class GenericBackend():
     #        _("Short description of the backend"),\
     #    }
     # The complete list of constants and their meaning is given below.
-    _general_description = {}
+    _general_description: Dict[str,Any] = {}
 
     # These are the parameters to configure a new backend of this type. A
     # parameter has a name, a type and a default value.
@@ -82,7 +83,7 @@ class GenericBackend():
     #        GenericBackend.PARAM_DEFAULT_VALUE: 42,
     #        }}
     # The complete list of constants and their meaning is given below.
-    _static_parameters = {}
+    _static_parameters: Dict[str,Dict[str,Any]] = {}
 
     def initialize(self):
         """

--- a/GTG/core/info.pyi
+++ b/GTG/core/info.pyi
@@ -1,0 +1,17 @@
+from typing import List
+
+NAME: str
+AUTHORS: str
+COPYRIGHT: str
+SHORT_DESCRIPTION: str
+URL: str
+CHAT_URL: str
+SOURCE_CODE_URL: str
+OPENHUB_URL: str
+REPORT_BUG_URL: str
+EMAIL: str
+VERSION: str
+AUTHORS_MAINTAINERS: List[str]
+AUTHORS_RELEASE_CONTRIBUTORS: List[str]
+ARTISTS: List[str]
+DOCUMENTERS: List[str]

--- a/GTG/core/plugins/engine.py
+++ b/GTG/core/plugins/engine.py
@@ -20,7 +20,7 @@ import importlib
 import inspect
 import os
 import logging
-from typing import List
+from typing import List, Tuple
 from gi.repository import GLib # type: ignore[import-untyped]
 
 from GTG.core.dirs import PLUGIN_DIRS
@@ -41,7 +41,7 @@ class Plugin():
     # True if the plugin is actually loaded and running.
     _active = False
     missing_modules: List[str] = []
-    missing_dbus = []
+    missing_dbus: List[Tuple[str, ...]] = []
 
     def __init__(self, info, module_paths):
         """Initialize the Plugin using a ConfigParser."""

--- a/GTG/core/search.py
+++ b/GTG/core/search.py
@@ -82,7 +82,7 @@ from GTG.core.dates import Date
 
 # Generate keywords and their possible translations
 # They must be listed because of gettext
-KEYWORDS = {
+TMP_KEYWORDS = {
     # Translators: Used in search parsing, no spaces, lowercased in code
     "not": _("not"),
     # Translators: Used in search parsing, no spaces, lowercased in code
@@ -108,9 +108,10 @@ KEYWORDS = {
 }
 
 # transform keywords and their translations into a list of possible commands
-for key in KEYWORDS:
-    if " " not in KEYWORDS[key] and KEYWORDS[key].lower() != key.lower():
-        possible_words = [key.lower(), KEYWORDS[key].lower()]
+KEYWORDS = dict()
+for key in TMP_KEYWORDS:
+    if " " not in TMP_KEYWORDS[key] and TMP_KEYWORDS[key].lower() != key.lower():
+        possible_words = [key.lower(), TMP_KEYWORDS[key].lower()]
     else:
         possible_words = [key.lower()]
     KEYWORDS[key] = possible_words

--- a/GTG/core/sorters.py
+++ b/GTG/core/sorters.py
@@ -129,10 +129,8 @@ class TaskTagSorter(ReversibleSorter):
     def get_first_letter(self, tags) -> str:
         """Get first letter of the first tag in a set of tags."""
 
-        # Fastest way to get the first item
-        # on a set in Python
-        for t in tags:
-            return t.name[0]
+        return next(iter(tags)).name[0]
+
 
     def do_compare(self, a, b) -> Gtk.Ordering:
 


### PR DESCRIPTION
The changes are as follows:
- Add some missing type hints. (It looks like `Plugin.missing_dbus` is never actually updated, maybe it can be removed once we are sure that we don't need it. The current type hint is based on an older code version.)
- Add a typing stub for `core/info.py.in`.
- Introduce `TMP_KEYWORDS` to avoid changing types.
- Simplify `TaskTagSorter.get_first_letter` to resolve a missing return error. (Based on my micro-benchmarks, it is still performant.)