### PR TITLE
Speed up (and fix) TagCompletion initialisation

### DIFF
--- a/GTG/gtk/tag_completion.py
+++ b/GTG/gtk/tag_completion.py
@@ -63,6 +63,7 @@ class TagCompletion(Gtk.EntryCompletion):
         """ Initialize entry completion"""
         super().__init__()
 
+        self.tagstore = tagstore
         self.tags = Gtk.ListStore(str)
 
         self.set_model(self.tags)
@@ -72,8 +73,19 @@ class TagCompletion(Gtk.EntryCompletion):
         self.set_inline_selection(True)
         self.set_popup_single_match(False)
 
-        for tag in tagstore.lookup.values():
-            self._on_tag_added(tag.name)
+        for opt in sorted(self._get_all_completion_options()):
+            self.tags.append((opt,))
+
+
+    def _get_all_completion_options(self) -> list[str]:
+        options = []
+        for tag in self.tagstore.lookup.values():
+            tname = normalize_unicode(tag.name)
+            options.append('@'+tname)
+            options.append('!@'+tname)
+            options.append(tname)
+            options.append('!'+tname)
+        return options
 
 
     def _try_insert(self, name):


### PR DESCRIPTION
This is a follow-up of [my recent profiling](https://github.com/getting-things-gnome/gtg/pull/1215#issuecomment-2952771547) showing increased runtime in the `TagCompletion` class. While working, I also noticed a small bug in the code. 

**The main changes are as follows:**

- Fill up `TagCompletion.tags` with presorted values. (This reduced the runtime of the `Gtk.ListStore` population from 313.30s to 0.16s on my dataset containing 3621 tags.)
- Take into account that `Tag.name` does not have a leading `@` sign.