### PR TITLE
Remember unselecting tags + disable saved search auto-selection

### DIFF
--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -405,6 +405,7 @@ class Sidebar(Gtk.ScrolledWindow):
 
     def unselect_tags(self) -> None:
         """Clear tags selection"""
+        self.browser.config.set("selected_tag", '')
 
         with signal_block(self.tag_selection, self.tag_handle):
             self.tag_selection.unselect_all()
@@ -492,8 +493,6 @@ class Sidebar(Gtk.ScrolledWindow):
 
         if tags:
             self.browser.config.set("selected_tag", tags[0])
-        else:
-            self.browser.config.set("selected_tag", '')
 
         self.emit('selection_changed')
 

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -126,6 +126,7 @@ class Sidebar(Gtk.ScrolledWindow):
         searches_button.connect('clicked', self.on_search_reveal)
 
         self.searches_selection = Gtk.SingleSelection.new(ds.saved_searches.model)
+        self.searches_selection.set_autoselect(False)
         self.searches_selection.set_can_unselect(True)
         self.searches_selection.unselect_item(0)
         self.search_handle = self.searches_selection.connect('selection-changed', self.on_search_selected)


### PR DESCRIPTION
Fixes #1130 

The main changes are as follows:
- updated the config both when a tag is selected and when tags are unselected,
- disable auto-selection for the saved searches.

The second point is unrelated to the original bug. While testing my solution, it turned out that there was no way of unselecting saved searchs because of the enabled auto-selection.