### PR TITLE
Use Task.set_status to mark tasks as dismissed

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1393,7 +1393,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def on_dismiss_task(self, widget=None):
         for task in self.get_pane().get_selection():
-            task.toggle_dismiss()
+            task.set_status(Status.DISMISSED)
 
     def on_reopen_task(self, widget=None):
         for task in self.get_pane().get_selection():


### PR DESCRIPTION
This is a follow-up to PR #1183.

Calling `Task.toggle_dismiss` caused the task to reactivate if it was already dismissed. 

**Steps to reproduce the bug:**
1. Create a nested task structure of 5 tasks: *a -> b -> c -> d -> e*.
2. Ensure that they are all visible in the main window.
3. Select all 5 tasks.
4. Try to dismiss them all at once using the *right-click/Dismiss* option. 
5. Observe that they are still active except *e*.

**Note:** While debugging, I noticed that certain tasks are dismissed multiple times since they are selected and they are descendants of other tasks.

