### PR TITLE
fix: save the parameters a backend has, not the ones it declares

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -255,6 +255,16 @@ class CoreConfig:
             DEFAULTS['backend'],
             self.save_backends_config)
 
+    def get_backend_raw_items(self, backend):
+        """Key/value pairs of a backend section, exactly as stored.
+
+        No typing, no defaults, no interpretation: this is for moving a
+        section without needing to understand it.
+        """
+        if backend not in self._backends_conf:
+            return []
+        return list(self._backends_conf[backend].items())
+
     def delete_backend_config(self, backend):
         """Remove the configuration section of a backend, if any."""
         if backend in self._backends_conf:

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -575,16 +575,32 @@ class Datastore:
         after an upgrade.
         """
         config = CoreConfig()
-        pid = backend.get_parameters()['pid']
-        section = config.get_backend_config(pid)
-        section.set('module', backend.get_name())
-        section.set('pid', pid)
-        specs = type(backend).get_static_parameters()
-        for name, spec in specs.items():
-            param_type = spec[GenericBackend.PARAM_TYPE]
-            section.set(name, backend.cast_param_type_to_string(
-                param_type, backend.get_parameters()[name]))
+        params = backend.get_parameters()
+        pid = params['pid']
         legacy = backend.get_name()
+        section = config.get_backend_config(pid)
+
+        # 1. Move the old section over verbatim. We carry values we
+        # can't read -- a password reference is useless to us if the
+        # keyring is down, but it's the user's, and dropping it would
+        # lose it for good.
+        if legacy != pid:
+            for key, value in config.get_backend_raw_items(legacy):
+                section.set(key, value)
+
+        # 2. Then write what the backend actually holds. Not what it
+        # declares: get_saved_backends_list() drops any parameter it
+        # can't read, so a declared parameter isn't guaranteed to be
+        # there. Whatever we don't write keeps the value moved above.
+        section.set('module', legacy)
+        for name, value in params.items():
+            if name == 'backend':
+                continue  # the live object; rebuilt at startup
+            param_type = backend.get_parameter_type(name)
+            section.set(str(name), backend.cast_param_type_to_string(
+                param_type, value))
+
+        # 3. Only now drop the old section.
         if legacy != pid:
             config.delete_backend_config(legacy)
 

--- a/tests/core/test_backend_persistence.py
+++ b/tests/core/test_backend_persistence.py
@@ -63,6 +63,51 @@ class BackendPersistenceTest(TestCase):
         self.ds.remove_backend(self.backend.get_id())
         self.assertEqual([], CoreConfig().get_all_backends())
 
+    def test_saving_a_parameter_the_backend_lacks(self):
+        """A config written before a parameter was added to a backend
+        simply lacks it -- which is every config out there, the day a
+        parameter is added (default-calendar, Feb 2026).
+        get_saved_backends_list() drops what it can't read, and the
+        rest of the code copes: the parameter panels check before
+        reading, the caldav backend falls back on its own default.
+        Saving must cope too, rather than demand a value nobody has.
+        """
+        config = CoreConfig()
+        section = config.get_backend_config(self.pid)
+        del section._section['default-calendar']
+        config.save_backends_config()
+
+        loaded = [b for b in BackendFactory().get_saved_backends_list()
+                  if b['pid'] == self.pid]
+        self.assertEqual(1, len(loaded))
+        backend = loaded[0]['backend']
+        self.assertNotIn('default-calendar', backend.get_parameters())
+
+        self.ds.save_backend_config(backend)  # used to raise KeyError
+
+        self.assertEqual('alice',
+                         CoreConfig().get_backend_config(self.pid)
+                         .get('username'))
+
+    def test_migration_carries_over_what_it_cannot_read(self):
+        """Moving a section to its pid must carry values we can't
+        produce ourselves. A password reference is useless to us when
+        the keyring is down, but it's the user's: dropping it would
+        lose it for good."""
+        config = CoreConfig()
+        legacy = config.get_backend_config('backend_caldav')
+        legacy.set('module', 'backend_caldav')
+        legacy.set('pid', self.pid)
+        legacy.set('a-value-we-cannot-read', 'must survive')
+        config.save_backends_config()
+
+        self.ds.save_backend_config(self.backend)
+
+        moved = CoreConfig().get_backend_config(self.pid)
+        self.assertEqual('must survive',
+                         moved.get('a-value-we-cannot-read'))
+        self.assertNotIn('backend_caldav', CoreConfig().get_all_backends())
+
     def test_legacy_module_named_section_is_cleaned_up(self):
         legacy = CoreConfig()
         legacy.get_backend_config('backend_caldav').set('module',


### PR DESCRIPTION
Fixing my own #1285.

It saves the parameters a backend **declares**, while
`get_saved_backends_list()` only provides the ones it managed to
**read** — it deliberately drops the rest (`# Parameter not found in
config`, there since 2020). The rest of the code copes with that: the
parameter panels check `if parameter_name in backend_parameters`
before reading, and the caldav backend falls back on its own default
(`.get('default-calendar', 'gtg')`). My function is the only place
that demands otherwise.

**The trigger is mundane**: the day a parameter is added to a backend,
every config already written lacks it. That happened in February with
`default-calendar`. The caldav backend has shipped since 0.6, so those
configs are real, and nothing had rewritten them in between — which
was precisely the bug #1285 fixed.

**The damage isn't the crash.** `SectionConfig.set()` writes to disk
on every call. So the `KeyError` lands after eleven writes and
**before** the line that drops the legacy section. The config ends up
with two sections for the same backend, and the next startup **loads
that backend twice**.

**The fix separates the three things the function was conflating.**

1. *Migrate first*: carry the old section over verbatim, without
   interpreting it. A keyring reference is useless to us when the
   keyring is down, but it belongs to the user and dropping it would
   lose it for good.
2. *Then persist*: write what the backend actually holds — which is
   how 0.6 did it (`for key, value in b.get_parameters().items()`)
   before that code was removed in 2022. Anything we don't write keeps
   the value carried over above.
3. *Clean up last*.

Checked against: a pre-February config, an unavailable keyring, two
backends of the same type (#845 still holds, no bleed between them),
and a config already duplicated by the current code — that one gets
repaired on the way through.

228 tests passing.