### PR TITLE
Save task before closing editor

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -84,7 +84,7 @@ class TaskEditor(Gtk.Window):
 
         self.app = app
         self.ds = app.ds
-        self.task = task
+        self.task: Task = task
         self.config = app.config_core
         self.task_config = self.config.get_task_config(str(task.id))
         self.time = None
@@ -778,7 +778,7 @@ class TaskEditor(Gtk.Window):
         self.time = time.time()
 
 
-    # light_save save the task without refreshing every 30seconds
+    # light_save save the task without refreshing every 30 seconds
     # We will reduce the time when the get_text will be in another thread
 
     def light_save(self):
@@ -836,13 +836,16 @@ class TaskEditor(Gtk.Window):
         # process textview to make sure every tag is parsed
         self.textview.process()
 
-        # Save should be also called when buffer is modified
+        # Save because self.textview.process() only calls light_save(), which
+        # isn't guaranteed to actually save (see #1138)
+        self.save()
+
         # self.pengine.onTaskClose(self.plugin_api)
         # self.pengine.remove_api(self.plugin_api)
 
         tid = self.task.id
 
-        if self.is_new():
+        if self.task.is_new():
             self.app.ds.tasks.remove(tid)
         else:
             self.save()

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -225,6 +225,7 @@ class TaskView(GtkSource.View):
 
         if not self.buffer.props.text:
             # Why process if there's nothing to process
+            log.warning('No text to process')
             return
 
         log.debug('Processing text buffer after %dms', self.PROCESSING_DELAY)
@@ -266,7 +267,7 @@ class TaskView(GtkSource.View):
             self.detect_url(text, start)
             self.detect_internal_link(text, start)
 
-            # remove current word from the text befor looking for tags
+            # remove current word from the text before looking for tags
             if mask_current_word and cursor_line==start.get_line():
                 cur_pos = cursor_iter.get_line_offset()
                 text = TaskView.mask_current_word(text,cur_pos)


### PR DESCRIPTION
Fixes #1138

When the task editor gets closed, it first calls
`self.textview.process()` which, after processing, calls `self.save_cb()`, which is set to `TaskEditor.light_save()`. This only calls `TaskEditor.save()` at most every 7 seconds. So if you crete a new task and close its editor within 7 seconds, the task doesn't get saved.

This commit makes `TaskEditor.desctruction()` call `TaskEditor.save()`, to make sure the task is saved properly before closing the task popup.