### PR TITLE
Add a manual "Synchronize now" button for remote backends (#929)

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -709,6 +709,34 @@ class Datastore:
         thread.start()
 
 
+    def sync_now(self, backend_id=None):
+        """
+        Trigger an immediate synchronization cycle on remote backends,
+        without waiting for the next periodic import.
+
+        @param backend_id: if given, only that backend is synced.
+        """
+
+        for backend in self.backends.values():
+            if backend_id and backend.get_id() != backend_id:
+                continue
+            if not backend.is_enabled():
+                continue
+            # Only remote (periodic import) backends can be forced.
+            # The local file backend syncs continuously and is skipped.
+            if not hasattr(backend, 'do_periodic_import'):
+                continue
+
+            def __sync_now(self, backend):
+                backend.start_get_tasks()
+                self.flush_all_tasks(backend.get_id())
+
+            thread = threading.Thread(target=__sync_now,
+                                      args=(self, backend))
+            thread.setDaemon(True)
+            thread.start()
+
+
     def set_backend_enabled(self, backend_id, state):
         """
         The backend corresponding to backend_id is enabled or disabled

--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -313,6 +313,7 @@ class Application(Gtk.Application):
             ('dismiss', self.dismiss, ('app.dismiss', ['<ctrl><shift>D'])),
             ('reopen', self.reopen, ('app.reopen', ['<ctrl>O'])),
             ('open_backends', self.open_backends_manager, None),
+            ('sync_now', self.sync_now, ('app.sync_now', ['F5'])),
             ('open_help', self.open_help, ('app.open_help', ['F1'])),
             ('open_preferences', self.open_preferences, ('app.open_preferences', ['<ctrl>comma'])),
             ('close', self.close_context, ('app.close', ['Escape'])),
@@ -413,6 +414,11 @@ class Application(Gtk.Application):
         """Callback to open the backends manager dialog."""
 
         self.open_edit_backends()
+
+    def sync_now(self, action=None, param=None):
+        """Callback to trigger an immediate backend synchronization."""
+
+        self.ds.sync_now()
 
     def open_preferences(self, action, param):
         """Callback to open the preferences dialog."""

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -179,7 +179,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.sync_button = Gtk.Button()
         self.sync_button.set_valign(Gtk.Align.CENTER)
         self.sync_button.set_action_name('app.sync_now')
-        self.sync_button.set_icon_name('emblem-synchronizing-symbolic')
+        self.sync_button.set_icon_name('view-refresh-symbolic')
         self.sync_button.set_tooltip_text(_('Synchronize now (F5)'))
         self.sync_button.set_visible(False)
         self.headerbar.pack_end(self.sync_button)
@@ -223,7 +223,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.sync_button.set_tooltip_text(_('Synchronizing…'))
         else:
             self._sync_spinner.stop()
-            self.sync_button.set_icon_name('emblem-synchronizing-symbolic')
+            self.sync_button.set_icon_name('view-refresh-symbolic')
             self.sync_button.set_tooltip_text(_('Synchronize now (F5)'))
 
     def _init_context_menus(self):

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -162,7 +162,70 @@ class MainWindow(Gtk.ApplicationWindow):
         # so the buttons start disabled
         self.on_selection_changed()
 
+        self._init_sync_indicator()
+
 # INIT HELPER FUNCTIONS #######################################################
+    def _init_sync_indicator(self):
+        """Add a "Synchronize now" button to the headerbar.
+
+        The button doubles as a sync activity indicator: while any
+        remote backend is syncing, it shows a spinner and is disabled.
+        It is only visible when a remote (periodic import) backend
+        is enabled.
+        """
+
+        self._syncing_backends = set()
+        self._sync_spinner = Gtk.Spinner()
+        self.sync_button = Gtk.Button()
+        self.sync_button.set_valign(Gtk.Align.CENTER)
+        self.sync_button.set_action_name('app.sync_now')
+        self.sync_button.set_icon_name('emblem-synchronizing-symbolic')
+        self.sync_button.set_tooltip_text(_('Synchronize now (F5)'))
+        self.sync_button.set_visible(False)
+        self.headerbar.pack_end(self.sync_button)
+
+        signals = BackendSignals()
+        signals.connect('backend-sync-started', self._on_backend_sync_started)
+        signals.connect('backend-sync-ended', self._on_backend_sync_ended)
+        signals.connect('backend-state-toggled', self._refresh_sync_button)
+        signals.connect('backend-added', self._refresh_sync_button)
+        signals.connect('default-backend-loaded', self._refresh_sync_button)
+        self._refresh_sync_button()
+
+    def _refresh_sync_button(self, *args):
+        """Show the sync button only if a remote backend is enabled."""
+
+        has_remote = any(hasattr(b, 'do_periodic_import')
+                         for b in self.app.ds.get_all_backends())
+        self.sync_button.set_visible(has_remote)
+
+    def _on_backend_sync_started(self, sender, backend_id):
+        """A backend sync cycle started: show activity."""
+
+        self._syncing_backends.add(backend_id)
+        self._update_sync_indicator()
+
+    def _on_backend_sync_ended(self, sender, backend_id):
+        """A backend sync cycle ended: back to idle when none left."""
+
+        self._syncing_backends.discard(backend_id)
+        self._update_sync_indicator()
+
+    def _update_sync_indicator(self):
+        """Reflect the current sync activity on the headerbar button."""
+
+        syncing = bool(self._syncing_backends)
+        self.sync_button.set_sensitive(not syncing)
+
+        if syncing:
+            self.sync_button.set_child(self._sync_spinner)
+            self._sync_spinner.start()
+            self.sync_button.set_tooltip_text(_('Synchronizing…'))
+        else:
+            self._sync_spinner.stop()
+            self.sync_button.set_icon_name('emblem-synchronizing-symbolic')
+            self.sync_button.set_tooltip_text(_('Synchronize now (F5)'))
+
     def _init_context_menus(self):
         builder = Gtk.Builder()
         builder.add_from_file(GnomeConfig.MENUS_UI_FILE)


### PR DESCRIPTION
## What this does

Adds a "Synchronize now" button to the main window headerbar, visible only when a remote backend is enabled. Clicking it (or pressing F5) triggers an immediate synchronization cycle instead of waiting for the next periodic import. While any sync runs, the button turns into a spinner and is disabled, so it also acts as a sync activity indicator.

## History of the request

@cpitclaudel opened #929 in 2022: the CalDAV service only syncs periodically, and there was no way to trigger it on demand. @MagicFab later widened the point: as a new user he had no feedback at all that sync was happening, and pointed to Joplin's always-visible sync button as the model. @jaesivsm gave the implementation direction: don't touch the plug itself, have the button talk to the mechanism that oversees sync runs. This PR follows that direction.

## Implementation notes

Everything reuses existing machinery: `PeriodicImportBackend.start_get_tasks()` already cancels the pending timer, runs an import and reschedules (with reentrance coalesced by its urgent-iteration logic), `flush_all_tasks()` pushes local changes, and the `backend-sync-started`/`backend-sync-ended` signals were already emitted on every cycle but never consumed by the UI. The new `Datastore.sync_now()` mirrors the existing backend startup convention. ~100 insertions, no deletions, no new dependencies.

## Testing

Manually tested against a Nextcloud CalDAV server: immediate pull of server-side changes, spinner on manual and periodic cycles, button hidden when no remote backend is enabled. Note: functional testing was done with #1265 applied, since the CalDAV backend on current master crashes during import (the very issue #1265 fixes). The patch itself applies cleanly on master and is backend-agnostic.

## Open question for review

There is deliberately no menu entry, to keep the main menu lean; the shortcut is discoverable via the button tooltip. Happy to add a "Synchronize Now" item next to "Synchronization" if you prefer it there too.