### PR TITLE
fix: now you can close preference window with Esc key

### DIFF
--- a/GTG/gtk/preferences.py
+++ b/GTG/gtk/preferences.py
@@ -18,7 +18,7 @@
 
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 from GTG.core.dirs import UI_DIR
 from GTG.gtk.general_preferences import GeneralPreferences
@@ -39,6 +39,7 @@ class Preferences(Gtk.Window):
 
         self.pages = {}
         self.add_page(GeneralPreferences(app))
+        self.connect('key-press-event', self._on_key_press)
 
     def activate(self):
         """ Activate the preferences window."""
@@ -51,9 +52,17 @@ class Preferences(Gtk.Window):
         self.hide()
         return True
 
+
     def add_page(self, page):
         """add_page adds a titled child to the main stack.
         All children are added using this function from __init__"""
         page_name = page.get_name()
         self.pages[page_name] = page
         self._page_stack.add_titled(page, page_name, page.get_title())
+
+    
+    def _on_key_press(self, widget, event):
+        """Close the window when Escape is pressed."""
+        if event.keyval == Gdk.KEY_Escape:
+            self.hide()
+            return True

--- a/GTG/gtk/preferences.py
+++ b/GTG/gtk/preferences.py
@@ -36,10 +36,11 @@ class Preferences(Gtk.Window):
     def __init__(self, app):
         super().__init__()
         self.config = app.config
-
         self.pages = {}
         self.add_page(GeneralPreferences(app))
-        self.connect('key-press-event', self._on_key_press)
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect('key-pressed', self._on_key_press)
+        self.add_controller(key_controller)
 
     def activate(self):
         """ Activate the preferences window."""
@@ -61,8 +62,8 @@ class Preferences(Gtk.Window):
         self._page_stack.add_titled(page, page_name, page.get_title())
 
     
-    def _on_key_press(self, widget, event):
+    def _on_key_press(self, controller, keyval, keycode, state):
         """Close the window when Escape is pressed."""
-        if event.keyval == Gdk.KEY_Escape:
+        if keyval == Gdk.KEY_Escape:
             self.hide()
             return True

--- a/GTG/gtk/preferences.py
+++ b/GTG/gtk/preferences.py
@@ -61,7 +61,7 @@ class Preferences(Gtk.Window):
         self.pages[page_name] = page
         self._page_stack.add_titled(page, page_name, page.get_title())
 
-    
+
     def _on_key_press(self, controller, keyval, keycode, state):
         """Close the window when Escape is pressed."""
         if keyval == Gdk.KEY_Escape:

--- a/GTG/gtk/preferences.py
+++ b/GTG/gtk/preferences.py
@@ -53,7 +53,6 @@ class Preferences(Gtk.Window):
         self.hide()
         return True
 
-
     def add_page(self, page):
         """add_page adds a titled child to the main stack.
         All children are added using this function from __init__"""


### PR DESCRIPTION
The preferences windows now can close with Esc key like all windows, for that adds a key-press-event handler that 
calls hide() when Escape is pressed, with that its must be close.