### PR TITLE
Improve the refiltering of all tasks

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -722,8 +722,16 @@ class FilteredTaskTreeManager:
 
 
     def _refilter_all_tasks(self) -> None:
+        self._clear_models()
         for t in self.store.data:
             self._update_with_descendants(t)
+
+
+    def _clear_models(self):
+        self.tid_to_containing_model = dict()
+        self.root_model.remove_all()
+        for model in self.tid_to_subtask_model.values():
+            model.remove_all()
 
 
     def _on_changed(self,*args):
@@ -751,6 +759,7 @@ class FilteredTaskTreeManager:
         if not self._in_the_right_model(t):
             self.remove(t)
             self.add(t)
+
 
     def _update_with_descendants(self,t:Task):
         self.update_position_of(t)


### PR DESCRIPTION
Switching from all tasks to a tag [can take an extremely long time with 5000+ tasks](https://github.com/getting-things-gnome/gtg/pull/1215#issuecomment-2952771547). This happens because manipulating the underlying `Gio.ListSotore` objects triggers many bind and unbind operations in the UI. Clearing the models before checking the items can massively reduce this time (from 295.3s to 0.8s in my case).