### PR TITLE
fix(caldav): add default calendar fallback for tasks without calendar tag

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -83,6 +83,9 @@ class Backend(PeriodicImportBackend):
         "is-first-run": {
             GenericBackend.PARAM_TYPE: GenericBackend.TYPE_BOOL,
             GenericBackend.PARAM_DEFAULT_VALUE: True},
+        "default-calendar": {
+            GenericBackend.PARAM_TYPE: GenericBackend.TYPE_STRING,
+            GenericBackend.PARAM_DEFAULT_VALUE: 'gtg'},
     }
 
     #
@@ -371,8 +374,8 @@ class Backend(PeriodicImportBackend):
         if todo and getattr(todo, 'parent', None):
             logger.debug('Found from todo %r and %r', todo, todo.parent)
             return todo, todo.parent
-        # fallback: use calendar named 'gtg' as default, or first available
-        default_calendar = self._cache.get_calendar(name='gtg')
+        # fallback: use configured default calendar, or first available
+        default_calendar = self._cache.get_calendar(name=self._parameters.get('default-calendar', 'gtg'))
         if not default_calendar:
             for __, default_calendar in self._cache.calendars:
                 break

--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -371,6 +371,14 @@ class Backend(PeriodicImportBackend):
         if todo and getattr(todo, 'parent', None):
             logger.debug('Found from todo %r and %r', todo, todo.parent)
             return todo, todo.parent
+        # fallback: use calendar named 'gtg' as default, or first available
+        default_calendar = self._cache.get_calendar(name='gtg')
+        if not default_calendar:
+            for __, default_calendar in self._cache.calendars:
+                break
+        if default_calendar:
+            logger.debug('No calendar found, using default %r', default_calendar)
+            return todo, default_calendar
         return None, None
 
     @property


### PR DESCRIPTION
## Problem
When a task has no calendar tag (@DAV_name) and no calendar_name 
attribute, GTG silently skips synchronization with the message 
"has no calendar to be synced with".

This affects all new users who set up CalDAV sync without knowing 
they need to manually tag every task with @DAV_<calendar_name>.

## Solution
Add a fallback in _get_todo_and_calendar() that uses a calendar 
named 'gtg' by default, or the first available calendar if none 
is named 'gtg'.

## Update
Added a configurable `default-calendar` parameter so users can set 
their preferred default calendar name, instead of relying on a 
hardcoded value. Defaults to 'gtg' for backward compatibility.

## Tested on
- GTG 0.6.0 / Debian 13
- Nextcloud CalDAV
- Synced with Tasks.org on Fairphone 4 (e/OS)