### PR TITLE
Fix automatic unit test dependencies

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         sudo apt-get update
         sudo apt install -y meson gettext itstool libgirepository1.0-dev gir1.2-gtk-4.0 libgtksourceview-5-dev libportal-dev
-        pip install --user pytest pycairo PyGObject caldav lxml
+        pip install --user pytest pycairo PyGObject==3.50.0 caldav lxml
 
     - name: Build and install GTG
       run: |


### PR DESCRIPTION
The GHA fails because of some dependency problem related to PyGObject. This can be avoided by specifying the exact version of PyGObject that matches the GNOME SDK.