### PR TITLE
fix: resurrect and wire the 0.6 data migration (#855)

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -496,9 +496,11 @@ class Datastore:
         # We couldn't open any file :(
         if not self.xml_tree:
             try:
-                # Try making a new empty file and open it
-                self.first_run(path)
+                # No data file yet: migrate old-format
+                # data if present, otherwise create the
+                # first-run file (see #855)
                 self.data_path = path
+                self.do_first_run_versioning(path)
 
             except IOError:
                 raise SystemError(f'Could not write a file at {path}')

--- a/GTG/core/versioning.py
+++ b/GTG/core/versioning.py
@@ -37,10 +37,26 @@ tags_cache = {}
 tid_cache = {}
 
 
+def _open_file(path: str, root_tag: str) -> et._ElementTree:
+    """Open an XML file and check its root tag.
+
+    Minimal replacement for the old core's _open_file(), which was
+    removed in e43eee0a together with the rest of the old core. The
+    backup-rotation logic of the original is intentionally not
+    reimplemented: migration sources are existing files, and failing
+    loudly beats silently ignoring user data.
+    """
+    tree = et.parse(path)
+    if tree.getroot().tag != root_tag:
+        raise ValueError(f'{path}: expected root tag {root_tag!r}, '
+                         f'found {tree.getroot().tag!r}')
+    return tree
+
+
 def convert(path: str) -> et._ElementTree:
     """Convert old XML into the new format."""
 
-    old_tree = xml.open_file(path, 'project')
+    old_tree = _open_file(path, 'project')
 
     new_root = et.Element('gtgData')
     # Bump this on each new GTG release, no matter what:
@@ -79,7 +95,7 @@ def convert_tags(old_tree: et._Element) -> Tuple[et._Element, et._Element]:
     """Convert old tags for the new format."""
 
     old_file = os.path.join(DATA_DIR, 'tags.xml')
-    tree = xml.open_file(old_file, 'tagstore')
+    tree = _open_file(old_file, 'tagstore')
 
     taglist = et.Element('taglist')
     searchlist = et.Element('searchlist')

--- a/tests/core/test_versioning_migration.py
+++ b/tests/core/test_versioning_migration.py
@@ -1,0 +1,63 @@
+import os
+from unittest import TestCase
+from tempfile import mkdtemp
+
+from GTG.core import dirs
+from GTG.core import versioning
+from GTG.core.datastore import Datastore
+
+OLD_TASKS = (
+    '<?xml version="1.0" ?>\n'
+    '<project>\n'
+    '<task id="1@1" status="Active" tags="" '
+    'uuid="aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa">\n'
+    '<title>old parent</title>\n'
+    '<modified>2020-01-01T10:00:00</modified>\n'
+    '<content>parent content</content>\n'
+    '<subtask>2@1</subtask>\n'
+    '</task>\n'
+    '<task id="2@1" status="Active" tags="" '
+    'uuid="bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb">\n'
+    '<title>old child</title>\n'
+    '<modified>2020-01-01T10:00:00</modified>\n'
+    '<content>child content</content>\n'
+    '</task>\n'
+    '</project>\n'
+)
+
+OLD_TAGS = '<?xml version="1.0" ?>\n<tagstore>\n</tagstore>\n'
+
+
+class OldFormatMigrationTest(TestCase):
+    """The 0.6 data migration must be reachable and functional
+    (regression tests for #855: converter dead since e43eee0a and
+    never wired into startup)."""
+
+    def setUp(self):
+        self._old_data_dir = dirs.DATA_DIR
+        self.tmp = mkdtemp()
+        dirs.DATA_DIR = self.tmp
+        # versioning imported DATA_DIR by value at module load time
+        versioning.DATA_DIR = self.tmp
+        with open(os.path.join(self.tmp, 'gtg_tasks.xml'), 'w') as f:
+            f.write(OLD_TASKS)
+        with open(os.path.join(self.tmp, 'tags.xml'), 'w') as f:
+            f.write(OLD_TAGS)
+
+    def tearDown(self):
+        dirs.DATA_DIR = self._old_data_dir
+        versioning.DATA_DIR = self._old_data_dir
+
+    def test_convert_parses_old_file(self):
+        tree = versioning.convert(
+            os.path.join(self.tmp, 'gtg_tasks.xml'))
+        self.assertEqual(2, len(tree.findall('.//task')))
+
+    def test_startup_migrates_old_data(self):
+        ds = Datastore()
+        ds.find_and_load_file(os.path.join(self.tmp, 'gtg_data.xml'))
+        titles = {t.title for t in ds.tasks.lookup.values()}
+        self.assertIn('old parent', titles)
+        self.assertIn('old child', titles)
+        self.assertTrue(os.path.exists(
+            os.path.join(self.tmp, 'gtg_tasks.xml.imported')))


### PR DESCRIPTION
## Summary

Fixes #855, and unblocks #109 (the bryce dataset becomes loadable, so
startup performance can finally be measured).

The 0.6 → 0.7 data migration was doubly dead on master:

- `versioning.py` called `xml.open_file()`, but that module was deleted
  in e43eee0a ("Remove old core code", Oct 2022): the converter would
  NameError on its first line if anything reached it.
- Nothing reached it: the file-not-found branch of
  `Datastore.find_and_load_file()` called `first_run()` directly,
  bypassing `do_first_run_versioning()`, which was written for exactly
  this job (find old file, convert, rename to `.imported`, else fall
  back to first run).

Net effect: any 0.6 user upgrading to 0.7 silently got the "Getting
started" tutorial instead of their data (left untouched but ignored
forever, and shadowed by the freshly saved empty file).

## Fix

- A minimal `_open_file()` inside `versioning.py`, modeled on the
  deleted one (strict parse + root tag check). The original's
  backup-rotation logic is intentionally not reimplemented: migration
  sources are existing files, and failing loudly beats silently
  ignoring user data.
- The file-not-found branch now goes through
  `do_first_run_versioning()`.

## Tests and verification

Two regression tests, both red on master: `convert()` NameErrors, and
the startup test's failure message is a portrait of the bug (the nine
tutorial titles where 'old parent' should be).

End-to-end on a real machine with the in-repo bryce dataset
(`./launch.sh -s bryce`): 1771 tasks and 659 subtask links migrated in
under a second, old file renamed to `.imported`, app fully usable. The
~50 `item not found in data` error logs during load are dangling
RELATED references inside that dataset, handled gracefully by
`base_store.parent()` — these are the "parent/child exceptions" this
issue originally reported, now demoted to log noise.

## Noticed in passing (left out of scope)

- `datastore.py:247` logs "Error renaming temp file" on any first save
  into a virgin data dir (pre-existing, also fires on plain first run).
- A cosmetic `Child name 'default' not found in GtkStack` warning at
  startup.