### PR TITLE
Update task counters of tags when a task is deleted

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -27,7 +27,7 @@ from time import time
 import random
 import string
 
-from GTG.core.tasks import TaskStore, Filter
+from GTG.core.tasks import TaskStore, Task, Filter
 from GTG.core.tags import TagStore, Tag
 from GTG.core.saved_searches import SavedSearchStore
 from GTG.core import firstrun_tasks
@@ -76,9 +76,16 @@ class Datastore:
             'actionable': {'all': 0, 'untagged': 0},
             'closed': {'all': 0, 'untagged': 0},
         }
+        self.tasks.connect('removed', self._on_task_removed)
 
         self.data_path: Optional[str] = None
         self._activate_non_default_backends()
+
+
+    def _on_task_removed(self,_,task:Task):
+        "When a task is removed, the corresponding tag-stats must be updated."
+        self.refresh_task_count()
+        self.refresh_tag_stats()
 
 
     @property


### PR DESCRIPTION
The `DataStore` observes the 'removed' events of the `TaskStore` and updates the statistics of the tags.

**Steps to reproduce the bug:**
1. Start GTG with the default dataset.
2. Remove all tasks at the same time.
3. Observe that the counter in the sidebar are unchanged.
