### PR TITLE
Convenience functions for adding and removing children

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -396,8 +396,6 @@ class TagStore(BaseStore[Tag]):
             self._append_to_parent_model(item.id)
 
         self.emit('added', item)
-        if parent_id:
-            self.lookup[parent_id].notify('children_count')
 
 
     def remove(self, item_id: UUID) -> None:
@@ -414,7 +412,6 @@ class TagStore(BaseStore[Tag]):
             self.model.remove(pos[1])
 
         super().remove(item_id)
-        if parent: self.lookup[parent.id].notify('children_count')
 
 
     def parent(self, item_id: UUID, parent_id: UUID) -> None:
@@ -425,7 +422,6 @@ class TagStore(BaseStore[Tag]):
         if item.parent is not None:
             old_parent = item.parent
             self._remove_from_parent_model(item_id)
-            self.lookup[old_parent.id].notify('children_count')
         else:
             pos = self.model.find(item)
             self.model.remove(pos[1])
@@ -434,7 +430,6 @@ class TagStore(BaseStore[Tag]):
 
         # Add back to UI
         self._append_to_parent_model(item_id)
-        self.lookup[parent_id].notify('children_count')
 
 
     def unparent(self, item_id: UUID) -> None:
@@ -451,5 +446,3 @@ class TagStore(BaseStore[Tag]):
 
         # Add back to UI
         self.model.append(item)
-
-        parent.notify('children_count')

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -962,7 +962,6 @@ class TaskStore(BaseStore[Task]):
             self.model.append(item)
         else:
             self._append_to_parent_model(item.id)
-            self.lookup[parent_id].notify('has_children')
 
         item.duplicate_cb = self.duplicate_for_recurrent
         self.notify('task_count_all')
@@ -978,7 +977,6 @@ class TaskStore(BaseStore[Task]):
         item = self.lookup[item_id]
         if item.parent is not None:
             self._remove_from_parent_model(item.id)
-            item.parent.notify('has_children')
         else:
             pos = self.model.find(item)
             self.model.remove(pos[1])
@@ -996,7 +994,6 @@ class TaskStore(BaseStore[Task]):
         # Remove from UI
         if item.parent is not None:
             self._remove_from_parent_model(item_id)
-            item.parent.notify('has_children')
         else:
             pos = self.model.find(item)
             self.model.remove(pos[1])
@@ -1005,8 +1002,6 @@ class TaskStore(BaseStore[Task]):
 
         # Add back to UI
         self._append_to_parent_model(item_id)
-        assert item.parent is not None
-        item.parent.notify('has_children')
 
 
     def unparent(self, item_id: UUID) -> None:
@@ -1018,7 +1013,6 @@ class TaskStore(BaseStore[Task]):
 
         # Remove from UI
         self._remove_from_parent_model(item_id)
-        parent.notify('has_children')
 
         super().unparent(item_id)
 
@@ -1027,7 +1021,6 @@ class TaskStore(BaseStore[Task]):
 
         # Add back to UI
         self.model.append(item)
-        parent.notify('has_children')
 
 
     def filter(self, filter_type: Filter, arg: Union[Tag,List[Tag],None] = None) -> List[Task]:


### PR DESCRIPTION
The main motivation behind this PR is to simplify the cases when class A emits a signal on class B because class C did something. E.g., the `Task` class can manage the update of its `has_children` property alone. (Overriding these methods can also help realising when a task is no longer actionable.)

**The main changes are as follows:**

- introduce the `StoreItem.add_child` and `StoreItem.remove_child` methods (automatically trigger signals and potentially other functionality)
- add unit tests for the methods above
- leverage these methods in the `BaseStore`, `TaskStore` and `TagStore`