### PR TITLE
Rework search bar

### DIFF
--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -326,7 +326,8 @@
           <object class="GtkToggleButton" id="search_button">
             <property name="tooltip_text" translatable="yes">Activate Search Entry</property>
             <property name="valign">center</property>
-            <property name="action_name">win.search</property>
+            <property name="active" bind-source="searchbar" bind-property="search-mode-enabled" bind-flags="sync-create|bidirectional"/>
+            <property name="action_name">win.toggle_search</property>
             <property name="icon_name">edit-find-symbolic</property>
           </object>
         </child>
@@ -401,6 +402,7 @@
                           <object class="GtkSearchEntry" id="search_entry">
                             <property name="max_width_chars">40</property>
                             <property name="placeholder_text" translatable="yes">Search here</property>
+                            <property name="search_delay">500</property>
                             <signal name="search-changed" handler="on_search" swapped="no"/>
                           </object>
                         </child>


### PR DESCRIPTION
The search bar's activation and deactivation are split into different methods, as the way the search bar should behave differently on a case-by-case basis.

This also makes use of modern APIs and methods provided by GTK, which should ease maintenance.

Fixes https://github.com/getting-things-gnome/gtg/issues/952