### PR TITLE
Tests and related bugfixes for BaseStore.remove

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -150,23 +150,17 @@ class BaseStore(GObject.Object,Generic[S]):
         """Remove an existing item from the store."""
 
         item = self.lookup[item_id]
+        parent = item.parent
+        children_ids = [ c.id for c in item.children ]
 
-        try:
-            parent = item.parent
-
-            for child in item.children:
-                del self.lookup[child.id]
-
-        except AttributeError:
-            parent = None
-
+        for cid in children_ids:
+            self.remove(cid)
 
         if parent:
             parent.children.remove(item)
-            del self.lookup[item_id]
         else:
             self.data.remove(item)
-            del self.lookup[item_id]
+        del self.lookup[item_id]
 
         self.emit('removed', str(item_id))
 

--- a/GTG/core/saved_searches.py
+++ b/GTG/core/saved_searches.py
@@ -27,24 +27,23 @@ import logging
 
 from lxml.etree import Element, _Element, SubElement
 
-from GTG.core.base_store import BaseStore
+from GTG.core.base_store import BaseStore, StoreItem
 
 log = logging.getLogger(__name__)
 
 
-class SavedSearch(GObject.Object):
+class SavedSearch(StoreItem):
     """A saved search."""
 
     __gtype_name__ = 'gtg_SavedSearch'
 
 
     def __init__(self, id: UUID, name: str, query: str) -> None:
-        self.id = id
         self._name = name
         self._query = query
         self._icon : Optional[str] = None
 
-        super().__init__()
+        super().__init__(id)
 
     @GObject.Property(type=str)
     def name(self) -> str:

--- a/tests/core/test_base_store.py
+++ b/tests/core/test_base_store.py
@@ -1,0 +1,69 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) 2008-2024 - the GTG contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+from unittest import TestCase
+from uuid import uuid4
+
+from GTG.core.base_store import StoreItem, BaseStore
+
+
+class BaseStoreRemove(TestCase):
+
+
+    def setUp(self):
+        self.store = BaseStore()
+
+        # add a simple item
+        self.simple_item = StoreItem(uuid4())
+        self.store.add(self.simple_item)
+
+        # add a tree
+        self.tree_items = [ StoreItem(uuid4()) for _ in range(12) ]
+        self.store.add(self.tree_items[0])
+        for item in self.tree_items[1:4]:
+            self.store.add(item,parent_id=self.tree_items[0].id)
+        for item in self.tree_items[4:7]:
+            self.store.add(item,parent_id=self.tree_items[3].id)
+        for item in self.tree_items[7:]:
+            self.store.add(item,parent_id=self.tree_items[5].id)
+
+
+    def test_remove_singel_item(self):
+        self.store.remove(self.simple_item.id)
+        self.assertEqual(self.store.count(), 12)
+
+
+    def test_remove_tree(self):
+        self.store.remove(self.tree_items[0].id)
+        self.assertEqual(self.store.count(), 1)
+
+
+    def test_remove_child_item(self):
+        child_id = self.tree_items[1].id
+        self.store.remove(child_id)
+        self.assertEqual(self.store.count(), 12)
+        self.assertTrue(self.tree_items[1] not in self.tree_items[0].children)
+
+
+    def test_signals(self):
+        removed = set()
+        def on_remove(obj,s):
+            removed.add(s)
+        self.store.connect('removed',on_remove)
+        self.store.remove(self.tree_items[0].id)
+        self.assertEqual(removed,{ str(item.id) for item in self.tree_items })


### PR DESCRIPTION
I wrote unit tests for BaseStore.remove and discovered 2 bugs along the way:
- When removing an item, the code only considered the children instead of removing all descendants. This resulted in the store being left in an inconsistent state. (This seems related to the scattered use of `BaseStore.refresh_lookup_cache` method.)
- When removing a tree of items, only the root element was reported with a `removed` signal. (If I am not mistaken, the code never relied on this signal, but let's fix it anyway.)

The main changes are as follows:
- write unit tests for `BaseStore.remove`,
- ensure that all descendants are recursively removed,
- ensure that a `removed` signal is emitted for each removed item,
- make `SavedSearch` a subclass of `StoreItem` to keep things readable.