### PR TITLE
fix: never let a plugin failure brick startup, verify declared DBus deps

### DIFF
--- a/GTG/core/plugins/engine.py
+++ b/GTG/core/plugins/engine.py
@@ -192,26 +192,65 @@ class PluginEngine(Borg):
     def remove_api(self, api):
         self.plugin_apis.remove(api)
 
+    def _check_dbus_depends(self, plugin):
+        """Check the DBus services a plugin declared as dependencies.
+
+        The `dbus-dependencies` manifest field was parsed but never
+        verified anywhere, so a plugin talking to an absent service
+        (Hamster, typically) blew up at activation or later instead of
+        being cleanly marked unavailable (#998, #683, #1248).
+        Conservative on purpose: no python-dbus module or no session
+        bus counts as missing.
+        """
+        plugin.missing_dbus = []
+        for dep in plugin.dbus_depends:
+            # the plugins dialog displays these as (name, path) pairs
+            bus_name, _, obj_path = dep.partition(':')
+            try:
+                import dbus
+                owned = dbus.SessionBus().name_has_owner(bus_name)
+            except Exception:
+                owned = False
+            if not owned:
+                plugin.missing_dbus.append((bus_name, obj_path))
+                plugin.error = True
+
     def activate_plugins(self, plugins=[]):
-        """Activate plugins."""
-        assert(isinstance(plugins, list))
+        """Activate plugins, never letting one break startup."""
+        assert isinstance(plugins, list)
         if not plugins:
             plugins = self.get_plugins("inactive")
         for plugin in plugins:
             # activate enabled plugins without errors
             if plugin.enabled and not plugin.error:
+                self._check_dbus_depends(plugin)
+                if plugin.error:
+                    plugin.enabled = False
+                    log.warning(
+                        "Not activating plugin %s, missing DBus "
+                        "service(s): %s", plugin.module_name,
+                        plugin.missing_dbus)
+                    continue
                 # activate the plugin
                 plugin.active = True
-                for api in self.plugin_apis:
-                    if hasattr(plugin.instance, "activate"):
-                        plugin.instance.activate(api)
-                    if api.is_editor():
-                        if hasattr(plugin.instance, "onTaskOpened"):
-                            plugin.instance.onTaskOpened(api)
-                        # also refresh the content of the task
-                        tv = api.get_ui().get_textview()
-                        if tv:
-                            tv.on_modified(None)
+                try:
+                    for api in self.plugin_apis:
+                        if hasattr(plugin.instance, "activate"):
+                            plugin.instance.activate(api)
+                        if api.is_editor():
+                            if hasattr(plugin.instance, "onTaskOpened"):
+                                plugin.instance.onTaskOpened(api)
+                            # also refresh the content of the task
+                            tv = api.get_ui().get_textview()
+                            if tv:
+                                tv.on_modified(None)
+                except Exception:
+                    log.exception(
+                        "Plugin %s failed to activate, disabling it "
+                        "for this session:", plugin.module_name)
+                    plugin.error = True
+                    plugin.active = False
+                    plugin.enabled = False
 
     def deactivate_plugins(self, plugins=[]):
         """Deactivate plugins."""

--- a/tests/core/test_plugin_engine_safety.py
+++ b/tests/core/test_plugin_engine_safety.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest import TestCase
+
+from GTG.core.plugins.engine import PluginEngine
+
+
+class _RaisingInstance:
+    def activate(self, api):
+        raise RuntimeError('boom')
+
+
+class _RecordingInstance:
+    def __init__(self):
+        self.activated = False
+
+    def activate(self, api):
+        self.activated = True
+
+
+def _stub_plugin(instance, dbus_depends=None):
+    return SimpleNamespace(enabled=True, error=False, active=False,
+                           instance=instance, module_name='stub',
+                           dbus_depends=dbus_depends or [],
+                           missing_dbus=[])
+
+
+def _engine():
+    engine = PluginEngine.__new__(PluginEngine)
+    engine.plugin_apis = [SimpleNamespace(is_editor=lambda: False)]
+    return engine
+
+
+class PluginEngineSafetyTest(TestCase):
+    """A broken or unsatisfied plugin must never break startup
+    (regression tests for #998 / #683 / #1248)."""
+
+    def test_raising_plugin_does_not_propagate(self):
+        plugin = _stub_plugin(_RaisingInstance())
+        _engine().activate_plugins([plugin])
+        self.assertTrue(plugin.error)
+        self.assertFalse(plugin.active)
+        self.assertFalse(plugin.enabled)
+
+    def test_missing_dbus_service_blocks_activation(self):
+        instance = _RecordingInstance()
+        plugin = _stub_plugin(
+            instance,
+            dbus_depends=['org.gnome.NoSuchService:/org/gnome/NoSuch'])
+        _engine().activate_plugins([plugin])
+        self.assertTrue(plugin.error)
+        self.assertFalse(instance.activated)
+        self.assertFalse(plugin.enabled)
+        # the plugins dialog unpacks (name, path) pairs: keep that shape
+        self.assertEqual([('org.gnome.NoSuchService', '/org/gnome/NoSuch')],
+                         plugin.missing_dbus)


### PR DESCRIPTION
## Summary

Fixes #998, Fixes #683, Fixes #1248

Enabling the Hamster plugin without the Hamster service present could
make GTG unlaunchable: tracebacks at startup, and since the plugin
stayed enabled in the configuration, every subsequent launch died the
same way. Two mechanisms combined into that brick:

- `activate_plugins()` ran `plugin.instance.activate(api)` with no
  protection whatsoever, at startup (application.py), so any exception
  in any plugin killed the whole application, forever.
- The `dbus-dependencies` manifest field (which Hamster declares) was
  parsed into `Plugin.dbus_depends`... and never checked anywhere. The
  safety net was designed but never woven. Meanwhile
  `dbus.SessionBus().get_object()` can succeed lazily (Flatpak,
  orphaned service files), letting activation complete and the first
  real method call blow up later with ServiceUnknown /
  NameHasNoOwner — the exact errors in these reports.

## Fix (engine-level, protects every plugin, present and future)

- New `PluginEngine._check_dbus_depends()`: before activating, verify
  each declared DBus name with `name_has_owner()`. Missing (or no
  python-dbus, or no session bus — conservative on purpose) means the
  plugin is marked errored and skipped, with a log warning. The plugins
  dialog already knew how to display `missing_dbus` as (name, path)
  pairs; it had just never been fed.
- The activation loop itself is now guarded: a plugin raising during
  `activate()` gets logged (`log.exception`), marked errored and
  deactivated for the session, and GTG keeps starting.
- A refused or crashing plugin is also un-flagged as `enabled`, so the
  dialog tells the truth: the row shows unchecked and insensitive with
  the missing service named, instead of a frozen checked box. A stale
  `enabled` entry left in the configuration just produces one warning
  line at boot.

## Tests and verification

New `tests/core/test_plugin_engine_safety.py`: a raising plugin must
not propagate and must end up disabled, and a plugin with an
unsatisfied DBus dependency must be blocked before activation, with
`missing_dbus` in the exact tuple shape the dialog unpacks. Red on
master, green after.

Verified live on a machine with no Hamster at all: a dataset with the
plugin already enabled in its config — the exact brick scenario — now
boots normally, with one clean warning in the log, and the plugins
dialog shows the row unchecked with "please start
org.gnome.Hamster:/org/gnome/Hamster".

## Noticed in passing (left out of scope)

hamster.py itself still speaks the old core in places:
`on_task_modified` references an undefined `task_id` (NameError on
task completion), `get_id()` / `get_status()` / `STA_*` usages, and an
unguarded `GetTodaysFacts()` call. Happy to send a follow-up PR
porting the plugin internals if there's interest.