### PR TITLE
Add typing_extensions to flatpak requirement

### DIFF
--- a/build-aux/requirements.txt
+++ b/build-aux/requirements.txt
@@ -3,3 +3,4 @@ caldav==1.3.9
 pytest
 Cheetah3
 dbus-python==1.2.18
+typing_extensions


### PR DESCRIPTION
Without it, the weekly flatpak fails on startup:

```
Traceback (most recent call last):
  File "/app/bin/gtg", line 98, in <module>
    from GTG.gtk.application import Application
  File "/app/lib/python3.11/site-packages/GTG/gtk/application.py", line 30, in <module>
    from GTG.core.datastore import Datastore
  File "/app/lib/python3.11/site-packages/GTG/core/datastore.py", line 30, in <module>
    from GTG.core.tasks import TaskStore, Filter
  File "/app/lib/python3.11/site-packages/GTG/core/tasks.py", line 35, in <module>
    from GTG.core.base_store import BaseStore, StoreItem
  File "/app/lib/python3.11/site-packages/GTG/core/base_store.py", line 29, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
```

The requirement has been necessary since 908da7d6ed11c01f99bcb31872ab96afad31ea83