### PR TITLE
fix: close a freshly created task by id and harden Task.__eq__ (#1273)

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -644,6 +644,9 @@ class Task(StoreItem):
     def __eq__(self, other) -> bool:
         """Equivalence."""
 
+        if not isinstance(other, Task):
+            return NotImplemented
+
         return self.id == other.id
 
 

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -458,7 +458,7 @@ class Application(Gtk.Application):
         task = editor.task
 
         if editor.is_new():
-            self.close_task(task)
+            self.close_task(task.id)
         else:
             self.delete_tasks([task], editor)
 

--- a/tests/core/test_task_equality.py
+++ b/tests/core/test_task_equality.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from uuid import uuid4
+
+from GTG.core.tasks import Task
+
+
+class TaskEqualityTest(TestCase):
+    """Task.__eq__ must follow the Python contract: comparing with a
+    foreign type (e.g. a bare UUID used as a dict key) must not raise
+    (regression test for #1273)."""
+
+    def test_equality_with_task(self):
+        tid = uuid4()
+        self.assertEqual(Task(id=tid, title='a'), Task(id=tid, title='b'))
+        self.assertNotEqual(Task(id=tid, title='a'),
+                            Task(id=uuid4(), title='a'))
+
+    def test_equality_with_foreign_type_does_not_raise(self):
+        task = Task(id=uuid4(), title='a')
+        self.assertFalse(task == uuid4())
+        self.assertFalse(task == 'not-a-task')


### PR DESCRIPTION
## Summary

Fixes #1273

Deleting a freshly created, still-untouched task from its editor crashed
with `AttributeError: 'UUID' object has no attribute 'id'`.

## Root cause

`delete_editor_task()` was the only one of the four `close_task()` call
sites passing the `Task` object instead of `task.id`. The failure mode
is sneaky: `Task.__hash__` delegates to `hash(self.id)`, so the stray
Task lands in exactly the right bucket of the `open_tasks` dict (which
is keyed by UUID), the dict then checks equality, and `Task.__eq__` does
`other.id` on a bare UUID.

## Fix (two one-liners)

- `application.py`: pass `task.id` like every other call site.
- `tasks.py`: make `Task.__eq__` follow the Python contract and return
  `NotImplemented` for foreign types, so this whole class of traps
  degrades to a clean `False`/`KeyError` instead of a crash. (Same
  type-safety family as the `str`-in-`children` issue being fixed in
  #1265.)

## Tests

New `tests/core/test_task_equality.py`: the foreign-type comparison test
fails with the exact reported AttributeError on master and passes with
the fix; Task-vs-Task equality is covered too. Also verified in the UI:
Ctrl+N then immediate delete now closes the editor and removes the task
cleanly, no traceback.