### PR TITLE
Fix crash when deleting a task and its descendant together

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -136,8 +136,8 @@ class BaseStore(GObject.Object,Generic[S]):
         self.emit('removed', str(item_id))
 
 
-    def batch_remove(self,item_ids: List[UUID]):
-        """Remove multiple items and their descendants at the same time. """
+    def batch_remove(self,item_ids: List[UUID]) -> None:
+        """Remove multiple items, ensuring nothing gets deleted twice"""
         for key in item_ids:
             if key in self.lookup:
                 self.remove(key)

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -136,6 +136,13 @@ class BaseStore(GObject.Object,Generic[S]):
         self.emit('removed', str(item_id))
 
 
+    def batch_remove(self,item_ids: List[UUID]):
+        """Remove multiple items and their descendants at the same time. """
+        for key in item_ids:
+            if key in self.lookup:
+                self.remove(key)
+
+
     # --------------------------------------------------------------------------
     # PARENTING
     # --------------------------------------------------------------------------

--- a/GTG/gtk/browser/delete_task.py
+++ b/GTG/gtk/browser/delete_task.py
@@ -44,8 +44,8 @@ class DeletionUI:
 
     def on_delete_confirm(self, tasklist):
 
-        for task in tasklist:
-            self.ds.tasks.remove(task.id)
+        task_ids = [ t.id for t in tasklist ]
+        self.ds.tasks.batch_remove(task_ids)
 
 
     def recursive_list_tasks(self, tasklist, root):


### PR DESCRIPTION
When deleting a task and one of its descendants simultaneously, the program crashes. It happens because it tries to remove the descendant twice: once as a selected task and once as the descendant of the other task.

**Steps to reproduce the bug:**
1. Start GTG with the default dataset.
2. Expand the first task (_"Getting Started with GTG (read me first)"_).
3. Select the parent tag and its children.
4. Try to delete them using simultaneously.
5. Observe the crash.

When deleting multiple tasks simultaneously, we should check that a given task was not already removed as the descendant of a previously removed task.