### PR TITLE
fix: persist backend configuration across restarts (#930, #845)

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -254,3 +254,9 @@ class CoreConfig:
             self._backends_conf[backend],
             DEFAULTS['backend'],
             self.save_backends_config)
+
+    def delete_backend_config(self, backend):
+        """Remove the configuration section of a backend, if any."""
+        if backend in self._backends_conf:
+            self._backends_conf.remove_section(backend)
+            self.save_backends_config()

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -34,6 +34,7 @@ from GTG.core import firstrun_tasks
 from GTG.core.dates import Date
 from GTG.backends.backend_signals import BackendSignals
 from GTG.backends.generic_backend import GenericBackend
+from GTG.core.config import CoreConfig
 import GTG.core.info as info
 import GTG.core.dirs as dirs
 import GTG.core.versioning as versioning
@@ -145,6 +146,9 @@ class Datastore:
         self._mutex = threading.Lock()
         self.backends: Dict[str,GenericBackend] = {}
         self._backend_signals = BackendSignals()
+        self._backend_signals.connect(
+            self._backend_signals.BACKEND_STATE_TOGGLED,
+            self._on_backend_state_toggled_persist)
 
         # When a backup has to be used, this will be filled with
         # info on the backup used
@@ -559,6 +563,45 @@ class Datastore:
             return None
 
 
+    def save_backend_config(self, backend) -> None:
+        """Persist a backend's configuration to backends.conf.
+
+        One section per backend, keyed by its pid, which also fixes the
+        historical collision where sections were keyed by the module
+        name and a second backend of the same type overwrote the first
+        (#845). Passwords go through the keyring, courtesy of
+        cast_param_type_to_string(). A leftover module-named legacy
+        section is dropped so the backend doesn't get loaded twice
+        after an upgrade.
+        """
+        config = CoreConfig()
+        pid = backend.get_parameters()['pid']
+        section = config.get_backend_config(pid)
+        section.set('module', backend.get_name())
+        section.set('pid', pid)
+        specs = type(backend).get_static_parameters()
+        for name, spec in specs.items():
+            param_type = spec[GenericBackend.PARAM_TYPE]
+            section.set(name, backend.cast_param_type_to_string(
+                param_type, backend.get_parameters()[name]))
+        legacy = backend.get_name()
+        if legacy != pid:
+            config.delete_backend_config(legacy)
+
+    def _on_backend_state_toggled_persist(self, sender, backend_id):
+        """Persist a backend once its enabled state has settled.
+
+        This runs on the main loop (BackendSignals marshals its
+        emissions through idle_add), after the quit thread has written
+        the final state; persisting directly from set_backend_enabled()
+        would race it. It also captures parameter edits, since the
+        configuration panel commits them right before toggling the
+        state.
+        """
+        backend = self.backends.get(backend_id)
+        if backend is not None:
+            self.save_backend_config(backend)
+
     def register_backend(self, backend_dic):
         """
         Registers a TaskSource as a backend for this DataStore
@@ -597,6 +640,8 @@ class Datastore:
                 backend.set_parameter(GenericBackend.KEY_ENABLED, True)
             if GenericBackend.KEY_DEFAULT_BACKEND not in backend_dic:
                 backend.set_parameter(GenericBackend.KEY_DEFAULT_BACKEND, True)
+            if first_run:
+                self.save_backend_config(backend)
             # if it's enabled, we initialize it
             if backend.is_enabled():
                 self._backend_startup(backend)
@@ -693,6 +738,8 @@ class Datastore:
             # we notify that the backend has been deleted
             self._backend_signals.backend_removed(backend.get_id())
             del self.backends[backend_id]
+            CoreConfig().delete_backend_config(
+                backend.get_parameters()['pid'])
 
 
     def backend_change_attached_tags(self, backend_id, tag_names):
@@ -705,6 +752,7 @@ class Datastore:
         """
         backend = self.backends[backend_id]
         backend.set_attached_tags(tag_names)
+        self.save_backend_config(backend)
 
 
     def flush_all_tasks(self, backend_id):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,17 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-from GTG import gi_version_requires
+# Isolate the whole test suite from the user's real XDG dirs:
+# some tests build real Datastores, which now persist backend
+# configuration (and would otherwise write into ~/.config/gtg).
+import os
+import tempfile
+
+_xdg_scratch = tempfile.mkdtemp(prefix='gtg-tests-xdg-')
+for _var in ('XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'XDG_CACHE_HOME'):
+    os.environ[_var] = os.path.join(_xdg_scratch, _var[4:].lower())
+
+from GTG import gi_version_requires  # noqa: E402
 
 def pytest_collection(session):
     gi_version_requires()

--- a/tests/core/test_backend_persistence.py
+++ b/tests/core/test_backend_persistence.py
@@ -1,0 +1,72 @@
+from tempfile import mkdtemp
+from unittest import TestCase
+
+from GTG.backends import BackendFactory
+from GTG.backends import generic_backend as gb_module
+from GTG.core import config as config_module
+from GTG.core.config import CoreConfig
+from GTG.core.datastore import Datastore
+
+
+class FakeKeyring:
+    store = {}
+
+    def set_password(self, name, password):
+        FakeKeyring.store[name] = password
+        return name
+
+    def get_password(self, name):
+        return FakeKeyring.store.get(name, '')
+
+
+class BackendPersistenceTest(TestCase):
+    """Backend configuration must survive a restart: written on
+    registration, on parameter/state changes, removed on deletion
+    (regression tests for #930 and #845)."""
+
+    def setUp(self):
+        self._old_config_dir = config_module.CONFIG_DIR
+        self._old_keyring = gb_module.Keyring
+        config_module.CONFIG_DIR = mkdtemp()
+        gb_module.Keyring = FakeKeyring
+        dic = BackendFactory().get_new_backend_dict(
+            'backend_caldav',
+            {'service-url': 'https://example.test/dav/',
+             'username': 'alice', 'password': 'secret'})
+        self.backend = dic['backend']
+        self.pid = dic['pid']
+        self.ds = Datastore()
+        self.ds.register_backend({'backend': self.backend,
+                                  'pid': self.pid,
+                                  'first_run': True,
+                                  'enabled': False})
+
+    def tearDown(self):
+        config_module.CONFIG_DIR = self._old_config_dir
+        gb_module.Keyring = self._old_keyring
+
+    def test_registering_persists_the_backend(self):
+        config = CoreConfig()
+        self.assertEqual([self.pid], config.get_all_backends())
+        section = config.get_backend_config(self.pid)
+        self.assertEqual('backend_caldav', section.get('module'))
+        self.assertEqual('alice', section.get('username'))
+
+    def test_state_toggle_persists_fresh_parameters(self):
+        self.backend.set_parameter('username', 'renamed')
+        self.ds._on_backend_state_toggled_persist(
+            None, self.backend.get_id())
+        section = CoreConfig().get_backend_config(self.pid)
+        self.assertEqual('renamed', section.get('username'))
+
+    def test_removing_deletes_the_section(self):
+        self.ds.remove_backend(self.backend.get_id())
+        self.assertEqual([], CoreConfig().get_all_backends())
+
+    def test_legacy_module_named_section_is_cleaned_up(self):
+        legacy = CoreConfig()
+        legacy.get_backend_config('backend_caldav').set('module',
+                                                        'backend_caldav')
+        self.ds.save_backend_config(self.backend)
+        self.assertNotIn('backend_caldav',
+                         CoreConfig().get_all_backends())


### PR DESCRIPTION
## Summary

Fixes #930, Fixes #845

On the new core, backend configuration was never written back:
`CoreConfig.get_backend_config()` (the only writable handle) had a
single caller, the *reader* at startup. Adding a backend went through
`ds.register_backend()` + `ds.save()` (which only saves task data), so
`backends.conf` stayed empty and every backend vanished on the next
launch. This also subsumes the original 0.6 report (#845): sections
used to be keyed by module name, so a second backend of the same type
overwrote the first.

## Design

The Datastore already owns backend lifecycle, so it now also owns their
persistence. A single documented entry point,
`Datastore.save_backend_config(backend)`, serializes every static
parameter via the existing `cast_param_type_to_string()` (passwords go
to the keyring, as before), one section keyed by **pid** — which fixes
the #845 collision — and drops any leftover module-named legacy section
so a backend isn't loaded twice after upgrading.

It is called at the four mutations the Datastore already handles:

- **registration** — only on a genuinely new backend (`first_run`),
  never when reloading from disk at startup;
- **removal** — the section is deleted;
- **state toggle & parameter edits** — via a `BACKEND_STATE_TOGGLED`
  listener. This is deliberate: disabling spins a quit thread that
  flips the state afterwards, so persisting synchronously would race
  it; the signal is marshalled to the main loop (`idle_add`), so we
  save the settled state. The configuration panel commits parameter
  edits right before toggling, so the same listener captures those too.

The UI layer learns nothing new — it already commits and toggles at one
point.

## Tests

New `tests/core/test_backend_persistence.py` (registration persists,
state toggle persists fresh parameters, removal deletes the section,
legacy section cleanup), all red before / green after, using a fake
keyring so the real one is never touched.

Also, a suite-wide isolation guard in `tests/conftest.py`: since real
Datastores now persist config, the whole suite is pointed at a scratch
XDG dir so tests can never write into a contributor's real
`~/.config/gtg`. Full suite: 190 passed, 7 skipped locally.

## Follow-up (out of scope)

A "parameters changed" signal with a single listener would be the
tidiest long-term shape, but it's more than this fix needs today.