### PR TITLE
Introduce the StoreItem base class

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -42,8 +42,8 @@ class StoreItem(GObject.Object):
     def __init__(self,id: UUID):
         self.id: UUID = id
         self.parent: Optional[Self] = None
-        self.children: List[Self] = []
-        super(StoreItem, self).__init__()
+        self.children: list[Self] = []
+        super().__init__()
 
 
     @GObject.Property(type=int)
@@ -67,7 +67,7 @@ class StoreItem(GObject.Object):
         return ancestors
 
 
-    def check_possible_parent(self, target) -> bool:
+    def is_parentable_to(self, target) -> bool:
         """Check for parenting an item to its own descendant or to itself."""
         return self != target and self not in target.get_ancestors()
 

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -25,7 +25,7 @@ from uuid import UUID
 import logging
 
 from lxml.etree import _Element
-from typing import Dict, List, Optional, TypeVar, Generic
+from typing import Dict, Optional, TypeVar, Generic
 from typing_extensions import Self
 
 
@@ -57,9 +57,9 @@ class StoreItem(GObject.Object):
         return len(self.children) > 0
 
 
-    def get_ancestors(self) -> List[Self]:
+    def get_ancestors(self) -> list[Self]:
         """Return all ancestors of this tag"""
-        ancestors: List[Self] = []
+        ancestors: list[Self] = []
         here = self
         while here.parent:
             here = here.parent
@@ -79,7 +79,7 @@ class BaseStore(GObject.Object,Generic[S]):
 
     def __init__(self) -> None:
         self.lookup: Dict[UUID, S] = {}
-        self.data: List[S] = []
+        self.data: list[S] = []
 
         super().__init__()
 
@@ -267,7 +267,7 @@ class BaseStore(GObject.Object,Generic[S]):
     def print_tree(self) -> None:
         """Print the all the items as a tree."""
 
-        def recursive_print(tree: List, indent: int) -> None:
+        def recursive_print(tree: list, indent: int) -> None:
             """Inner print function. """
 
             tab =  '   ' * indent if indent > 0 else ''

--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -29,7 +29,7 @@ import re
 from lxml.etree import Element, SubElement, _Element
 from typing import Dict, List, Set, Optional
 
-from GTG.core.base_store import BaseStore
+from GTG.core.base_store import BaseStore, StoreItem
 
 log = logging.getLogger(__name__)
 
@@ -40,26 +40,23 @@ def extract_tags_from_text(text):
     return re.findall(r'(?:^|[\s])(@[\w\/\.\-\:\&]*\w)', text)
 
 
-class Tag(GObject.Object):
+class Tag(StoreItem):
     """A tag that can be applied to a Task."""
 
     __gtype_name__ = 'gtg_Tag'
 
     def __init__(self, id: UUID, name: str) -> None:
-        self.id = id
         self._name = name
 
         self._icon: Optional[str] = None
         self._color: Optional[str] = None
         self.actionable = True
-        self.children: List[Tag] = []
-        self.parent = None
 
         self._task_count_open = 0
         self._task_count_actionable = 0
         self._task_count_closed = 0
 
-        super(Tag, self).__init__()
+        super(Tag, self).__init__(id)
 
 
     def __str__(self) -> str:
@@ -80,11 +77,6 @@ class Tag(GObject.Object):
         return self.id == other.id
 
 
-    @GObject.Property(type=int)
-    def children_count(self) -> int:
-        """Read only property."""
-
-        return len(self.children)
 
 
     @GObject.Property(type=str)
@@ -168,16 +160,6 @@ class Tag(GObject.Object):
     @task_count_closed.setter
     def set_task_count_closed(self, value: int) -> None:
         self._task_count_closed = value
-
-
-    def get_ancestors(self) -> List['Tag']:
-        """Return all ancestors of this tag"""
-        ancestors: List[Tag] = []
-        here = self
-        while here.parent:
-            here = here.parent
-            ancestors.append(here)
-        return ancestors
 
 
     def get_matching_tags(self) -> List['Tag']:

--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -56,7 +56,7 @@ class Tag(StoreItem):
         self._task_count_actionable = 0
         self._task_count_closed = 0
 
-        super(Tag, self).__init__(id)
+        super().__init__(id)
 
 
     def __str__(self) -> str:

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -112,7 +112,7 @@ class Task(StoreItem):
             raise NotImplementedError
         self.duplicate_cb: Callable[[Task],Task] = default_duplicate_cb
 
-        super(Task, self).__init__(id)
+        super().__init__(id)
 
 
     @GObject.Property(type=bool, default=True)

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -590,27 +590,11 @@ class Sidebar(Gtk.ScrolledWindow):
             source.get_widget().set_opacity(1)
 
 
-    def check_parent(self, value, target) -> bool:
-        """Check for parenting a tag to its own descendant or to itself."""
-
-        if value == target:
-            return False
-
-        item = target
-        while item.parent:
-            if item.parent == value:
-                return False
-
-            item = item.parent
-
-        return True
-
-
     def drag_drop(self, target, value, x, y):
         """Callback when dropping onto a target"""
         dropped = target.get_widget().props.tag
 
-        if not self.check_parent(value, dropped):
+        if not value.check_possible_parent(dropped):
             return
 
         if value.parent:

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -594,7 +594,7 @@ class Sidebar(Gtk.ScrolledWindow):
         """Callback when dropping onto a target"""
         dropped = target.get_widget().props.tag
 
-        if not value.check_possible_parent(dropped):
+        if not value.is_parentable_to(dropped):
             return
 
         if value.parent:

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -617,7 +617,7 @@ class TaskPane(Gtk.ScrolledWindow):
 
         dropped = target.get_widget().props.task
 
-        if not task.check_possible_parent(dropped):
+        if not task.is_parentable_to(dropped):
             return
 
         if task.parent:

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -612,28 +612,12 @@ class TaskPane(Gtk.ScrolledWindow):
         return Gdk.DragAction.COPY
 
 
-    def check_parent(self, value, target) -> bool:
-        """Check for parenting a task to its own descendant or to itself."""
-
-        if value == target:
-            return False
-
-        item = target
-        while item.parent:
-            if item.parent == value:
-                return False
-
-            item = item.parent
-
-        return True
-
-
     def drag_drop(self, target, task, x, y):
         """Callback when dropping onto a target"""
 
         dropped = target.get_widget().props.task
 
-        if not self.check_parent(task, dropped):
+        if not task.check_possible_parent(dropped):
             return
 
         if task.parent:

--- a/docs/contributors/coding best practices.md
+++ b/docs/contributors/coding best practices.md
@@ -171,7 +171,7 @@ Modules should begin with the following header (updated to the current year):
 
 ```
 # -----------------------------------------------------------------------------
-# Gettings Things GNOME! - a personal organizer for the GNOME desktop
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
 # Copyright (c) 2008-2022 - the GTG contributors
 #
 # This program is free software: you can redistribute it and/or modify it under

--- a/tests/core/test_store_item.py
+++ b/tests/core/test_store_item.py
@@ -1,0 +1,144 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) 2008-2024 - the GTG contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+from unittest import TestCase
+from uuid import uuid4
+
+from GTG.core.base_store import StoreItem
+
+
+class TestStoreItemProperties(TestCase):
+
+
+    def test_init(self):
+        uuid = uuid4()
+        item = StoreItem(uuid)
+        self.assertEqual(item.id, uuid)
+
+
+    def test_children_count_default_value(self):
+        item = StoreItem(uuid4())
+        self.assertEqual(item.children_count, 0)
+        self.assertFalse(item.has_children)
+
+
+    def test_children_count_singel_child(self):
+        item = StoreItem(uuid4())
+        item.children.append(StoreItem(uuid4))
+        self.assertEqual(item.children_count, 1)
+        self.assertTrue(item.has_children)
+
+
+    def test_children_count_multiple_children(self):
+        item = StoreItem(uuid4())
+        item.children = [ StoreItem(uuid4) for _ in range(15) ]
+        self.assertEqual(item.children_count, 15)
+        self.assertTrue(item.has_children)
+
+
+
+class TestStoreItemGetAncestors(TestCase):
+
+
+    def setUp(self):
+        self.root = StoreItem(uuid4())
+
+        self.children = [ StoreItem(uuid4()) for _ in range(5) ]
+        self.root.children = self.children
+        for c in self.children:
+            c.parent = self.root
+
+        self.grandchildren = [ StoreItem(uuid4()) for _ in range(7) ]
+        self.root.children[-1].children = self.grandchildren
+        for c in self.grandchildren:
+            c.parent = self.root.children[-1]
+
+        self.greatgrandchildren = [ StoreItem(uuid4()) for _ in range(2) ]
+        self.root.children[-1].children[0].children = self.greatgrandchildren
+        for c in self.greatgrandchildren:
+            c.parent = self.root.children[-1].children[0]
+
+
+    def test_default_value(self):
+        item = StoreItem(uuid4())
+        self.assertEqual(item.get_ancestors(),[])
+
+
+    def test_root_element(self):
+        self.assertEqual(self.root.get_ancestors(),[])
+
+
+    def test_single_ancestor(self):
+        self.assertEqual(self.children[3].get_ancestors(),[self.root])
+
+
+    def test_multiple_ancestors(self):
+        expected = [self.root.children[-1].children[0],self.root.children[-1],self.root]
+        self.assertEqual(self.greatgrandchildren[0].get_ancestors(),expected)
+
+
+
+class TestStoreItemCheckPossibleParent(TestCase):
+
+
+    def setUp(self):
+        self.root = StoreItem(uuid4())
+        self.strangers = [ StoreItem(uuid4()) for _ in range(3) ]
+
+        self.children = [ StoreItem(uuid4()) for _ in range(5) ]
+        self.root.children = self.children
+        for c in self.children:
+            c.parent = self.root
+
+        self.grandchildren = [ StoreItem(uuid4()) for _ in range(7) ]
+        self.root.children[-1].children = self.grandchildren
+        for c in self.grandchildren:
+            c.parent = self.root.children[-1]
+
+        self.greatgrandchildren = [ StoreItem(uuid4()) for _ in range(2) ]
+        self.root.children[-1].children[0].children = self.greatgrandchildren
+        for c in self.greatgrandchildren:
+            c.parent = self.root.children[-1].children[0]
+
+
+    def test_forbid_selfparenting(self):
+        self.assertFalse(self.root.check_possible_parent(self.root))
+
+
+    def test_forbid_children(self):
+        self.assertFalse(self.root.check_possible_parent(self.children[0]))
+
+
+    def test_forbid_distant_descendant(self):
+        self.assertFalse(self.root.check_possible_parent(self.greatgrandchildren[1]))
+
+
+    def test_allow_parent(self):
+        self.assertTrue(self.children[1].check_possible_parent(self.root))
+
+
+    def test_allow_distant_ancestor(self):
+        self.assertTrue(self.greatgrandchildren[0].check_possible_parent(self.root))
+
+
+    def test_allow_sibling(self):
+        self.assertTrue(self.children[1].check_possible_parent(self.children[2]))
+
+
+    def test_allow_other_trees(self):
+        self.assertTrue(self.greatgrandchildren[0].check_possible_parent(self.strangers[2]))

--- a/tests/core/test_store_item.py
+++ b/tests/core/test_store_item.py
@@ -37,7 +37,7 @@ class TestStoreItemProperties(TestCase):
         self.assertFalse(item.has_children)
 
 
-    def test_children_count_singel_child(self):
+    def test_children_count_single_child(self):
         item = StoreItem(uuid4())
         item.children.append(StoreItem(uuid4))
         self.assertEqual(item.children_count, 1)
@@ -93,7 +93,7 @@ class TestStoreItemGetAncestors(TestCase):
 
 
 
-class TestStoreItemCheckPossibleParent(TestCase):
+class TestStoreItemIsParentableTo(TestCase):
 
 
     def setUp(self):
@@ -117,28 +117,28 @@ class TestStoreItemCheckPossibleParent(TestCase):
 
 
     def test_forbid_selfparenting(self):
-        self.assertFalse(self.root.check_possible_parent(self.root))
+        self.assertFalse(self.root.is_parentable_to(self.root))
 
 
     def test_forbid_children(self):
-        self.assertFalse(self.root.check_possible_parent(self.children[0]))
+        self.assertFalse(self.root.is_parentable_to(self.children[0]))
 
 
     def test_forbid_distant_descendant(self):
-        self.assertFalse(self.root.check_possible_parent(self.greatgrandchildren[1]))
+        self.assertFalse(self.root.is_parentable_to(self.greatgrandchildren[1]))
 
 
     def test_allow_parent(self):
-        self.assertTrue(self.children[1].check_possible_parent(self.root))
+        self.assertTrue(self.children[1].is_parentable_to(self.root))
 
 
     def test_allow_distant_ancestor(self):
-        self.assertTrue(self.greatgrandchildren[0].check_possible_parent(self.root))
+        self.assertTrue(self.greatgrandchildren[0].is_parentable_to(self.root))
 
 
     def test_allow_sibling(self):
-        self.assertTrue(self.children[1].check_possible_parent(self.children[2]))
+        self.assertTrue(self.children[1].is_parentable_to(self.children[2]))
 
 
     def test_allow_other_trees(self):
-        self.assertTrue(self.greatgrandchildren[0].check_possible_parent(self.strangers[2]))
+        self.assertTrue(self.greatgrandchildren[0].is_parentable_to(self.strangers[2]))


### PR DESCRIPTION
This is a followup to PR #1151 removing duplicated functionality. The main benefits include:
- reduced code duplication,
- isolated testing of common functionality,
- the possibility of a more targeted testing of the `BaseStore` class (which I would be happy to do).

The main changes are as follows:
- introduced a new class that implements common functionality for items in a `BaseStore`,
- added corresponding unit tests,
- fixed a typo in the copyright text.