### PR TITLE
Recognise tag parents by their names

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -247,13 +247,22 @@ class TagStore(BaseStore[Tag]):
         for element in elements:
             child_id: UUID = UUID(element.get('id'))
             hex_parent_id: Optional[str] = element.get('parent')
+            parent_id: Optional[UUID] = None
+
             if hex_parent_id is None:
                 continue
 
             try:
-                parent_id: UUID = UUID(hex_parent_id)
+                parent_id = UUID(hex_parent_id)
             except ValueError:
-                log.debug('Malformed parent UUID: %s', tag, hex_parent_id)
+                log.debug('Parent id is not a valid UUID: %s', hex_parent_id)
+
+            if parent_id is None and hex_parent_id in self.lookup_names:
+                log.debug('Parent id recognised as tag name from an old format: %s', hex_parent_id)
+                parent_id = self.lookup_names[hex_parent_id].id
+
+            if parent_id is None:
+                log.error('Failed to identify parent tag: %s', hex_parent_id)
                 continue
 
             try:

--- a/tests/core/test_tag_store.py
+++ b/tests/core/test_tag_store.py
@@ -66,6 +66,19 @@ class TestTagStore(TestCase):
         self.assertEqual(store.count(root_only=True), 2)
 
 
+    def test_xml_load_tree_with_old_parent_naming(self):
+        store = TagStore()
+        xml_doc = XML('''
+        <taglist>
+            <tag id="df4db599-63f8-4fc8-9f3d-5454dcadfd78" name="money"/>
+            <tag id="ef4db599-73f8-4fc8-9f3d-5454dcadfd78" name="errands" parent="money"/>
+        </taglist>
+            ''')
+
+        store.from_xml(xml_doc)
+        self.assertIs(store.find("errands").parent,store.find("money"))
+
+
     def test_xml_load_bad(self):
         store = TagStore()
         xml_doc = XML('''


### PR DESCRIPTION
Fixes #1249

Old formats used the tag name instead of the ID to identify parent tags. This is now considered in `TagStore.from_xml` and checked by an additional test case.

