### PR TITLE
Fix automatic unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         sudo apt-get update
         sudo apt install -y meson gettext itstool libgirepository1.0-dev gir1.2-gtk-4.0 libgtksourceview-5-dev libportal-dev
-        pip install --user pytest pycairo PyGObject==3.50.0 caldav lxml
+        pip install --user pytest pycairo PyGObject==3.50.0 caldav==1.4.0 vobject lxml
 
     - name: Build and install GTG
       run: |


### PR DESCRIPTION
The automatic GHA tests are failing because it does not find the *vobject* package. PR #1219 passed when I opened it, but the exact same code failed after the merge. The difference seems to be that the GHA moved to a *cladav* version not requiring *vobject* anymore.

**The changes are as follows:**
- Require the same *caldav* version as in the flatpak build.
- Add *vobject* as an explicit dependency.