### PR TITLE
Change default view to `open_view`

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -36,7 +36,7 @@ DEFAULTS = {
         "sidebar_width": 265,
         'collapsed_tasks': [],
         'expanded_tags': [],
-        'view': 'default',
+        'view': 'open_view',
         "opened_tasks": [],
         'width': 1024,
         'height': 600,


### PR DESCRIPTION
This removes the warning "Child name 'default' not found in GtkStack"