### PR TITLE
Update links to old wiki

### DIFF
--- a/GTG/core/firstrun_tasks.py
+++ b/GTG/core/firstrun_tasks.py
@@ -136,7 +136,7 @@ tasks : List[TaskData] = [
             "\n"
             "We hope you will enjoy using GTG, and thank you for trying it out! "
             "To learn more about the GTG project and how you can contribute, "
-            "visit our web page: https://wiki.gnome.org/Apps/GTG/ \n"
+            "visit our web page: https://getting-things-gnome.github.io/ \n"
             "\n"
             "— The GTG team")
     },

--- a/GTG/core/info.py.in
+++ b/GTG/core/info.py.in
@@ -35,7 +35,7 @@ COPYRIGHT = _(f"Copyright © 2008-%d {AUTHORS}") \
                 % date.today().year
 SHORT_DESCRIPTION = _("""A personal productivity tool for GNOME,
 inspired by the GTD methodology.""") # A manual line break looks better in the About dialog.
-URL = "https://wiki.gnome.org/Apps/GTG"
+URL = "https://getting-things-gnome.github.io/"
 CHAT_URL = "https://matrix.to/#/#gtg:gnome.org"
 SOURCE_CODE_URL = "https://github.com/getting-things-gnome/gtg/"
 OPENHUB_URL = "https://www.openhub.net/p/gtg/contributors"

--- a/NEWS
+++ b/NEWS
@@ -228,4 +228,4 @@ for those who want to control the app via DBus).
 Older releases
 ==============
 They predate this file, and documenting them here is a questionable endeavor.
-See https://wiki.gnome.org/Apps/GTG/release_names for historical info.
+See https://getting-things-gnome.github.io/release_names for historical info.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GTG is intended to help you track everything you need to do and need to know, fr
 
 You are currently reading the index of the information intended for **new contributors** (beta testers, developers, packagers, etc.), found in [the project's main software development and management hub](https://github.com/getting-things-gnome/gtg).
 
-See [our website](https://wiki.gnome.org/Apps/GTG) for the list of features and information intended for **users** (including how to install the stable release with pre-built packages).
+See [our website](https://getting-things-gnome.github.io/) for the list of features and information intended for **users** (including how to install the stable release with pre-built packages).
 Except if you're here to report an issue – then you can just directly create
 an issue rather than continue reading.
 
@@ -212,6 +212,6 @@ yelp docs/user_manual/C/index.page
 
 # Other documentation
 
-* Our wiki serves as our website: https://wiki.gnome.org/Apps/GTG
+* [GTG website](https://getting-things-gnome.github.io/)
 * Check out the [docs folder in the main repository](./docs/) for more
   information and documentation for contributors

--- a/docs/contributors/git workflow tips.md
+++ b/docs/contributors/git workflow tips.md
@@ -28,7 +28,7 @@ You can then "add" (choose) and "commit" (save) your changes:
     $ git add changed_file_1_to_include changed_file_2_to_include_too
     $ git commit
 
-Pro tip: using a graphical tool like [gitg](https://wiki.gnome.org/Apps/Gitg/), which not only lets you see visually the relationship between the various branches, but also lets you select which lines of which files you want to "stage" to commit, making it INCREDIBLY easier, and letting you make much cleaner, smaller, "atomic" commits. Check out the [Meld](https://wiki.gnome.org/Apps/Meld) tool, too.
+Pro tip: using a graphical tool like [gitg](https://wiki.gnome.org/Apps/Gitg/), which not only lets you see visually the relationship between the various branches, but also lets you select which lines of which files you want to "stage" to commit, making it INCREDIBLY easier, and letting you make much cleaner, smaller, "atomic" commits. Check out the [Meld](https://meldmerge.org/) tool, too.
 
 If your branch is solving specific reported issue, please include the number of the issue in the commit message or the pull request description. This will enable others to quickly navigate to the issue being solved. For example, this is a proper Git commit message:
 

--- a/docs/contributors/release process and checklist.md
+++ b/docs/contributors/release process and checklist.md
@@ -9,7 +9,7 @@
 6. Update the version number in `meson.build` (in the main directory), and the `appVersion` value in `GTG/core/versioning.py` and `GTG/core/xml.py` (the xmlVersion doesn't necessarily change, but appVersion should)
 7. Update `data/org.gnome.GTG.appdata.xml.in.in` to add the new release version number, date, and planned announcement (release notes) URL. For a beta/RC release, use a separate announcement URL, version number and type (ex: `version=0.4_RC" date="2020-06-11" type=development"`). When making the final stable release, replace that release by the final version number, date and URL. Note that you cannot use dates in the future, as Flathub will not be able to handle that.
 8. Tag the stable release (see below) and create the tarballs and Flatpak packages. Tagging RCs/betas is not needed.
-9. Remember to update the historical wiki page at https://wiki.gnome.org/Apps/GTG/release_names
+9. Remember to update the historical wiki page at https://getting-things-gnome.github.io/release_names
 
 Tip: You can prepare the release commit in advance by setting both the authorship and commit date to the future planned release date and time, and keeping the commit sitting in your personal fork's branch, with a command such as: `GIT_AUTHOR_DATE='the date and time' GIT_COMMITTER_DATE='the date and time' git commit` (note that if you rebase the branch, you should also reuse that `GIT_COMMITTER_DATE` environment variable, otherwise your resulting rebased commit will have the rebase time set as the new commit date).
 

--- a/docs/contributors/translating.md
+++ b/docs/contributors/translating.md
@@ -7,7 +7,7 @@ For existing translations, you would use the old language as a basis, but it is 
 Because of that, you may need to update the translation files manually.
 
 [gtg-pot]: ../../po/gtg.pot
-[gtranslator]: https://wiki.gnome.org/Apps/Gtranslator/
+[gtranslator]: https://gitlab.gnome.org/GNOME/gtranslator/
 [poedit]: https://poedit.net/
 [gettext-plural]: https://www.gnu.org/software/gettext/manual/html_node/Translating-plural-forms.html#Translating-plural-forms
 

--- a/docs/source/releases/v0.3.1.rst
+++ b/docs/source/releases/v0.3.1.rst
@@ -103,6 +103,6 @@ We also have many other projects in the pipeline, most notably:
   Izidor Matusov during Google Summer of Code 2012.
 * Testing and merging GTGOnline! `synchronization backend`_ with the trunk.
 
-.. _`redesign of GTG`: https://wiki.gnome.org/Apps/gtg/Design/
+.. _`redesign of GTG`: https://getting-things-gnome.github.io/pre2020/design
 .. _`collaborative task management`: https://wiki.gnome.org/Outreach/SummerOfCode/2012/Projects/IzidorMatusov_CollaborativeGTG
 .. _`synchronization backend`: https://code.launchpad.net/~parinporecha/gtg/backend_gtgonline

--- a/tests/core/test_urlregex.py
+++ b/tests/core/test_urlregex.py
@@ -23,9 +23,9 @@ import GTG.core.urlregex as urlregex
 class TestUrlregex(TestCase):
     def test_search_does_not_include_preceeding_whitespace(self):
         match = urlregex.search("This snippet contains an url with whitespace"
-            "before it:  https://wiki.gnome.org/Apps/GTG/")
-        self.assertEqual(list(match)[0].group(), "https://wiki.gnome.org/Apps/GTG/")
+            "before it:  https://getting-things-gnome.github.io/")
+        self.assertEqual(list(match)[0].group(), "https://getting-things-gnome.github.io/")
 
-    def test_domain_with_short_suffix(selfs):
+    def test_domain_with_short_suffix(self):
         match = urlregex.search("https://ticketsystem.company.x/issues/12345")
-        selfs.assertEqual(list(match)[0].group(), "https://ticketsystem.company.x/issues/12345")
+        self.assertEqual(list(match)[0].group(), "https://ticketsystem.company.x/issues/12345")


### PR DESCRIPTION
Closes #1164
 
This commit updates the references to wiki.gnome.org, except the ones in the translations (I assume there is a process to mark translations as outdated), and the following:

```
$ ag wiki.gnome.org --ignore po
docs/contributors/git workflow tips.md
31:Pro tip: using a graphical tool like [gitg](https://wiki.gnome.org/Apps/Gitg/), which not only lets you see visually the relationship between the various branches, but also lets you select which lines of which files you want to "stage" to commit, making it INCREDIBLY easier, and letting you make much cleaner, smaller, "atomic" commits. Check out the [Meld](https://meldmerge.org/) tool, too.

docs/contributors/profiling GTG for performance.md
63:![Generated image](https://wiki.gnome.org/Apps/GTG/development?action=AttachFile&do=get&target=profile.png)

docs/source/releases/v0.3.1.rst
41:.. _`his Google Summer of Code 2013 project`: https://wiki.gnome.org/Outreach/SummerOfCode/2013/Projects/ParinPorecha_GTGOnline
50:.. _`ported GTG to python3 and gtk3`: https://wiki.gnome.org/Outreach/SummerOfCode/2013/Projects/XuanHu_PortingGTG
107:.. _`collaborative task management`: https://wiki.gnome.org/Outreach/SummerOfCode/2012/Projects/IzidorMatusov_CollaborativeGTG
```

gitg still marks wiki.gnome.org as their website, so I didn't change the link. Updating it to the GitLab project would also be a viable option.

The image was probably lost to time and would need to be regenerated.

The 0.3.1 release references some GSoC projects that I haven't chased new links for.