### PR TITLE
Use flathub-infra/flatpak-github-actions/ to build weekly flatpak

### DIFF
--- a/.github/workflows/weekly_flatpak.yml
+++ b/.github/workflows/weekly_flatpak.yml
@@ -16,7 +16,7 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v4
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
       with:
         bundle: org.gnome.GTG.Devel.flatpak
         manifest-path: build-aux/org.gnome.GTG.Devel.json


### PR DESCRIPTION
Fixes #1184

Our current `flatpak/flatpak-github-actions` is not longer working, because it is using a deprecated version of the `upload-artifact` GHA. From
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/:

> Starting January 30th, 2025, GitHub Actions customers will no longer
> be able to use v3 of https://github.com/actions/upload-artifact or
> https://github.com/actions/download-artifact.

We're using upload-artifact from flatpak-github-actions, and the issue has been filed there as
https://github.com/flatpak/flatpak-github-actions/issues/214. https://github.com/flatpak/flatpak-github-actions/issues/184 is expected to fix that, but the associated PR
https://github.com/flatpak/flatpak-github-actions/pull/198 hasn't been merged.

The GHA has been forked at
https://github.com/flathub-infra/flatpak-github-actions, and the issue was fixed there back in July:
https://github.com/flathub-infra/flatpak-github-actions/commit/efb7f71f7715a0c5a96930bbf81b6a0c5d80a56c

So let's switch to that. I don't like that it's not versioned and we need to use the master branch, which may add breaking changes at any time. But it's better than our current solution, which can no longer work.

Tested on a fork, and the artifact is created correctly: https://github.com/SqAtx/gtg/actions/runs/13222384044