### PR TITLE
Remove deleted saved searches from the UI

### DIFF
--- a/GTG/core/saved_searches.py
+++ b/GTG/core/saved_searches.py
@@ -182,3 +182,14 @@ class SavedSearchStore(BaseStore):
         self.model.append(item)
 
         self.emit('added', item)
+
+
+    def remove(self, item_id: UUID) -> None:
+        """Remove an existing saved search."""
+
+        # Remove from UI
+        item = self.lookup[item_id]
+        pos = self.model.find(item)
+        self.model.remove(pos[1])
+
+        super().remove(item_id)


### PR DESCRIPTION
This closes #1005, which is originally about tags, and the saved search related part is only mentioned in the discussion). However, the tag related part was already fixed in PR #1131. 

The solution is simple: when a saved search is deleted, the corresponding `ListStore` is also updated.