### PR TITLE
build: move the development Flatpak to the GNOME 50 runtime (#939)

### DIFF
--- a/.github/workflows/weekly_flatpak.yml
+++ b/.github/workflows/weekly_flatpak.yml
@@ -12,7 +12,7 @@ jobs:
     # again
     runs-on: ubuntu-24.04
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
     - uses: actions/checkout@v4

--- a/build-aux/org.gnome.GTG.Devel.json
+++ b/build-aux/org.gnome.GTG.Devel.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTG.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "48",
+  "runtime-version": "50",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "tags": ["devel", "development", "nightly"],

--- a/build-aux/python3-requirements.yaml
+++ b/build-aux/python3-requirements.yaml
@@ -47,6 +47,9 @@ modules:
         url: https://files.pythonhosted.org/packages/bb/1b/f4b3c2d105cc51bab1f441930b0c15b4d56b79096997887686ea18b564da/recurring_ical_events-3.4.1-py3-none-any.whl
         sha256: 971bc3be38c03f208e6ad8956adda45227ce8122b63da9457c3a1cf125a56204
       - type: file
+        url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+        sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+      - type: file
         url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
         sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
       - type: file


### PR DESCRIPTION
Refs #939.

The development manifest targeted GNOME 48, which reached end of life
on 24 March 2026 — flatpak now prints the EOL warning when installing
the nightly. Flathub currently offers 49 and 50.

Moving to 50 needs exactly one extra thing: `six`. The Python modules
are installed offline (`--no-index --find-links`), and `six` is a
dependency of `python-dateutil` that used to come from the runtime;
under 50 (Python 3.13) it doesn't, so `python3-caldav` fails to build.
Adding the wheel is the whole fix.

Built and ran locally against runtime 50: the app starts, icons are
fine, and the CalDAV backend syncs against a live Nextcloud. Details
and the wider runtime picture are in #939.

Not touched here, but worth knowing: `.github/workflows/weekly_flatpak.yml`
still uses the `gnome-46` builder image while the manifest asks for a
different runtime. It seems to work (flatpak-builder pulls what the
manifest declares), so I left it alone rather than guess — happy to
follow up if you'd rather align it.