### PR TITLE
Consider all tasks in `TaskStore.filter`

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -244,9 +244,6 @@ class Datastore:
                     val = count.get(tag.name, 0)
                     count[tag.name] = val + 1
 
-                if task.children:
-                    count_tasks(count, task.children)
-
         # Reset task counts
         self.task_count = {
             'open': {'all': 0, 'untagged': 0},

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -1131,16 +1131,16 @@ class TaskStore(BaseStore[Task]):
 
 
         if filter_type == Filter.STATUS:
-            return [t for t in self.data if t.status == arg]
+            return [t for t in self.lookup.values() if t.status == arg]
 
         elif filter_type == Filter.ACTIVE:
-            return [t for t in self.data if t.status == Status.ACTIVE]
+            return [t for t in self.lookup.values() if t.status == Status.ACTIVE]
 
         elif filter_type == Filter.CLOSED:
-            return [t for t in self.data if t.status != Status.ACTIVE]
+            return [t for t in self.lookup.values() if t.status != Status.ACTIVE]
 
         elif filter_type == Filter.ACTIONABLE:
-            return [t for t in self.data if t.is_actionable]
+            return [t for t in self.lookup.values() if t.is_actionable]
 
         elif filter_type == Filter.PARENT:
             return [t for t in self.lookup.values() if not t.parent]


### PR DESCRIPTION
`TaskStore.filter` only considered root tasks in some cases, causing wrong sidebar counters and faulty task purging.

**Steps to reproduce the bug:**
1. Create a new nested task structure: _a > b > c_
2. Create a new tag: _z_.
3. Tag _c_ with _z_.
4. Restart GTG.
5. Go to the Actionable view
6. Observe the wrong counter value for _z_ (0 instead of 1).
7. (If you mark _c_ as completed, you can not purge it.)
