### PR TITLE
Ensure we have an added date to task in caldav

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -982,6 +982,10 @@ class Translator:
         if not CATEGORIES.has_calendar_tag(task, todo.parent):
             tag = datastore.tags.new(CATEGORIES.get_calendar_tag(todo.parent))
             task.add_tag(tag)
+
+        if not task.get_added_date():
+            task.set_added_date(datetime.now())
+
         return task
 
     @classmethod


### PR DESCRIPTION
Syncing a task that has no CREATED field leads to a state where the task's 'date_added' attribute is not set.

The xml task element that is subsequently written to disk has then no added tag, although the schema requires it to be always present.

fixes #1033

⚠️ This needs help testing!