### PR TITLE
Use signals instead of direct calls to update `TreeListModel` instances

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -126,23 +126,21 @@ class BaseStore(GObject.Object,Generic[S]):
         if item.id in self.lookup.keys():
             log.warning('Failed to add item with id %s, already added!',
                         item.id)
+            raise KeyError
 
+        if parent_id and parent_id not in self.lookup:
+            log.warning(('Failed to add item with id %s to parent %s, '
+                         'parent not found!'), item.id, parent_id)
             raise KeyError
 
         if parent_id:
-            try:
-                self.lookup[parent_id].add_child(item)
-                item.parent = self.lookup[parent_id]
-
-            except KeyError:
-                log.warning(('Failed to add item with id %s to parent %s, '
-                            'parent not found!'), item.id, parent_id)
-                raise
-
+            self.lookup[parent_id].add_child(item)
+            item.parent = self.lookup[parent_id]
         else:
             self.data.append(item)
 
         self.lookup[item.id] = item
+        self.emit('added', item)
         log.debug('Added %s', item)
 
 

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -151,7 +151,7 @@ class BaseStore(GObject.Object,Generic[S]):
         """Signal to emit when adding a new item."""
 
 
-    @GObject.Signal(name='removed', arg_types=(str,))
+    @GObject.Signal(name='removed', arg_types=(object,))
     def remove_signal(self, *_):
         """Signal to emit when removing a new item."""
 
@@ -182,7 +182,7 @@ class BaseStore(GObject.Object,Generic[S]):
             self.data.remove(item)
         del self.lookup[item_id]
 
-        self.emit('removed', str(item_id))
+        self.emit('removed', item)
 
 
     def batch_remove(self,item_ids: list[UUID]) -> None:

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -863,24 +863,10 @@ class TaskStore(BaseStore[Task]):
     #: Tag to look for in XML
     XML_TAG = 'task'
 
-    def __init__(self) -> None:
-        super().__init__()
-
-        self.managers: list[FilteredTaskTreeManager] = []
-        self.always_true_filter = Gtk.CustomFilter()
-        self.always_true_filter.set_filter_func(lambda x: True)
-        self.tree_model, manager = self.get_filtered_tree_model(self.always_true_filter)
-
 
     @GObject.Signal(name='task-filterably-changed', arg_types=(object,))
     def task_filterably_changed_signal(self, *_):
         """Signal to emit when a task was changed in a filterable way. (E.g., A tag was added.)"""
-
-
-    def get_filtered_tree_model(self,task_filter: Optional[Gtk.Filter]):
-        manager = FilteredTaskTreeManager(self,task_filter)
-        self.managers.append(manager)
-        return manager.get_tree_model(), manager
 
 
     def __str__(self) -> str:
@@ -1088,8 +1074,6 @@ class TaskStore(BaseStore[Task]):
         item.duplicate_cb = self.duplicate_for_recurrent
         self.notify('task_count_all')
         self.notify('task_count_no_tags')
-
-        self.emit('added', item)
 
 
     def remove(self, item_id: UUID) -> None:

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -19,7 +19,7 @@
 """Task pane and list."""
 
 from gi.repository import Gtk, GObject, Gdk, Gio, Pango
-from GTG.core.tasks import Task, Status
+from GTG.core.tasks import Task, Status, FilteredTaskTreeManager
 from GTG.core.filters import TaskFilter
 from GTG.core.sorters import (TaskAddedSorter, TaskDueSorter,
                               TaskModifiedSorter, TaskStartSorter,
@@ -153,7 +153,8 @@ class TaskPane(Gtk.ScrolledWindow):
         # -------------------------------------------------------------------------------
 
         self.task_filter = TaskFilter(self.app.ds, pane)
-        self.filtered, self.filter_manager = self.app.ds.tasks.get_filtered_tree_model(self.task_filter)
+        self.filter_manager = FilteredTaskTreeManager(self.app.ds.tasks,self.task_filter)
+        self.filtered = self.filter_manager.get_tree_model()
 
         self.sort_model = Gtk.TreeListRowSorter()
         self.sort_model.set_sorter(TaskTitleSorter())

--- a/GTG/plugins/hamster/hamster.py
+++ b/GTG/plugins/hamster/hamster.py
@@ -137,15 +137,12 @@ class HamsterPlugin():
         task.set_attribute("id-list", ",".join(ids),
                            namespace=self.PLUGIN_NAMESPACE)
 
-    def on_task_deleted(self, task_id, path):
+    def on_task_deleted(self, store, task):
         """ Stop tracking a deleted task if it is being tracked """
-        self.stop_task(task_id)
+        self.stop_task(task.id)
 
-    def on_task_modified(self, task_id, path):
+    def on_task_modified(self, store, task):
         """ Stop task if it is tracked and it is Done/Dismissed """
-        task = self.plugin_api.ds.tasks.lookup[task_id]
-        if not task:
-            return
         if task.get_status() in (Task.STA_DISMISSED, Task.STA_DONE):
             self.stop_task(task_id)
 
@@ -176,8 +173,8 @@ class HamsterPlugin():
         #     ("node-deleted-inview", self.on_task_deleted),
         # ])
 
-        plugin_api.ds.tasks.tree_model.connect('items-changed', self.on_task_modified)
-        plugin_api.ds.tasks.tree_model.connect('items-changed', self.on_task_deleted)
+        plugin_api.ds.tasks.connect('task-filterably-changed', self.on_task_modified)
+        plugin_api.ds.tasks.connect('removed', self.on_task_deleted)
 
         # set up preferences
         self.preference_dialog_init()

--- a/tests/core/test_base_store.py
+++ b/tests/core/test_base_store.py
@@ -66,7 +66,7 @@ class TestBaseStoreRemove(TestCase):
             removed.add(s)
         self.store.connect('removed',on_remove)
         self.store.remove(self.tree_items[0].id)
-        self.assertEqual(removed,{ str(item.id) for item in self.tree_items })
+        self.assertEqual(removed,set(self.tree_items))
 
 
 


### PR DESCRIPTION
This is a follow-up PR of #1208

The basic idea is to rely on signaling instead of direct calls to update the different `TreeListModel` instances in `FilteredTaskTreeManager`. This change allowed many simplifications, and I believe it can facilitate other future bug fixes (e.g., #1039).

Another notable change is that the "removed" signal now contains the removed item instead of the ID. This was necessary since the ID itself wasn't that useful once the item was deleted. (This changes the original signal specification, but it was not used anywhere else in the code.)