### PR TITLE
Fix metainfo for flathub linter

### DIFF
--- a/data/org.gnome.GTG.metainfo.xml.in.in
+++ b/data/org.gnome.GTG.metainfo.xml.in.in
@@ -26,13 +26,16 @@
 
     <screenshots>
         <screenshot type="default">
-            <image type="source">https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/main_window.png</image>
+            <caption>Main window</caption>
+            <image>https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/main_window.png</image>
         </screenshot>
         <screenshot>
-            <image type="source">https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/detail.png</image>
+            <caption>Task details</caption>
+            <image>https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/detail.png</image>
         </screenshot>
         <screenshot>
-            <image type="source">https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/main_with_background.png</image>
+            <caption>Main window with background</caption>
+            <image>https://raw.githubusercontent.com/wiki/getting-things-gnome/gtg/assets/screenshots/0.6/main_with_background.png</image>
         </screenshot>
     </screenshots>
 


### PR DESCRIPTION
Fix for the linter errors when building the flatpak for flathub (https://github.com/flathub/org.gnome.GTG/pull/9)