### PR TITLE
Remove old List use introduced by another branch from base_store.py

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -171,7 +171,7 @@ class BaseStore(GObject.Object,Generic[S]):
         self.emit('removed', str(item_id))
 
 
-    def batch_remove(self,item_ids: List[UUID]) -> None:
+    def batch_remove(self,item_ids: list[UUID]) -> None:
         """Remove multiple items, ensuring nothing gets deleted twice"""
         for key in item_ids:
             if key in self.lookup:


### PR DESCRIPTION
PR #1158 aimed to remove all outdated `typing.List` references form the `base_store.py` file. However, PR #1159 introduced a new one in the meantime that was not considered by 1158. When 1158 was merged, it caused all sorts of errors (e.g., failing the GHA tests) because of the now missing `typing.List` import. 