### PR TITLE
Fix sidebar counters

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -54,6 +54,11 @@ class TaskCounts(GObject.Object):
     task_count_actionable = GObject.Property(type=int,default=0)
     task_count_closed = GObject.Property(type=int,default=0)
 
+    def reset(self) -> None:
+        self.task_count_open = 0
+        self.task_count_actionable = 0
+        self.task_count_closed = 0
+
 
 
 class TagStats:
@@ -72,6 +77,9 @@ class TagStats:
 
     def recalculate_all(self):
         "Recalculate all stats from scratch."
+
+        for task_count in self.stats.values():
+            task_count.reset()
 
         for tname,count in TagStats._count_tasks(self.tasks.filter(Filter.ACTIVE)).items():
             self.get_by_name(tname).task_count_open = count

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -134,15 +134,16 @@ class Datastore:
 
         # Count of tasks for each pane and each tag
         self.tag_stats = TagStats(self.tags,self.tasks)
-        self.tasks.connect('removed', self._on_task_removed)
+        for event in ['removed','added','parent-change','parent-removed','task-filterably-changed']:
+            self.tasks.connect(event, self._handle_possible_tag_stat_chnages)
 
         self.data_path: Optional[str] = None
         self._activate_non_default_backends()
 
 
-    def _on_task_removed(self,_,task:Task):
-        "When a task is removed, the corresponding tag-stats must be updated."
-        self.refresh_tag_stats()
+    def _handle_possible_tag_stat_chnages(self,*args,**kwargs) -> None:
+        "Recalculate tag_stats. This is a method to be used as a callback."
+        self.tag_stats.recalculate_all()
 
 
     @property

--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -48,14 +48,15 @@ class TagEmptyFilter(Gtk.Filter):
     def do_match(self, item) -> bool:
         tag = unwrap(item, Tag)
 
+        task_counts = self.ds.get_task_counts(tag.name)
         if self.pane == 'open_view':
-            return self.show_zero or tag.task_count_open > 0
+            return self.show_zero or task_counts.task_count_open > 0
 
         elif self.pane == 'closed_view':
-            return self.show_zero or tag.task_count_closed > 0
+            return self.show_zero or task_counts.task_count_closed > 0
 
         elif self.pane == 'actionable_view':
-            return (self.show_zero or tag.task_count_actionable > 0) and tag.actionable
+            return (self.show_zero or task_counts.task_count_actionable > 0) and tag.actionable
 
         else:
             return True

--- a/GTG/core/filters.py
+++ b/GTG/core/filters.py
@@ -48,7 +48,7 @@ class TagEmptyFilter(Gtk.Filter):
     def do_match(self, item) -> bool:
         tag = unwrap(item, Tag)
 
-        task_counts = self.ds.get_task_counts(tag.name)
+        task_counts = self.ds.get_task_counts(tag)
         if self.pane == 'open_view':
             return self.show_zero or task_counts.task_count_open > 0
 

--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -52,10 +52,6 @@ class Tag(StoreItem):
         self._color: Optional[str] = None
         self.actionable = True
 
-        self._task_count_open = 0
-        self._task_count_actionable = 0
-        self._task_count_closed = 0
-
         super().__init__(id)
 
 
@@ -75,8 +71,6 @@ class Tag(StoreItem):
         """Equivalence."""
 
         return self.id == other.id
-
-
 
 
     @GObject.Property(type=str)
@@ -129,39 +123,6 @@ class Tag(StoreItem):
         return self._icon is not None
 
 
-    @GObject.Property(type=int, default=0)
-    def task_count_open(self) -> int:
-
-        return self._task_count_open
-
-
-    @task_count_open.setter
-    def set_task_count_open(self, value: int) -> None:
-        self._task_count_open = value
-
-
-    @GObject.Property(type=int, default=0)
-    def task_count_actionable(self) -> int:
-
-        return self._task_count_actionable
-
-
-    @task_count_actionable.setter
-    def set_task_count_actionable(self, value: int) -> None:
-        self._task_count_actionable = value
-
-
-    @GObject.Property(type=int, default=0)
-    def task_count_closed(self) -> int:
-
-        return self._task_count_closed
-
-
-    @task_count_closed.setter
-    def set_task_count_closed(self, value: int) -> None:
-        self._task_count_closed = value
-
-
     def get_matching_tags(self) -> List['Tag']:
         """Return the tag with its descendants."""
         matching = [self]
@@ -172,6 +133,7 @@ class Tag(StoreItem):
 
     def __hash__(self):
         return id(self)
+
 
 
 class TagStore(BaseStore[Tag]):

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -1043,7 +1043,7 @@ class TaskStore(BaseStore[Task]):
         super().add(item, parent_id)
         item.duplicate_cb = self.duplicate_for_recurrent
         for event in ['notify::is-actionable','notify::is-active','tags-changed']:
-            item.connect(event,lambda *a: self.emit('task-filterably-changed',item))
+            item.connect(event,lambda *_: self.emit('task-filterably-changed',item))
 
 
     def unparent(self, item_id: UUID) -> None:

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -241,6 +241,7 @@ class Task(StoreItem):
 
         self.has_date_start = bool(value)
         self.date_start_str = self._date_start.to_readable_string()
+        self.notify('is_actionable')
 
 
     @property

--- a/GTG/gtk/browser/delete_tag.py
+++ b/GTG/gtk/browser/delete_tag.py
@@ -43,7 +43,6 @@ class DeleteTagsDialog:
 
             self.browser.app.ds.tags.remove(tag.id)
 
-        self.browser.app.ds.tasks.notify('task_count_no_tags')
         self.tags_todelete = []
 
     def on_response(self, dialog, response, tagslist, callback):

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -883,8 +883,8 @@ class MainWindow(Gtk.ApplicationWindow):
 
         #TODO: Add back recurring
 
-        tags = [ self.app.ds.tags.new(t) for t in data['tags'] ]
-        self.app.ds.tasks.add_tags(task,tags)
+        for tag in [ self.app.ds.tags.new(t) for t in data['tags'] ]:
+            task.add_tag(tag)
 
         # signal the event for the plugins to catch
         GLib.idle_add(self.emit, "task-added-via-quick-add", task.id)

--- a/GTG/gtk/browser/modify_tags.py
+++ b/GTG/gtk/browser/modify_tags.py
@@ -111,7 +111,6 @@ class ModifyTagsDialog(Gtk.Dialog):
                     task.remove_tag(_tag.name)
 
         self.app.ds.save()
-        self.app.ds.tasks.notify('task_count_no_tags')
 
         # Rember the last actions
         self.last_tag_entry = self._tag_entry.get_text()

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -274,7 +274,7 @@ class Sidebar(Gtk.ScrolledWindow):
         count_label.add_css_class('dim-label')
         box.append(count_label)
 
-        task_counts = self.ds.get_task_counts(count_prop)
+        task_counts = self.ds.get_task_counts_by_handle(count_prop)
         task_counts.bind_property('task_count_open', count_label, 'label', BIND_FLAGS)
 
         return box
@@ -378,7 +378,7 @@ class Sidebar(Gtk.ScrolledWindow):
         box.props.tag = item
         expander.set_list_row(listitem.get_item())
 
-        task_counts = self.ds.get_task_counts(item.name)
+        task_counts = self.ds.get_task_counts(item)
 
         listitem.bindings = [
             item.bind_property('name', label, 'label', BIND_FLAGS),

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -200,14 +200,12 @@ class TaskEditor(Gtk.Window):
     def tag_added(self, name):
 
         self.task.add_tag(self.ds.tags.new(name))
-        self.ds.tasks.notify('task_count_no_tags')
         self.app.browser.sidebar.refresh_tags()
 
 
     def tag_removed(self, name):
 
         self.task.remove_tag(name)
-        self.ds.tasks.notify('task_count_no_tags')
         self.app.browser.sidebar.refresh_tags()
 
 


### PR DESCRIPTION
Closes #1023 

While considering different options, I realised that if a task is changed in a way that it influences at least one counter, it can possibly impact any other counters as well. The complication mainly revolves around actionability. E.g., if the user completes/removes/dismisses a task, it can impact: all the tags applied to that task, their ancestor tags, and the same can be true for the parent task, which can possibly become actionable.

**Based on the previous observation, I made the following changes:**
- Move stat-related calculations to its own class (`TagStats`). The goal is to prevent logic from being scattered and making other methods more complex. This could also help recognise bugs and optimise the calculations.
- Connected major task events with stat recalculations. This may raise performance concerns for large datasets. I plan to investigate it, but this PR is already big enough. `TagStats` is a good start for incremental updates, but in the worst case, we can consider enabling and disabling stat calculations with a keybinding.
- Use IDs instead of tag names. This avoids conflicting names when _"all"_ or _"untagged"_ names are used, and avoids complications when tags are renamed.