### PR TITLE
Apply sidebar filters to all panes

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1401,7 +1401,6 @@ class MainWindow(Gtk.ApplicationWindow):
         #       to actionable
         self.stack_switcher.get_stack().get_first_child().get_first_child().emit('expand-all')
 
-        self.get_pane().set_filter_tags(set(self.sidebar.selected_tags()))
         self.sidebar.change_pane(current_pane)
         self.get_pane().sort_btn.set_popover(None)
         self.get_pane().sort_btn.set_popover(self.sort_menu)
@@ -1476,6 +1475,23 @@ class MainWindow(Gtk.ApplicationWindow):
 
 
         return self.stack_switcher.get_stack().get_visible_child().get_first_child()
+
+
+    def set_filter_tags(self,required_tags=None):
+        if required_tags is None:
+            required_tags = []
+        for p in self.panes.values():
+            p.set_filter_tags(required_tags)
+
+
+    def set_filter_notags(self):
+        for p in self.panes.values():
+            p.set_filter_notags()
+
+
+    def set_search_query(self,query):
+        for p in self.panes.values():
+            p.set_search_query(query)
 
 
     @GObject.Property(type=bool, default=True)

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -425,7 +425,7 @@ class Sidebar(Gtk.ScrolledWindow):
             return
         with signal_block(self.searches_selection, self.search_handle):
             self.searches_selection.unselect_item(search_id)
-            self.app.browser.get_pane().set_search_query('')
+            self.app.browser.set_search_query('')
 
 
     def unselect_general_box(self) -> None:
@@ -444,9 +444,9 @@ class Sidebar(Gtk.ScrolledWindow):
         self.app.browser.get_pane().emit('expand-all')
 
         if index == 0:
-            self.app.browser.get_pane().set_filter_tags()
+            self.app.browser.set_filter_tags()
         elif index == 1:
-            self.app.browser.get_pane().set_filter_notags()
+            self.app.browser.set_filter_notags()
 
         self.emit('selection_changed')
 
@@ -459,7 +459,7 @@ class Sidebar(Gtk.ScrolledWindow):
 
         item = model.get_item(position)
         self.app.browser.get_pane().emit('expand-all')
-        self.app.browser.get_pane().set_search_query(item.query)
+        self.app.browser.set_search_query(item.query)
         self.emit('selection_changed')
 
 
@@ -495,7 +495,7 @@ class Sidebar(Gtk.ScrolledWindow):
         self.unselect_searches()
 
         self.app.browser.get_pane().emit('expand-all')
-        self.app.browser.get_pane().set_filter_tags(set(self.selected_tags()))
+        self.app.browser.set_filter_tags(set(self.selected_tags()))
 
         tags = self.selected_tags(names_only=True)
 


### PR DESCRIPTION
Fixes #1246

The sidebar updated only the current pane instead of all of them. (The same bug was reproducible for saved searches, too.)

**The changes are as follows:**
- Introduce helper methods in `MainWindow` to change the filtering in all panes at once.
- Use these methods in `Sidebar` instead of updating only the current pane.
- Do not call `TaskPane.set_filter_tags` when changing panes. (This would undo the "untagged" filtering.)

