### PR TITLE
Use Task.set_status to mark tasks as done or active

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1389,7 +1389,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def on_mark_as_done(self, widget=None):
         for task in self.get_pane().get_selection():
-            task.toggle_active()
+            task.set_status(Status.DONE)
 
     def on_dismiss_task(self, widget=None):
         for task in self.get_pane().get_selection():
@@ -1397,7 +1397,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def on_reopen_task(self, widget=None):
         for task in self.get_pane().get_selection():
-            task.toggle_active()
+            task.set_status(Status.ACTIVE)
 
     def on_select_tag(self, widget=None, row=None, col=None):
         """ Callback for tag(s) selection from left sidebar.


### PR DESCRIPTION
Fixes GitHub issue #1180

Somehow, setting the task done was triggered twice: in `TaskEditor.change_status` and in `MainWindow.on_mark_as_done`. Since `MainWindow.on_mark_as_done` also used `Task.toggle_status`, the effect was reversed.

**Some remarks:**
- I don't clearly see why was the `set_status` triggered twice, but since fixing `MainWindow.on_mark_as_done` fixes the problem, I would say it is a question for another day.
- Dismissing tasks may have similar problems, but I couldn't yet reproduce the bug (see `MainWindow.on_dismiss_task`).