### PR TITLE
Remove top border in `.task-list`

### DIFF
--- a/GTG/gtk/data/style.css
+++ b/GTG/gtk/data/style.css
@@ -6,10 +6,6 @@
     min-width: 16px;
 }
 
-.task-list {
-    border-top: 1px solid rgb(213, 208, 204);
-}
-
 .dummy {
   background: transparent;
   border: none;


### PR DESCRIPTION
This removes the weird white bar at the top of the list in dark style.

Fixes https://github.com/getting-things-gnome/gtg/issues/1009