### PR TITLE
fix: port the Hamster plugin internals to the new core and GTK 4

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1531,24 +1531,22 @@ class MainWindow(Gtk.ApplicationWindow):
             return None
 
     def get_selected_tasks(self, tree_view: str = ''):
-        """
-        Returns a list of 'uids' of the selected tasks, and the corresponding
-        iters
+        """Return the ids of the selected tasks, if any.
 
-        @param tree_view: The tree view to find the selected task in.
-                          Defaults to the task_tview.
+        @param tree_view: The pane to look in. Defaults to the
+                          currently selected one, falling back to the
+                          first pane with a selection.
         """
-
-        selected = []
         if tree_view:
-            selected = self.panes[tree_view].get_selected_nodes()
+            tasks = self.panes[tree_view].get_selection()
         else:
-            current_pane = self.get_selected_pane()
-            selected = self.panes[current_pane].get_selected_nodes()
-            for i in self.panes:
-                if not selected:
-                    selected = self.panes[i].get_selected_nodes()
-        return selected
+            tasks = self.panes[self.get_selected_pane()].get_selection()
+            if not tasks:
+                for pane in self.panes.values():
+                    tasks = pane.get_selection()
+                    if tasks:
+                        break
+        return [task.id for task in tasks]
 
     # If nospecial=True, only normal @tag are considered
     def get_selected_tags(self, nospecial=False):

--- a/GTG/plugins/hamster/hamster.py
+++ b/GTG/plugins/hamster/hamster.py
@@ -26,7 +26,7 @@ from gettext import gettext as _
 import dbus
 from gi.repository import Gtk, Gio
 
-from GTG.core.tasks import Task
+from GTG.core.tasks import Status
 from GTG.plugins.hamster.helper import FactBuilder
 
 log = logging.getLogger(__name__)
@@ -61,8 +61,7 @@ class HamsterPlugin():
         self.button = Gtk.Button()
         self.task_menu_items = {}
 
-        self.tree = None
-        self.liblarch_callbacks = []
+        self._task_handlers = []
         self.tracked_task_id = None
 
     # Interaction with Hamster ###
@@ -77,7 +76,7 @@ class HamsterPlugin():
         ids = self.get_hamster_ids(task)
         ids.append(str(hamster_id))
         self.set_hamster_ids(task, ids)
-        self.tracked_task_id = task.get_id()
+        self.tracked_task_id = task.id
 
     def get_records(self, task):
         """Get a list of hamster facts for a task"""
@@ -101,7 +100,11 @@ class HamsterPlugin():
 
     def get_active_id(self):
         """ returns active hamster task id, or None if hamster don't have active task """
-        todays_facts = self.hamster.GetTodaysFacts()
+        try:
+            todays_facts = self.hamster.GetTodaysFacts()
+        except dbus.DBusException:
+            log.error("Hamster service vanished while querying facts")
+            return None
         ID_INDEX = 0
         END_TIME_INDEX = 2
         if todays_facts and todays_facts[-1][END_TIME_INDEX] == 0:
@@ -143,8 +146,8 @@ class HamsterPlugin():
 
     def on_task_modified(self, store, task):
         """ Stop task if it is tracked and it is Done/Dismissed """
-        if task.get_status() in (Task.STA_DISMISSED, Task.STA_DONE):
-            self.stop_task(task_id)
+        if task.status in (Status.DISMISSED, Status.DONE):
+            self.stop_task(task.id)
 
     # Plugin api methods ###
     def activate(self, plugin_api):
@@ -168,30 +171,20 @@ class HamsterPlugin():
             header_bar.pack_end(self.button)
             plugin_api.set_active_selection_changed_callback(self.selection_changed)
 
-        # self.subscribe_task_updates([
-        #     ("node-modified-inview", self.on_task_modified),
-        #     ("node-deleted-inview", self.on_task_deleted),
-        # ])
-
-        plugin_api.ds.tasks.connect('task-filterably-changed', self.on_task_modified)
-        plugin_api.ds.tasks.connect('removed', self.on_task_deleted)
+        self._task_handlers = [
+            plugin_api.ds.tasks.connect('task-filterably-changed',
+                                        self.on_task_modified),
+            plugin_api.ds.tasks.connect('removed', self.on_task_deleted),
+        ]
 
         # set up preferences
         self.preference_dialog_init()
         self.preferences_load()
 
-    def subscribe_task_updates(self, signal_callbacks):
-        """ Subscribe to updates about tasks """
-        self.tree = self.plugin_api.get_requester().get_tasks_tree()
-        self.liblarch_callbacks = []
-        for event, callback in signal_callbacks:
-            callback_id = self.tree.register_cllbck(event, callback)
-            self.liblarch_callbacks.append((callback_id, event))
-
     def onTaskOpened(self, plugin_api):
         task = plugin_api.get_ui().get_task()
 
-        if task.get_status() != Task.STA_ACTIVE:
+        if task.status != Status.ACTIVE:
             return
 
         group = Gio.SimpleActionGroup()
@@ -201,17 +194,11 @@ class HamsterPlugin():
         plugin_api.get_ui().insert_action_group(self.EDIT_ACTIVITY_ACTION_PREF, group)
 
         task_menu_item = Gio.MenuItem.new(
-            (self.STOP_ACTIVITY_LABEL if self.is_task_active(task.get_id())
+            (self.STOP_ACTIVITY_LABEL if self.is_task_active(task.id)
              else self.START_ACTIVITY_LABEL),
             self.EDIT_ACTIVITY_ACTION_FULL
         )
-        self.task_menu_items.update({task.get_id(): task_menu_item})
-        if self.is_task_active(task.get_id()):
-            task_menu_item.props.text = self.STOP_ACTIVITY_LABEL
-        else:
-            task_menu_item.props.text = self.START_ACTIVITY_LABEL
-        task_menu_item.show_all()
-        task_menu_item.connect('clicked', self.task_cb, plugin_api)
+        self.task_menu_items[task.id] = task_menu_item
         plugin_api.add_menu_item(task_menu_item)
 
         records = self.get_records(task)
@@ -220,8 +207,8 @@ class HamsterPlugin():
     def onTaskClosed(self, plugin_api):
         task = plugin_api.get_ui().get_task()
         plugin_api.get_ui().insert_action_group(self.EDIT_ACTIVITY_ACTION_PREF, None)
-        if task.get_id() in self.task_menu_items:
-            del self.task_menu_items[task.get_id()]
+        if task.id in self.task_menu_items:
+            del self.task_menu_items[task.id]
         self.check_task_selected()
 
     def render_record_list(self, records, plugin_api):
@@ -233,11 +220,9 @@ class HamsterPlugin():
             inner_grid = Gtk.Grid()
             if len(records) > 4:
                 inner_container = Gtk.ScrolledWindow()
-                inner_container.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-                viewport = Gtk.Viewport()
-                viewport.add(inner_grid)
-                inner_container.add(viewport)
-                viewport.set_shadow_type(Gtk.ShadowType.NONE)
+                inner_container.set_policy(Gtk.PolicyType.NEVER,
+                                           Gtk.PolicyType.AUTOMATIC)
+                inner_container.set_child(inner_grid)
                 inner_container.set_size_request(-1, 80)
             else:
                 inner_container = inner_grid
@@ -301,36 +286,38 @@ class HamsterPlugin():
             header_bar = plugin_api.get_header()
             header_bar.remove(self.button)
         else:
-            for _, menu_button in self.task_menu_items.items():
-                plugin_api.remove_menu_item(menu_button)
-            plugin_api.remove_widget_from_taskeditor(self.vbox_id)
+            for menu_item in self.task_menu_items.values():
+                plugin_api.remove_menu_item(menu_item)
+            if self.vbox_id is not None:
+                plugin_api.remove_widget_from_taskeditor(self.vbox_id)
 
-        # Deactivate LibLarch callbacks
-        for callback_id, event in self.liblarch_callbacks:
-            self.tree.deregister_cllbck(event, callback_id)
-        self.liblarch_callbacks = []
+        for handler_id in self._task_handlers:
+            plugin_api.ds.tasks.disconnect(handler_id)
+        self._task_handlers = []
 
     def browser_cb(self, widget, plugin_api):
-        task_id = plugin_api.browser.get_pane().get_selection()[0]
-        task = plugin_api.ds.tasks.lookup[task_id]
-        self.decide_start_or_stop_activity(task, widget)
+        selected = plugin_api.get_selected()
+        if not selected:
+            return
+        task = plugin_api.ds.tasks.lookup[selected[0]]
+        self.decide_start_or_stop_activity(task, plugin_api)
 
     def task_cb(self, action, gparam, plugin_api):
         task = plugin_api.get_ui().get_task()
         self.decide_start_or_stop_activity(task, plugin_api)
 
     def decide_start_or_stop_activity(self, task, plugin_api):
-        if self.is_task_active(task.get_id()):
+        if self.is_task_active(task.id):
             self.change_button_to_start_activity(self.button)
-            self.change_task_menu_to_start_activity(task.get_id(), plugin_api)
-            self.stop_task(task.get_id())
-        elif task.get_status() == Task.STA_ACTIVE:
+            self.change_task_menu_to_start_activity(task.id, plugin_api)
+            self.stop_task(task.id)
+        elif task.status == Status.ACTIVE:
             self.change_button_to_stop_activity(self.button)
-            self.change_task_menu_to_stop_activity(task.get_id(), plugin_api)
+            self.change_task_menu_to_stop_activity(task.id, plugin_api)
             self.send_task(task)
 
     def selection_changed(self, selection):
-        if selection.count_selected_rows() == 1:
+        if len(selection) == 1:
             self.button.set_sensitive(True)
             self.check_task_selected()
         else:
@@ -338,14 +325,14 @@ class HamsterPlugin():
             self.button.set_sensitive(False)
 
     def check_task_selected(self):
-        task_id = self.plugin_api.get_browser().get_selected_task()
-        if not task_id:
+        selected = self.plugin_api.get_selected()
+        if not selected:
             return
-        task = self.plugin_api.ds.tasks.lookup[task_id]
+        task = self.plugin_api.ds.tasks.lookup[selected[0]]
         self.decide_button_mode(self.button, task)
 
     def decide_button_mode(self, button, task):
-        if self.is_task_active(task.get_id()):
+        if self.is_task_active(task.id):
             self.change_button_to_stop_activity(button)
         else:
             self.change_button_to_start_activity(button)
@@ -359,8 +346,12 @@ class HamsterPlugin():
         button.set_icon_name('process-stop-symbolic')
 
     def change_task_menu_to_start_activity(self, task_id, plugin_api):
+        # relabelling only makes sense on an open editor's menu:
+        # the browser api would (silently) edit its own burger menu
+        if not plugin_api.is_editor():
+            return
         if task_id in self.task_menu_items:
-            plugin_api.remove_menu_item(self.task_menu_items[task_id][0])
+            plugin_api.remove_menu_item(self.task_menu_items[task_id])
             replacement_item = Gio.MenuItem.new(
                 self.START_ACTIVITY_LABEL, self.EDIT_ACTIVITY_ACTION_FULL
             )
@@ -368,8 +359,12 @@ class HamsterPlugin():
             plugin_api.add_menu_item(replacement_item)
 
     def change_task_menu_to_stop_activity(self, task_id, plugin_api):
+        # relabelling only makes sense on an open editor's menu:
+        # the browser api would (silently) edit its own burger menu
+        if not plugin_api.is_editor():
+            return
         if task_id in self.task_menu_items:
-            plugin_api.remove_menu_item(self.task_menu_items[task_id][0])
+            plugin_api.remove_menu_item(self.task_menu_items[task_id])
             replacement_item = Gio.MenuItem.new(
                 self.STOP_ACTIVITY_LABEL, self.EDIT_ACTIVITY_ACTION_FULL
             )

--- a/GTG/plugins/hamster/helper.py
+++ b/GTG/plugins/hamster/helper.py
@@ -31,14 +31,14 @@ class FactBuilder():
             if len(activity_candidates) >= 1:
                 activity = list(activity_candidates)[0]
         elif self.preferences['activity'] == 'title':
-            activity = task.get_title()
+            activity = task.title
         # hamster can't handle ',' or '@' in activity name
         activity = activity.replace(',', '')
         activity = re.sub(' +@.*', '', activity)
         return activity
 
     def _build_category(self, task):
-        gtg_title = task.get_title()
+        gtg_title = task.title
         gtg_tags = self._get_gtg_tags(task)
 
         category = ""
@@ -67,10 +67,9 @@ class FactBuilder():
     def _build_description(self, task):
         description = ""
         if self.preferences['description'] == 'title':
-            description = task.get_title()
+            description = task.title
         elif self.preferences['description'] == 'contents':
-            description = task.get_excerpt(strip_tags=True,
-                                           strip_subtasks=True)
+            description = task.excerpt
         return description
 
     def _build_tags(self, task):
@@ -91,5 +90,6 @@ class FactBuilder():
     @staticmethod
     def _get_gtg_tags(task):
         return [
-            tag_name.lstrip('@').lower() for tag_name in task.get_tags_name()
+            tag.name.lstrip('@').lower() for tag in sorted(
+                task.tags, key=lambda t: t.name)
         ]

--- a/tests/plugins/test_hamster_plugin.py
+++ b/tests/plugins/test_hamster_plugin.py
@@ -2,11 +2,15 @@ from types import SimpleNamespace
 from unittest import TestCase
 from uuid import uuid4
 
-import dbus
+import pytest
 
-from GTG.core.tasks import Status, Task
-from GTG.plugins.hamster.hamster import HamsterPlugin
-from GTG.plugins.hamster.helper import FactBuilder
+# python-dbus is an optional dependency (the Hamster plugin's): skip
+# this whole module where it isn't installed, e.g. on the CI runner
+dbus = pytest.importorskip('dbus')
+
+from GTG.core.tasks import Status, Task  # noqa: E402
+from GTG.plugins.hamster.hamster import HamsterPlugin  # noqa: E402
+from GTG.plugins.hamster.helper import FactBuilder  # noqa: E402
 
 
 class HamsterPluginTest(TestCase):

--- a/tests/plugins/test_hamster_plugin.py
+++ b/tests/plugins/test_hamster_plugin.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from uuid import uuid4
+
+import dbus
+
+from GTG.core.tasks import Status, Task
+from GTG.plugins.hamster.hamster import HamsterPlugin
+from GTG.plugins.hamster.helper import FactBuilder
+
+
+class HamsterPluginTest(TestCase):
+    """The Hamster plugin must speak the new core and survive a
+    vanishing service (follow-up to #1286, see #998)."""
+
+    def _task(self, title='Inspect the hive'):
+        task = Task(id=uuid4(), title=title)
+        return task
+
+    def test_factbuilder_speaks_the_new_core(self):
+        fake_hamster = SimpleNamespace(GetTags=lambda only_visible: [])
+        builder = FactBuilder(
+            fake_hamster, dict(HamsterPlugin.DEFAULT_PREFERENCES))
+        fact = builder.build(self._task())
+        self.assertIn('Inspect the hive', fact)
+
+    def test_completing_a_task_does_not_nameerror(self):
+        plugin = HamsterPlugin()
+        task = self._task()
+        task.status = Status.DONE
+        plugin.on_task_modified(None, task)
+
+    def test_get_active_id_survives_a_dead_service(self):
+        plugin = HamsterPlugin()
+
+        def boom():
+            raise dbus.DBusException('gone')
+        plugin.hamster = SimpleNamespace(GetTodaysFacts=boom)
+        self.assertIsNone(plugin.get_active_id())


### PR DESCRIPTION
## Summary

Follow-up to #1286, delivering the "noticed in passing" list there:
with the engine now refusing to activate Hamster when the service is
absent, this makes the plugin actually work when the service *is*
there. First full GTG↔Hamster loop verified on the new core.

## What was broken

The plugin still spoke the old core and GTK 3 throughout:

- `on_task_modified` referenced an undefined `task_id` (NameError the
  moment any task was completed), plus `get_id()` / `get_status()` /
  `STA_*` everywhere; helper.py used `get_title()`, `get_excerpt()`,
  `get_tags_name()`.
- The editor menu block built a `Gio.MenuItem` and then treated it
  like an old Gtk widget (`props.text`, `show_all()`,
  `connect('clicked')`); the change-label helpers indexed the stored
  item as a tuple (`[0]` TypeError).
- The headerbar button handler passed the clicked widget where the
  plugin api was expected (pre-existing), so toggling from the browser
  crashed as soon as the task's editor had been opened once. The
  relabel helpers also now only touch an editor's menu — called with
  the browser api they would silently append items to the burger menu.
- The records table used `Gtk.Viewport.add()` / `ShadowType`, both
  gone in GTK 4.
- `GetTodaysFacts()` was unguarded (the exact ServiceUnknown /
  NameHasNoOwner emitter from #998); `deactivate()` could pass a None
  widget id and never disconnected its datastore handlers; dead
  liblarch subscription code lingered.
- The selection callback still expected a `GtkTreeSelection`
  (`count_selected_rows()`).

## Bonus core fix

The plugin turned out to be the first real caller of
`PluginAPI.get_selected()` on the new core, and it was broken:
`MainWindow.get_selected_tasks()` still called the old tree's
`get_selected_nodes()`, which no longer exists. It now honors its
documented contract (a list of task ids) through the new pane's
`get_selection()`. Neighboring old-tree calls remain on the tag side
(~1446/1562/1748) — left for a follow-up.

## Tests and verification

New `tests/plugins/test_hamster_plugin.py`: FactBuilder builds a fact
from a real new-core Task, completing a task no longer NameErrors, and
`get_active_id()` survives a vanishing service. Red on master, green
after.

Verified live against hamster-time-tracker 3.0.3: headerbar button
enables on selection, starting from GTG creates the running activity
in Hamster, the records table renders in the task editor, toggling
works on a task whose editor was previously opened, and completing the
task stops the tracking automatically (with the historical one-minute
buffer). No tracebacks.

## Noticed in passing (left out of scope)

- The fact string sends empty fields as bare commas when description
  or tags are empty (cosmetic in Hamster's UI).
- The old-tree calls on the tag side of main_window, listed above.