### PR TITLE
Task filtering related fixes and simplifications

### DIFF
--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -61,60 +61,16 @@ class TagEmptyFilter(Gtk.Filter):
             return True
 
 
-class TaskPaneFilter(Gtk.Filter):
-    __gtype_name__ = 'TaskPaneFilter'
 
-    def __init__(self, ds, pane, tags = [], no_tags=False):
-        super(TaskPaneFilter, self).__init__()
-        self.ds = ds
-        self.pane = pane
-        self.tags = set()
-        self.no_tags = no_tags
-        self.expand = False
-
-
-    def match_tags(self, task: Task) -> bool:
-        """Match selected tags to task tags."""
-        for tag in self.tags:
-            matching_tags = set(tag.get_matching_tags())
-            if set(task.tags).isdisjoint(matching_tags):
-                return False
-        return True
-
-
-    def is_task_matched_by_pane(self,task: Task) -> bool:
-        """Return true if and only if the current pane does not filter out the task."""
-        if self.pane == 'active':
-            return task.status is Status.ACTIVE
-        elif self.pane == 'workview':
-            return task.is_actionable
-        elif self.pane == 'closed':
-            return task.status is not Status.ACTIVE
-        raise Exception("Unknown pane: " + self.pane)
-
-
-    def is_task_matched_by_tags(self,task: Task) -> bool:
-        """Return true if and only if the selected tag filtering option does not filter out the task."""
-        if self.no_tags:
-            return len(task.tags) == 0
-        return self.match_tags(task)
-
-
-    def do_match(self, item) -> bool:
-        task = item if isinstance(item, Task) else  unwrap(item, Task)
-        return self.is_task_matched_by_pane(task) and self.is_task_matched_by_tags(task)
-
-
-class SearchTaskFilter(Gtk.Filter):
-    __gtype_name__ = 'SearchTaskFilter'
+class TaskFilter(Gtk.Filter):
+    __gtype_name__ = 'TaskFilter'
 
     def __init__(self, ds, pane) -> None:
-        super(SearchTaskFilter, self).__init__()
+        super(TaskFilter, self).__init__()
         self.ds = ds
         self.query = ''
         self.checks = None
         self.pane : str = pane
-        self.expand = False
         self.tags: list[Tag] = []
         self.only_untagged = False
 
@@ -128,6 +84,11 @@ class SearchTaskFilter(Gtk.Filter):
     def set_required_tags(self,tags: list[Tag]) -> None:
         self.tags = tags
         self.only_untagged = False
+        self.changed(Gtk.FilterChange.DIFFERENT)
+
+
+    def set_pane(self,pane: str) -> None:
+        self.pane = pane
         self.changed(Gtk.FilterChange.DIFFERENT)
 
 

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -699,6 +699,7 @@ class FilteredTaskTreeManager:
     def __init__(self,store:'TaskStore',task_filter:Gtk.Filter) -> None:
         self.root_model: Gio.ListStore = Gio.ListStore.new(Task)
         self.task_filter: Gtk.Filter = task_filter
+        self.task_filter.connect('changed',self._on_changed)
         self.tid_to_subtask_model: Dict[UUID,Gio.ListStore] = dict()
         self.tid_to_containing_model: Dict[UUID,Gio.ListStore] = dict()
         self.tree_model = Gtk.TreeListModel.new(self.root_model, False, False, self._model_expand)

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -237,6 +237,7 @@ class TaskPane(Gtk.ScrolledWindow):
         self.task_filter.pane = pane
         self.task_filter.expand = True
         self.task_filter.changed(Gtk.FilterChange.DIFFERENT)
+        self.filter_manager.set_filter(self.task_filter)
         self.set_title()
 
 
@@ -244,8 +245,7 @@ class TaskPane(Gtk.ScrolledWindow):
         """Change tasks filter."""
 
         if self.searching:
-            self.search_filter.tags = tags
-            self.search_filter.changed(Gtk.FilterChange.DIFFERENT)
+            self.search_filter.set_required_tags(tags)
         else:
             self.task_filter.tags = tags
             self.task_filter.no_tags = False
@@ -257,8 +257,7 @@ class TaskPane(Gtk.ScrolledWindow):
         """Change tasks filter."""
 
         if self.searching:
-            self.search_filter.tags = []
-            self.search_filter.changed(Gtk.FilterChange.DIFFERENT)
+            self.search_filter.allow_untagged_only()
         else:
             self.task_filter.tags = []
             self.task_filter.no_tags = True

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -20,7 +20,7 @@
 
 from gi.repository import Gtk, GObject, Gdk, Gio, Pango
 from GTG.core.tasks import Task, Status
-from GTG.core.filters import TaskPaneFilter, SearchTaskFilter
+from GTG.core.filters import TaskFilter
 from GTG.core.sorters import (TaskAddedSorter, TaskDueSorter,
                               TaskModifiedSorter, TaskStartSorter,
                               TaskTagSorter, TaskTitleSorter)
@@ -150,8 +150,7 @@ class TaskPane(Gtk.ScrolledWindow):
         # Task List
         # -------------------------------------------------------------------------------
 
-        self.search_filter = SearchTaskFilter(self.ds, pane)
-        self.task_filter = TaskPaneFilter(self.app.ds, pane)
+        self.task_filter = TaskFilter(self.app.ds, pane)
         self.filtered, self.filter_manager = self.app.ds.tasks.get_filtered_tree_model(self.task_filter)
 
         self.sort_model = Gtk.TreeListRowSorter()
@@ -220,10 +219,9 @@ class TaskPane(Gtk.ScrolledWindow):
     def set_search_query(self, query) -> None:
         """Change tasks filter."""
 
-        self.search_filter.set_query(query)
-        self.search_filter.pane = self.pane
+        self.task_filter.set_pane(self.pane)
+        self.task_filter.set_query(query)
         self.searching = True
-        self.filter_manager.set_filter(self.search_filter)
 
 
     def set_filter_pane(self, pane) -> None:
@@ -231,38 +229,23 @@ class TaskPane(Gtk.ScrolledWindow):
 
         if self.searching:
             self.searching = False
-            self.filter_manager.set_filter(self.task_filter)
 
         self.pane = pane
-        self.task_filter.pane = pane
-        self.task_filter.expand = True
-        self.task_filter.changed(Gtk.FilterChange.DIFFERENT)
-        self.filter_manager.set_filter(self.task_filter)
+        self.task_filter.set_pane(pane)
         self.set_title()
 
 
     def set_filter_tags(self, tags=[]) -> None:
         """Change tasks filter."""
 
-        if self.searching:
-            self.search_filter.set_required_tags(tags)
-        else:
-            self.task_filter.tags = tags
-            self.task_filter.no_tags = False
-            self.task_filter.changed(Gtk.FilterChange.DIFFERENT)
-
+        self.task_filter.set_required_tags(tags)
         self.set_title()
+
 
     def set_filter_notags(self, tags=[]) -> None:
         """Change tasks filter."""
 
-        if self.searching:
-            self.search_filter.allow_untagged_only()
-        else:
-            self.task_filter.tags = []
-            self.task_filter.no_tags = True
-            self.task_filter.changed(Gtk.FilterChange.DIFFERENT)
-
+        self.task_filter.allow_untagged_only()
         self.set_title()
 
 


### PR DESCRIPTION
The original goal was to address some bugs in the task filtering functionality. The main changes are as follows:
-  Ensure that all required tags are matched separately (important  when filtering based on multiple tags with children tags).
- Allow filtering of untagged tasks in `SearchTaskFilter`.
- Do not count the tags of subtasks (causing to show immediate parents when filtering for tags).

After a bit of refactoring, it was clear that `TaskPaneFilter`'s functionality was a subset of `SearchTaskFilter`'s functionality. Keeping only `SearchTaskFilter` under a new name also allowed further simplifications in the `TaskPane` that constantly switched between different filters.
