### PR TITLE
fix: Escape closes the open date popover instead of the whole task editor (#403)

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -439,6 +439,8 @@ class Application(Gtk.Application):
         search = self.browser.search_entry.is_focus()
 
         if editor:
+            if editor.close_open_date_popover():
+                return
             self.close_task(editor.task.id)
         elif search:
             self.browser.toggle_search(action, params)

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -247,6 +247,23 @@ class TaskEditor(Gtk.Window):
 
         self.closed_popover.popup()
 
+    def close_open_date_popover(self) -> bool:
+        """Close the currently open date popover, if any.
+
+        Returns True if a popover was closed. Used by the application's
+        Escape accelerator so that a first Escape only dismisses the
+        popover instead of closing the whole editor (see issue #403).
+        """
+
+        for popover in (self.start_popover,
+                        self.due_popover,
+                        self.closed_popover):
+            if popover.get_visible():
+                popover.popdown()
+                return True
+
+        return False
+
     @Gtk.Template.Callback()
     def sync_tag_store(self, widget=None):
 


### PR DESCRIPTION
## Summary

Addresses the Escape key part of #403 (not using the "Fixes" keyword on
purpose: the original report also covers the preset buttons behavior, which
this PR deliberately leaves untouched).

Full root-cause analysis in
https://github.com/getting-things-gnome/gtg/issues/403#issuecomment-4910225357 (my comment
from today). Short version below.

## Root cause

Three pieces combine:

- `app.close` is bound to Escape at the application level
  (`GTG/gtk/application.py`), so the accelerator fires anywhere in GTG.
- The date popovers (`start_popover`, `due_popover`, `closed_popover`) are
  declared `autohide=False` in `task_editor.ui`, so they do not grab focus and
  do not consume Escape themselves. This is a deliberate design inherited from
  `modal=False` in the GTK 3 UI files (converted in 90f8ec5b): it lets the user
  keep typing in the date entry while the calendar stays visible. Flipping
  autohide would also change focus and click-outside behavior, hence this PR
  does not touch the .ui files.
- `close_context()` only asks "is an editor active?" and closes the whole
  task, never asking whether a popover is open.

## Changes

- New `TaskEditor.close_open_date_popover()`: pops down the currently visible
  date popover, if any, and reports whether it did.
- `close_context()` asks that question first: if a date popover was open, the
  first Escape only dismisses it; the second Escape closes the editor, as
  before.

This is the behavior @nekohayo suggested in the issue ("remap the Escape key
to apply only to the popover"), and follows the same pattern as the recent
Escape fixes #1270 and #1271.

## Testing

Manually tested on Debian (GTK 4, 0.7-dev):

- Editor open, no popover, Escape: editor closes (historical behavior kept).
- Editor open, start/due/closed date popover open, first Escape: only the
  popover closes, the editor survives. Second Escape: the editor closes.
- Recurrence popover: still closes itself on Escape (GtkPopoverMenu,
  autohide default), unaffected.
- Main window search bar and Escape: unaffected (no change to that branch of
  `close_context`).

Terminal stays clean during all scenarios.