### PR TITLE
Tests and a fix for BaseStore.parent

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -179,19 +179,17 @@ class BaseStore(GObject.Object,Generic[S]):
     def parent(self, item_id: UUID, parent_id: UUID) -> None:
         """Add a child to an item."""
 
-        try:
-            item = self.lookup[item_id]
-        except KeyError:
-            raise
+        if item_id not in self.lookup:
+            raise KeyError("item_id is not in store: "+str(item_id))
+        if parent_id not in self.lookup:
+            raise KeyError("parent_id is not in store: "+str(parent_id))
 
-        try:
-            self.data.remove(item)
-            self.lookup[parent_id].children.append(item)
-            item.parent = self.lookup[parent_id]
+        item = self.lookup[item_id]
+        item.parent = self.lookup[parent_id]
 
-            self.emit('parent-change', item, self.lookup[parent_id])
-        except KeyError:
-            raise
+        self.data.remove(item)
+        self.lookup[parent_id].children.append(item)
+        self.emit('parent-change', item, self.lookup[parent_id])
 
 
     def unparent(self, item_id: UUID, parent_id: UUID) -> None:


### PR DESCRIPTION
I wrote unit tests for `BaseStore.parent`. The tests revealed that calling the method with a non-existing `parent_id` changes the list of root elements (`self.data`).

The main changes are as follows:
- add unit tests for `BaseStore.parent`,
- ensure that the store is unchanged when called with invalid IDs,
- add helpful error messages to the exceptions.