### PR TITLE
Fix quick add with a tag

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -886,6 +886,12 @@ class TaskStore(BaseStore[Task]):
         return f'Task Store. Holds {len(self.lookup)} task(s)'
 
 
+    def add_tags(self, task: Task, tags: list[Tag]):
+        for t in tags:
+            task.add_tag(t)
+        self.emit('task-filterably-changed',task)
+
+
     def get(self, tid: UUID) -> Task:
         """Get a task by name."""
 

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -883,9 +883,8 @@ class MainWindow(Gtk.ApplicationWindow):
 
         #TODO: Add back recurring
 
-        for tag in data['tags']:
-            _tag = self.app.ds.tags.new(tag)
-            task.add_tag(_tag)
+        tags = [ self.app.ds.tags.new(t) for t in data['tags'] ]
+        self.app.ds.tasks.add_tags(task,tags)
 
         # signal the event for the plugins to catch
         GLib.idle_add(self.emit, "task-added-via-quick-add", task.id)

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -889,7 +889,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # signal the event for the plugins to catch
         GLib.idle_add(self.emit, "task-added-via-quick-add", task.id)
-        self.get_pane().select_last()
+        self.get_pane().select_task(task)
 
 
     def on_tag_treeview_click_begin(self, gesture, sequence):

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -308,13 +308,6 @@ class TaskPane(Gtk.ScrolledWindow):
             self.expand_selected(True)
 
 
-    def select_last(self) -> None:
-        """Select last position in the task list."""
-
-        position = self.filtered.get_n_items()
-        self.task_selection.select_item(position - 1, True)
-
-
     def select_task(self, task: Task) -> None:
         """Select a task in the list."""
 


### PR DESCRIPTION
I discovered two somewhat related bugs during testing.

**Steps to reproduce the first bug:**
1. Start GTG with the default dataset.
2. Delete all tasks.
3. Select a tag.
4. Add a task via quick add and observe a crash.

This happens because GTG tries to select the last task in the task list even when it is empty. The original intention was probably to select the newly added task. (Note that it is still possible to have an empty list, e.g., when in the Closed or Actionable view.) I removed the `select_last` method since it wasn't used anywhere else.

**Fixing the crash revealed the second bug:** the newly added task is not visible in the task list. 

This is solved by the new `TaskStore.add_tags` method that emits a signal when the tags are added. It accepts a list of tags but emits only a single signal to keep things efficient.