### PR TITLE
Fix toggling saved searches

### DIFF
--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -404,11 +404,15 @@ class Sidebar(Gtk.ScrolledWindow):
             binding.unbind()
 
 
-    def unselect_tags(self) -> None:
+    def unselect_tags(self, block: bool = True) -> None:
         """Clear tags selection"""
+
         self.browser.config.set("selected_tag", '')
 
-        with signal_block(self.tag_selection, self.tag_handle):
+        if block:
+            with signal_block(self.tag_selection, self.tag_handle):
+                self.tag_selection.unselect_all()
+        else:
             self.tag_selection.unselect_all()
 
 
@@ -447,7 +451,7 @@ class Sidebar(Gtk.ScrolledWindow):
     def on_search_selected(self, model, position, user_data=None):
         """Callback when selecting a saved search"""
 
-        self.unselect_tags()
+        self.unselect_tags(block=False)
         self.unselect_general_box()
 
         item = model.get_item(position)


### PR DESCRIPTION
When unselecting tags when a search is selected we don't want to block the signal, so that filtering changes and we can search across all tags.

This fixes the last part of #390 

closes #390