### PR TITLE
Ensure that colouring fills the entire row in the task list

### DIFF
--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -39,6 +39,8 @@ class TaskBox(Gtk.Box):
         self.config = config
         super().__init__(valign=Gtk.Align.CENTER)
 
+        self.add_css_class('task-box')
+
         self.expander = Gtk.TreeExpander()
         self.expander.add_css_class('arrow-only-expander')
         self.expander.set_indent_for_icon(True)
@@ -170,6 +172,7 @@ class TaskPane(Gtk.ScrolledWindow):
         view = Gtk.ListView.new(self.task_selection, tasks_signals)
         view.set_show_separators(True)
         view.add_css_class('rich-list')
+        view.add_css_class('task-list')
 
         view_drop = Gtk.DropTarget.new(Task, Gdk.DragAction.COPY)
         view_drop.connect("drop", self.on_toplevel_tag_drop)

--- a/GTG/gtk/data/style.css
+++ b/GTG/gtk/data/style.css
@@ -24,6 +24,16 @@ indent, expander{
     -gtk-icon-size: 16px;
 }
 
+.task-list row {
+    padding: 0px;
+}
+
+.task-list .task-box {
+    min-height: 48px;
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
 /* --------------------------------------------------------------------------------
  * ERROR HANDLER
  * --------------------------------------------------------------------------------


### PR DESCRIPTION
The solution mixes the old styling with the new `.rich-list` formatting while ensuring that spacing values are increments of 6 pixels.

This fixes GitHub issue #1206.