### PR TITLE
Update the sidebar counters after stat recalculations

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -84,7 +84,6 @@ class Datastore:
 
     def _on_task_removed(self,_,task:Task):
         "When a task is removed, the corresponding tag-stats must be updated."
-        self.refresh_task_count()
         self.refresh_tag_stats()
 
 
@@ -108,7 +107,7 @@ class Datastore:
         self.tags.from_xml(tags_xml)
         self.tasks.from_xml(tasks_xml, self.tags)
 
-        self.refresh_task_count()
+        self.refresh_tag_stats()
 
 
     def load_file(self, path: str) -> None:

--- a/GTG/gtk/browser/tag_editor.py
+++ b/GTG/gtk/browser/tag_editor.py
@@ -247,9 +247,7 @@ class TagEditor(Gtk.Dialog):
 
             self.tag.name = self.tag_name
 
-        self.app.ds.refresh_task_count()
-        self.app.ds.refresh_task_for_tag(self.tag)
-        self.app.ds.notify_tag_change([self.tag])
+        self.app.ds.refresh_tag_stats()
         self.app.browser.sidebar.refresh_tags()
         self.destroy()
 


### PR DESCRIPTION
Ancestor tag counters were off in the sidebar even after a restart. 

**Steps to reproduce the bug:**
1. Create a nested tag structure with the following new tags: _x > y > z_
2. Create a task with tag _z_. (The counters are wrong here, too, but that is another story.)
3. Restart GTG.
4. Observe the faulty counters in the sidebar (_x_ and _y_ have 0 instead of 1).

The fix prefers `DataStore.update_tag_stats` over `DataStore.refresh_task_count` to trigger an update in the sidebar stats.