### PR TITLE
fix: don't crash when closing the date picker before it was shown (#1195)

### DIFF
--- a/GTG/gtk/editor/calendar.py
+++ b/GTG/gtk/editor/calendar.py
@@ -45,6 +45,7 @@ class GTGCalendar(GObject.GObject):
         self.__builder.add_from_file(GnomeConfig.CALENDAR_UI_FILE)
         self.__date_kind = None
         self.__date = Date.no_date()
+        self.__sigid = None
         self.__init_gtk__()
 
     def __init_gtk__(self):


### PR DESCRIPTION
## Summary

Fixes #1195

`GTGCalendar.close_calendar()` crashes with `AttributeError: 'Window' object has
no attribute '_GTGCalendar__sigid'` when it runs before the calendar was ever shown.

## Analysis

- `self.__sigid` is only created in `show()`, when the "day-selected" signal
  gets connected.
- `close_calendar()` already guards with `if self.__sigid is not None:`, but if
  `show()` was never called, the attribute does not exist at all, so the guard
  itself raises.
- The class delegates unknown attributes to the wrapped window through
  `__getattr__`, which explains the unusual error message mentioning the
  'Window' object.

The close paths (`close_calendar`, `_esc_close`) can be reached independently of
`show()`: the Escape shortcut is registered at construction time.

## Changes

Initialize `self.__sigid = None` in `__init__`, next to the other state
attributes. The existing guard in `close_calendar()` then works as intended.
One line changed.

## Testing

Deterministic reproduction, no UI interaction needed (run from the repo root):

    import gi
    gi.require_version('Gtk', '4.0')
    gi.require_version('GtkSource', '5')
    from gi.repository import Gtk
    Gtk.init_check()

    from GTG.gtk.editor.calendar import GTGCalendar

    cal = GTGCalendar()      # show() never called
    cal.close_calendar()     # AttributeError on master, harmless with this fix
    cal._esc_close()         # the other close path
    print("No crash: closing before show() is harmless")

On master this reproduces the exact traceback from #1195. With this fix, both
calls are harmless no-ops.

Also manually tested the custom date picker in the task browser (the only place
GTGCalendar is instantiated): picking a date, reopening, closing with Escape,
everything works and the terminal stays clean.