### PR TITLE
fix: port the backend infobar to GTK 4 and the new core

### DIFF
--- a/GTG/gtk/browser/backend_infobar.py
+++ b/GTG/gtk/browser/backend_infobar.py
@@ -42,21 +42,19 @@ class BackendInfoBar(Gtk.InfoBar):
     DBUS_MESSAGE = _("Cannot connect to DBus, I've disabled "
                      "the <b>%s</b> synchronization service.")
 
-    def __init__(self, req, browser, app, backend_id):
+    def __init__(self, browser, app, backend_id):
         """
         Constructor, Prepares the infobar.
 
-        @param req: a Requester object
-        @param browser: a MainWindow object
-        @param app: a ViewManager object
+        @param browser: the MainWindow
+        @param app: the Application
         @param backend_id: the id of the backend linked to the infobar
         """
         super().__init__()
-        self.req = req
         self.browser = browser
         self.app = app
         self.backend_id = backend_id
-        self.backend = self.req.get_backend(backend_id)
+        self.backend = app.ds.get_backend(backend_id)
 
     def get_backend_id(self):
         """
@@ -67,14 +65,13 @@ class BackendInfoBar(Gtk.InfoBar):
 
     def _populate(self):
         """Setting up gtk widgets"""
-        content_box = self.get_content_area()
-        content_box.set_homogeneous(False)
         self.label = Gtk.Label()
         self.label.set_hexpand(True)
         self.label.set_wrap(True)
-        self.label.set_alignment(0.5, 0.5)
+        self.label.set_xalign(0.5)
+        self.label.set_yalign(0.5)
         self.label.set_justify(Gtk.Justification.FILL)
-        content_box.append(self.label)
+        self.add_child(self.label)
 
     def _on_error_response(self, widget, event):
         """
@@ -84,7 +81,7 @@ class BackendInfoBar(Gtk.InfoBar):
         @param widget: not used, here for compatibility with signals callbacks
         @param event: the code of the gtk response
         """
-        self.hide()
+        self.set_revealed(False)
         if event == Gtk.ResponseType.ACCEPT:
             self.app.open_edit_backends(backend_id=self.backend_id)
 
@@ -118,7 +115,7 @@ class BackendInfoBar(Gtk.InfoBar):
             self.label.set_markup(self.DBUS_MESSAGE % backend_name)
             self.add_button(_('OK'), Gtk.ResponseType.CLOSE)
 
-        self.show_all()
+        self.set_revealed(True)
 
     def set_interaction_request(self, description, interaction_type, callback):
         """
@@ -142,7 +139,7 @@ class BackendInfoBar(Gtk.InfoBar):
             self.add_button(_('Continue'), Gtk.ResponseType.ACCEPT)
         elif interaction_type == BackendSignals().INTERACTION_INFORM:
             self.add_button(_('OK'), Gtk.ResponseType.ACCEPT)
-        self.show_all()
+        self.set_revealed(True)
 
     def _on_interaction_response(self, widget, event):
         """
@@ -156,51 +153,42 @@ class BackendInfoBar(Gtk.InfoBar):
             if self.interaction_type == BackendSignals().INTERACTION_TEXT:
                 self._prepare_textual_interaction()
             elif self.interaction_type == BackendSignals().INTERACTION_CONFIRM:
-                self.hide()
+                self.set_revealed(False)
                 threading.Thread(target=getattr(self.backend,
                                                 self.callback)).start()
             else:
-                self.hide()
+                self.set_revealed(False)
 
     def _prepare_textual_interaction(self):
         """
         Helper function. gtk calls to populate the infobar in the case of
         interaction request
         """
-        title, description\
+        title, description \
             = getattr(self.backend,
                       self.callback)("get_ui_dialog_text")
-        self.dialog = Gtk.Window()  # type = Gtk.WindowType.POPUP
+        self.dialog = Gtk.Window()
         self.dialog.set_title(title)
-        self.dialog.set_transient_for(self.browser.window)
+        self.dialog.set_transient_for(self.browser)
         self.dialog.set_destroy_with_parent(True)
         self.dialog.set_modal(True)
-        #        self.dialog.set_size_request(300,170)
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        for setter in (vbox.set_margin_top, vbox.set_margin_bottom,
+                       vbox.set_margin_start, vbox.set_margin_end):
+            setter(12)
         self.dialog.set_child(vbox)
         description_label = Gtk.Label()
         description_label.set_justify(Gtk.Justification.FILL)
         description_label.set_wrap(True)
         description_label.set_markup(description)
-        align = Gtk.Alignment.new(0.5, 0.5, 1, 1)
-        align.set_padding(10, 0, 20, 20)
-        align.set_vexpand(True)
-        align.add(description_label)
-        vbox.append(align)
+        vbox.append(description_label)
         self.text_box = Gtk.Entry()
-        self.text_box.set_size_request(-1, 40)
-        align = Gtk.Alignment.new(0.5, 0.5, 1, 1)
-        align.set_vexpand(True)
-        align.set_padding(20, 20, 20, 20)
-        align.add(self.text_box)
-        vbox.append(align)
-        button = Gtk.Button()
-        button.set_label(_("OK"))
+        vbox.append(self.text_box)
+        button = Gtk.Button(label=_("OK"))
         button.connect("clicked", self._on_text_confirmed)
-        button.set_size_request(-1, 40)
         vbox.append(button)
-        self.dialog.show_all()
-        self.hide()
+        self.dialog.present()
+        self.set_revealed(False)
 
     def _on_text_confirmed(self, widget):
         """

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1696,18 +1696,19 @@ class MainWindow(Gtk.ApplicationWindow):
         infobar = self._new_infobar(backend_id)
         infobar.set_interaction_request(description, interaction_type, callback)
 
-    def __remove_backend_infobar(self, child, backend_id):
-        """
-        Helper function to remove an Gtk.Infobar related to a backend
+    def _remove_backend_infobars(self, backend_id):
+        """Remove the infobars related to a backend.
 
-        @param child: a Gtk.Infobar
-        @param backend_id: the id of the backend which Gtk.Infobar should be
-                            removed.
+        GTK 4 removed Gtk.Container.foreach(): walk the siblings,
+        grabbing the next one before a potential removal.
         """
-        if isinstance(child, BackendInfoBar) and\
-                child.get_backend_id() == backend_id:
-            if self.vbox_toolbars:
+        child = self.vbox_toolbars.get_first_child()
+        while child is not None:
+            next_child = child.get_next_sibling()
+            if isinstance(child, BackendInfoBar) and \
+                    child.get_backend_id() == backend_id:
                 self.vbox_toolbars.remove(child)
+            child = next_child
 
     def remove_backend_infobar(self, sender, backend_id):
         """
@@ -1722,7 +1723,7 @@ class MainWindow(Gtk.ApplicationWindow):
         if not backend or (backend and backend.is_enabled()):
             # remove old infobar related to backend_id, if any
             if self.vbox_toolbars:
-                self.vbox_toolbars.foreach(self.__remove_backend_infobar, backend_id)
+                self._remove_backend_infobars(backend_id)
 
     def _new_infobar(self, backend_id):
         """
@@ -1734,11 +1735,11 @@ class MainWindow(Gtk.ApplicationWindow):
         # remove old infobar related to backend_id, if any
         if not self.vbox_toolbars:
             return
-        self.vbox_toolbars.foreach(self.__remove_backend_infobar, backend_id)
+        self._remove_backend_infobars(backend_id)
         # add a new one
-        infobar = BackendInfoBar(self.req, self, self.app, backend_id)
+        infobar = BackendInfoBar(self, self.app, backend_id)
         infobar.set_vexpand(True)
-        self.vbox_toolbars.add(infobar)
+        self.vbox_toolbars.append(infobar)
         return infobar
 
 # SEARCH RELATED STUFF ########################################################

--- a/tests/gtk/test_backend_infobar.py
+++ b/tests/gtk/test_backend_infobar.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest import TestCase, skipUnless
+
+from gi.repository import Gdk, Gtk
+
+from GTG.backends.backend_signals import BackendSignals
+from GTG.gtk.browser.backend_infobar import BackendInfoBar
+
+try:
+    _init_ok = Gtk.init_check()
+except Exception:
+    _init_ok = False
+DISPLAY_OK = bool(_init_ok) and Gdk.Display.get_default() is not None
+
+
+def _fake_app():
+    backend = SimpleNamespace(get_human_name=lambda: 'TestService',
+                              is_enabled=lambda: True)
+    ds = SimpleNamespace(get_backend=lambda backend_id: backend)
+    return SimpleNamespace(ds=ds)
+
+
+@skipUnless(DISPLAY_OK, 'needs a display')
+class BackendInfoBarTest(TestCase):
+    """The backend infobar must build and populate on the new core
+    and GTK 4 (regression tests for #784 / #901: any backend error
+    used to crash before anything was shown)."""
+
+    def test_error_banner_builds(self):
+        bar = BackendInfoBar(None, _fake_app(), 'backend@1')
+        bar.set_error_code(BackendSignals.ERRNO_AUTHENTICATION)
+        self.assertIn('TestService', bar.label.get_label())
+        self.assertEqual(Gtk.MessageType.ERROR, bar.get_message_type())
+
+    def test_interaction_banner_builds(self):
+        bar = BackendInfoBar(None, _fake_app(), 'backend@1')
+        bar.set_interaction_request(
+            'need something', BackendSignals().INTERACTION_INFORM, 'cb')
+        self.assertEqual(Gtk.MessageType.INFO, bar.get_message_type())
+        bar.response(Gtk.ResponseType.ACCEPT)
+        self.assertFalse(bar.get_revealed())


### PR DESCRIPTION
## Summary

Fixes #784, Fixes #901

The backend infobar is GTG's historical way (since the 0.x era) of
telling the user that a synchronization backend failed or needs
attention. It never survived the GTK 4 / new core transition: the
container was restored in 1e93bbde, but the code paths behind it were
still speaking GTK 3 and the old core, so any backend error crashed
before anything was shown, leaving a frozen window and an orphan modal.
I hit this five times while testing #1265 — and it is what currently
blocks re-testing it (see the "blocked by #1241" note there; #1241's
content is already on master, this PR is the follow-up discussed
there).

## What was dead, now ported

- `main_window.py`: two `Gtk.Container.foreach()` calls (removed in
  GTK 4) replaced by a sibling-walking helper; `Box.add()` → `append()`;
  `BackendInfoBar(self.req, ...)` (old-core Requester) → the datastore.
- `backend_infobar.py`: constructor now takes the datastore route
  (`app.ds.get_backend()`); `get_content_area()` (gone in GTK 4) →
  `add_child()`; `Label.set_alignment()` → `set_xalign/set_yalign`;
  `show_all()` → `set_revealed(True)`; `hide()` on responses →
  `set_revealed(False)` (plain hide doesn't collapse a GTK 4 InfoBar);
  the textual-interaction dialog rebuilt without `Gtk.Alignment`
  (removed in GTK 4) and shown with `present()`.

Behavior is deliberately preserved as-is (this is a resurrection, not a
redesign).

## Tests and verification

New `tests/gtk/test_backend_infobar.py`: builds the error banner and
the interaction banner against a fake datastore, and checks that
responding collapses the bar. Red on master (TypeError on the old-core
constructor), green after. The tests skip cleanly when no display is
available, and pass under xvfb.

Verified live with a CalDAV backend armed with a wrong password: the
banner now appears instead of the historical freeze, the window stays
responsive, and OK collapses the banner.

## Honest notes

- `Gtk.InfoBar` is deprecated since GTK 4.10 (the test run shows the
  warnings). GTG doesn't depend on libadwaita, so migrating this to
  `Adw.Banner` (or a small custom revealer) is left as a maintainer
  decision / follow-up, together with possible UX simplifications
  (the CalDAV backend already uses the info-only INTERACTION_INFORM
  path, whose message text embeds a raw `repr()` worth cleaning).
- After this lands, #1241 can be closed and #1265 becomes re-testable.