### PR TITLE
fix: keep sidebar tags sorted

### DIFF
--- a/GTG/core/tags.py
+++ b/GTG/core/tags.py
@@ -166,11 +166,24 @@ class TagStore(BaseStore[Tag]):
 
         # open the first one
         if item.children:
-            for child in item.children:
+            for child in sorted(item.children, key=lambda child: child.name.casefold()):
                 model.append(child)
 
         self.tid_to_children_model[item.id] = model
         return Gtk.TreeListModel.new(model, False, False, self.model_expand)
+
+
+    @staticmethod
+    def _insert_sorted(model: Gio.ListStore, item: Tag) -> None:
+        """Insert a tag in alphabetical order without changing its parent."""
+        name = item.name.casefold()
+        for position in range(model.get_n_items()):
+            current = model.get_item(position)
+            if name < current.name.casefold():
+                model.insert(position, item)
+                return
+
+        model.append(item)
 
 
     def __str__(self) -> str:
@@ -353,7 +366,7 @@ class TagStore(BaseStore[Tag]):
         model = self.tid_to_children_model[item.parent.id]
         pos = model.find(item)
         if not pos[0]:
-            model.append(item)
+            self._insert_sorted(model, item)
 
 
     def add(self, item: Tag, parent_id: Optional[UUID] = None) -> None:
@@ -364,7 +377,7 @@ class TagStore(BaseStore[Tag]):
 
         # Update UI
         if not parent_id:
-            self.model.append(item)
+            self._insert_sorted(self.model, item)
         else:
             self._append_to_parent_model(item.id)
 

--- a/tests/core/test_tag_store.py
+++ b/tests/core/test_tag_store.py
@@ -37,6 +37,27 @@ class TestTagStore(TestCase):
         self.assertEqual(len(store.data), 2)
         self.assertEqual(tag2.name, 'a_tag')
 
+    def test_new_keeps_root_tags_sorted(self):
+        store = TagStore()
+        store.new('zulu')
+        store.new('Alpha')
+        store.new('bravo')
+
+        names = [store.model.get_item(i).name for i in range(store.model.get_n_items())]
+        self.assertEqual(names, ['Alpha', 'bravo', 'zulu'])
+
+    def test_new_keeps_child_tags_sorted(self):
+        store = TagStore()
+        parent = store.new('parent')
+        store.model_expand(parent)
+        store.new('zulu', parent.id)
+        store.new('Alpha', parent.id)
+        store.new('bravo', parent.id)
+
+        children = store.tid_to_children_model[parent.id]
+        names = [children.get_item(i).name for i in range(children.get_n_items())]
+        self.assertEqual(names, ['Alpha', 'bravo', 'zulu'])
+
 
     def test_xml_load_simple(self):
         store = TagStore()


### PR DESCRIPTION
## Summary

- keep root tags alphabetically ordered in the GTK4 sidebar model
- keep child tags sorted within their existing parent hierarchy
- add regression coverage for newly created root and nested tags

## Why

Tags currently appear in creation/XML order, which makes the sidebar difficult to scan. This addresses #1251 without changing the serialized tag order or parent relationships.

## Validation

- `python -m compileall -q GTG/core/tags.py tests/core/test_tag_store.py`
- `git diff --check`
- targeted pytest could not run because pytest is not installed in this environment

Fixes #1251