### PR TITLE
fix: use available icon for all tasks

### DIFF
--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -181,7 +181,7 @@ class Sidebar(Gtk.ScrolledWindow):
         button.set_margin_start(6)
         button.set_margin_end(6)
 
-        tags_icon = Gtk.Image.new_from_icon_name('view-list-symbolic')
+        tags_icon = Gtk.Image.new_from_icon_name('tag-symbolic')
         tags_icon.set_margin_end(6)
         btn_box.append(tags_icon)
         btn_box.append(button_label)

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -87,7 +87,7 @@ class Sidebar(Gtk.ScrolledWindow):
         self.general_box = Gtk.ListBox()
         self.general_box.get_style_context().add_class('navigation-sidebar')
 
-        self.all_btn = self.btn_item('emblem-documents-symbolic', _('All Tasks'), 'all')
+        self.all_btn = self.btn_item('view-list-symbolic', _('All Tasks'), 'all')
         self.none_btn = self.btn_item('task-past-due-symbolic', _('Tasks With No Tags'), 'untagged')
 
         self.general_box.append(self.all_btn)


### PR DESCRIPTION
## Summary

- replace the unavailable `emblem-documents-symbolic` icon used by the All Tasks sidebar row
- use the existing `view-list-symbolic` icon already supported by the sidebar

## Why

The current icon renders as broken when GTG is run from GNOME Builder because it is not bundled and is not available in that icon theme. This fixes #1274 with a one-line, theme-compatible change.

## Validation

- `python -m compileall -q GTG/gtk/browser/sidebar.py`
- `git diff --check`

Fixes #1274