### PR TITLE
docs: update the dependency lists for the GTK 4 port (#1001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,18 @@ You can get most of those from your distribution packages:
 
 ```sh
 # On Fedora:
-sudo dnf install meson python3-cairo python3-gobject gtk3 itstool gettext python3-lxml libsecret gtksourceview4
-# On Debian 10 (buster), you need to install the backported version, activate it with:
-echo 'deb http://deb.debian.org/debian buster-backports main' | sudo tee -a /etc/apt/sources.list
+sudo dnf install meson ninja-build gettext itstool gtk4-devel gtksourceview5 libportal libsecret python3-gobject python3-cairo python3-lxml
 # On Debian/Ubuntu:
-sudo apt install meson python3-gi-cairo python3-gi gir1.2-pango-1.0 gir1.2-gdkpixbuf-2.0 gir1.2-gtk-3.0 itstool gettext python3-lxml libgirepository1.0-dev libsecret-1.0 gir1.2-secret-1
+sudo apt install meson ninja-build pkgconf gettext itstool libgtk-4-dev gir1.2-gtk-4.0 gir1.2-gtksource-5 gir1.2-xdp-1.0 gir1.2-secret-1 python3-gi python3-gi-cairo python3-lxml
 ```
 
 #### Optional Dependencies
 
 * [setproctitle](https://pypi.org/project/setproctitle/)
   (to set the process title when listing processes with `ps` et al.)
+* [caldav](https://pypi.org/project/caldav/) (`python3-caldav` on
+  Debian/Ubuntu and Fedora): required to enable the CalDAV
+  synchronization backend.
 
 ### Test dependencies
 
@@ -77,9 +78,9 @@ To run the current test suite, you need some additional packages (this list may 
 
 ```sh
 # On Fedora:
-sudo dnf install python3-pytest python3-pyflakes python3-spec python3-pycodestyle
+sudo dnf install python3-pytest python3-pycodestyle python3-caldav
 # On Ubuntu/Debian:
-sudo apt install python3-pytest python3-pyflakes python3-pep8 python3-pycodestyle python3-caldav
+sudo apt install python3-pytest python3-pycodestyle python3-caldav
 ```
 
 You currently also need the optional plugin dependencies, as the tests don't automatically skip them. (Help welcome improving that!)

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ dep_gtk4 = dependency('gtk4', version: '>= 4.10')
 # when building which could give the user an idea what could be missing.
 dep_glib = dependency('glib-2.0', required: false)
 dep_libsecret = dependency('libsecret-1', required: false)
-dep_gtksourceview = dependency('gtksourceview-4', required: false)
+dep_gtksourceview = dependency('gtksourceview-5', required: false)
 
 test(
 	'pytest',


### PR DESCRIPTION
## Summary

Fixes #1001

The dependency lists still described the GTK 3 era (`gtk3`,
`gir1.2-gtk-3.0`, `gtksourceview4`, a Debian 10 backports note). Updated
for the GTK 4 port and the new core.

## Sources of truth

- `meson.build` requires `gtk4 >= 4.10`.
- `GTG/__init__.py` requires at runtime: Gdk/Gtk 4.0, GtkSource 5 and
  Xdp 1.0 (hence `gir1.2-xdp-1.0` / libportal).
- Dropped packages that are no longer needed: the pango/gdkpixbuf GIRs
  (pulled in by GTK 4), `libgirepository1.0-dev`, and the
  pyflakes/pep8/spec relics from the test line (style is handled by
  pre-commit nowadays).
- `python3-caldav` moved to an optional-dependency bullet (it is what
  enables the CalDAV synchronization backend), and stays in the test
  line since the test module imports it.

## Verification

The Debian/Ubuntu lines were exercised for real on the fresh Debian 13
install used to develop #1265 this week: running the exact commands
reports every package as already installed (or installs the missing
one), and both `./launch.sh` and the test suite work with exactly this
set. Honest caveat: the Fedora line is a best-effort name mapping and is
untested — Fedora testers welcome to correct package names.

Also bumps the stale `gtksourceview-4` meson probe to `gtksourceview-5`, matching the runtime requirement (the dep object is unused, so it is cosmetic).
