### PR TITLE
fix: refresh editor when a subtask is deleted externally (#544)

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -169,6 +169,11 @@ class TaskEditor(Gtk.Window):
 
         self.textview.set_text_from_task()
 
+        # Refresh editor if a subtask is deleted externally (fix #544)
+        self._removed_handler = self.ds.tasks.connect(
+            'removed', self._on_task_removed
+        )
+
         # Connect search field to tags popup
         self.tags_tree.set_search_entry(self.tags_entry)
         self.tags_tree.set_search_equal_func(self.search_function, None)
@@ -696,7 +701,15 @@ class TaskEditor(Gtk.Window):
     def remove_subtask(self, tid):
         """Remove a subtask of this task."""
 
+        if tid not in self.app.ds.tasks.lookup:
+            log.debug('Task %s already removed, skipping unparent', tid)
+            return
         self.app.ds.tasks.unparent(tid)
+
+    def _on_task_removed(self, store, removed_task):
+        """Refresh textview if a subtask of this task was removed externally."""
+        if removed_task.id in self.textview.subtasks['tags']:
+            self.textview.process()
 
     def rename_subtask(self, tid, new_title):
         """Rename a subtask of this task."""
@@ -837,6 +850,9 @@ class TaskEditor(Gtk.Window):
         # Save because self.textview.process() only calls light_save(), which
         # isn't guaranteed to actually save (see #1138)
         self.save()
+
+        # Disconnect the task-removed signal handler
+        self.ds.tasks.disconnect(self._removed_handler)
 
         # self.pengine.onTaskClose(self.plugin_api)
         # self.pengine.remove_api(self.plugin_api)

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -363,6 +363,16 @@ class TaskView(GtkSource.View):
 
             # Don't auto-remove it
             tid = sub_tag.tid
+
+            # Task may have been deleted externally (fix #544)
+            if tid not in self.ds.tasks.lookup:
+                log.debug('Task %s was deleted externally, removing from content', tid)
+                end = start.copy()
+                end.forward_to_line_end()
+                start.backward_chars(2)
+                self.buffer.delete(start, end)
+                return False
+
             task = self.ds.tasks.lookup[tid]
             parent = task.parent
 


### PR DESCRIPTION
## Summary

Fixes #544

When a subtask was deleted from the task browser while its parent task 
editor was open, the subtask remained visible as a dead link in the editor. 
Clicking it caused a `KeyError` traceback (previously `AttributeError` 
in older versions, as noted in the original issue).

## Steps to reproduce (before this fix)

1. Create a parent task and open it in the task editor
2. Add a subtask to it
3. Close and reopen the editor to make sure the subtask is saved
4. Reopen the parent task editor and **leave it open**
5. In the task browser, right-click the subtask → Delete
6. **Bug**: the subtask remains visible as a dead link in the open editor
7. Clicking it produces a `KeyError` traceback in the terminal

## Root cause

The task editor had no way of knowing that a subtask was deleted 
externally (from the browser). The `TaskStore` emits a `'removed'` 
signal, but the editor was not connected to it.

Additionally, `detect_subtasks()` in `taskview.py` and `remove_subtask()` 
in `editor.py` both performed unchecked `lookup[tid]` calls, which raise 
a `KeyError` when the task has already been removed from the store.

## Changes

- **`GTG/gtk/editor/editor.py`**: connect to `TaskStore`'s `'removed'` 
  signal in `__init__`. When a removed task is found in the textview's 
  tracked subtasks, trigger `textview.process()` to refresh the content. 
  The signal is properly disconnected in `destruction()` to avoid leaks.
  Also added a guard in `remove_subtask()` to skip `unparent()` if the 
  task no longer exists in the store.

- **`GTG/gtk/editor/taskview.py`**: added a guard in `detect_subtasks()` 
  to handle the case where a subtask's `tid` is no longer present in 
  `ds.tasks.lookup`. The orphaned line is cleanly removed from the buffer.

## Testing

Verified manually on the development version (`./launch.sh`) by 
reproducing the exact steps above. After this fix:
- The subtask disappears from the open editor immediately upon deletion
- No `KeyError` traceback is produced
- No regressions observed on normal subtask creation/deletion workflows