### PR TITLE
Avoid deleting children multiple times while purging old tasks

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -484,8 +484,7 @@ class Application(Gtk.Application):
         to_remove = [t for t in closed_tasks
                      if (today - t.date_closed).days > max_days]
 
-        for t in to_remove:
-            self.ds.tasks.remove(t.id)
+        self.ds.tasks.batch_remove([t.id for t in to_remove])
 
 
     def autoclean(self, timer):


### PR DESCRIPTION
Fixes #1247

GTG tried to delete the same closed task multiple times. E.g., the task is first deleted as the child of another closed task, and then a second delete is attempted because the task is also present in `to_remove`. Using `BaseStore.batch_remove` avoids this problem.

