### PR TITLE
fix: remember collapsed tasks again on the new task pane

### DIFF
--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import ast
 import re
 from uuid import UUID
 from typing import Optional
@@ -438,8 +437,6 @@ class MainWindow(Gtk.ApplicationWindow):
         # active_pane_key_controller.connect('key-pressed', task_treeview_key_press)
         # self.vtree_panes['active'].add_controller(active_pane_gesture_single)
         # self.vtree_panes['active'].add_controller(active_pane_key_controller)
-        # self.vtree_panes['active'].connect('node-expanded', self.on_task_expanded)
-        # self.vtree_panes['active'].connect('node-collapsed', self.on_task_collapsed)
 
         # # Workview tasks TreeView
         # tsk_treeview_btn_press = self.on_task_treeview_click_begin
@@ -532,22 +529,6 @@ class MainWindow(Gtk.ApplicationWindow):
         and maximize it if needed """
         self.config.set("maximized", self.is_maximized())
 
-    def restore_collapsed_tasks(self, tasks=None):
-        tasks = tasks or self.config.get("collapsed_tasks")
-
-        for path_s in tasks:
-            # the tuple was stored as a string. we have to reconstruct it
-            path = ()
-            for p in path_s[1:-1].split(","):
-                p = p.strip(" '")
-                path += (p, )
-            if path[-1] == '':
-                path = path[:-1]
-            try:
-                self.vtree_panes['active'].collapse_node(path)
-            except IndexError:
-                print(f"Invalid path {path}")
-
     def restore_tag_selection(self) -> None:
         """Restore tag selection from config."""
 
@@ -596,6 +577,11 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.set_sorter(sort_mode.capitalize())
 
+        # Every row is born collapsed (autoexpand is off on the tree
+        # model): once the pane is up, expand everything except what
+        # the user collapsed, like the sidebar filters already do.
+        GLib.idle_add(lambda: self.get_pane().emit('expand-all'))
+
 
         # Callbacks for sorting and restoring previous state
         # model = self.vtree_panes['active'].get_model()
@@ -606,8 +592,6 @@ class MainWindow(Gtk.ApplicationWindow):
         # if sort_column and sort_order:
         #     sort_column, sort_order = int(sort_column), int(sort_order)
         #     model.set_sort_column_id(sort_column, sort_order)
-
-        # self.restore_collapsed_tasks()
 
         # view_name = PANE_STACK_NAMES_MAP_INVERTED.get(self.config.get('view'),
         #                                               PANE_STACK_NAMES_MAP_INVERTED['active'])
@@ -724,40 +708,14 @@ class MainWindow(Gtk.ApplicationWindow):
     def on_collapse_all_tasks(self, action, param):
         """Collapse all tasks."""
 
+        self.get_pane().mark_user_action()
         self.get_pane().emit('collapse-all')
 
     def on_expand_all_tasks(self, action, param):
-        """Expand all tasks."""
+        """Expand all tasks, clearing the collapsed-tasks memory."""
 
+        self.get_pane().forget_collapsed()
         self.get_pane().emit('expand-all')
-
-    def on_task_expanded(self, sender, path: str):
-        # For some reason, path is turned from a tuple into a string of a
-        # tuple
-        if type(path) is str:
-            path = ast.literal_eval(path)
-        tid = path[-1]
-
-        collapsed_tasks = self.config.get("collapsed_tasks")
-        stringified_path = str(path)
-        if stringified_path in collapsed_tasks:
-            collapsed_tasks.remove(stringified_path)
-            self.config.set("collapsed_tasks", collapsed_tasks)
-
-        # restore expanded state of subnodes
-        model = sender.get_model()
-        for child_id in model.tree.node_all_children(tid):
-            child_path = path + (child_id,)
-            if str(child_path) not in collapsed_tasks:
-                # Warning: Recursion. We expect having not too many nested
-                # subtasks for now.
-                sender.expand_node(child_path)
-
-    def on_task_collapsed(self, sender, tid):
-        colt = self.config.get("collapsed_tasks")
-        if tid not in colt:
-            colt.append(str(tid))
-        self.config.set("collapsed_tasks", colt)
 
     def on_tag_expanded(self, sender, tag):
         colt = self.config.get("expanded_tags")

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -18,7 +18,7 @@
 
 """Task pane and list."""
 
-from gi.repository import Gtk, GObject, Gdk, Gio, Pango
+from gi.repository import Gtk, GObject, Gdk, Gio, GLib, Pango
 from GTG.core.tasks import Task, Status, FilteredTaskTreeManager
 from GTG.core.filters import TaskFilter
 from GTG.core.sorters import (TaskAddedSorter, TaskDueSorter,
@@ -135,6 +135,22 @@ class TaskPane(Gtk.ScrolledWindow):
         self.browser = browser
         self.pane = pane
         self.searching = False
+
+        # Tasks the user collapsed, remembered across sessions by task
+        # id. Legacy entries (stringified tree paths from the pre-GTK4
+        # code) can never match an id, and the config reader drops bare
+        # ids whenever such entries are present: prune them at load time
+        # and rewrite the setting right away.
+        stored = self.app.config.get('collapsed_tasks')
+        self.collapsed_ids = {i for i in stored if not i.startswith('(')}
+        self._collapsed_save_pending = False
+        if len(self.collapsed_ids) != len(stored):
+            self._save_collapsed()
+
+        # The model collapses rows on its own (loading, refiltering,
+        # teardown) and those emissions must not be remembered. Only a
+        # fold change right after a user gesture on this pane counts.
+        self._armed_tid = None
 
         self.set_vexpand(True)
         self.set_hexpand(True)
@@ -354,6 +370,50 @@ class TaskPane(Gtk.ScrolledWindow):
         return selected
 
 
+    def _on_expander_pressed(self, gesture, n_press, x, y, task):
+        """A press on a row's own fold arrow arms that row only."""
+        self._armed_tid = str(task.id)
+
+
+    def mark_user_action(self) -> None:
+        """Menu actions (collapse/expand all) arm every row at once."""
+        self._armed_tid = '*'
+
+
+    def _on_row_expanded_changed(self, row, _pspec, task):
+        """Remember manually collapsed tasks across sessions."""
+
+        # Accept only fold changes whose own expander arrow was
+        # pressed (or a collapse/expand-all menu action). Mechanical
+        # collapses from loading, refiltering or teardown never press
+        # an arrow, so they are never remembered.
+        if self._armed_tid not in ('*', str(task.id)):
+            return
+
+        tid = str(task.id)
+        if row.get_expanded():
+            self.collapsed_ids.discard(tid)
+        else:
+            self.collapsed_ids.add(tid)
+
+        # collapse-all fires this for every row: save once, on idle
+        if not self._collapsed_save_pending:
+            self._collapsed_save_pending = True
+            GLib.idle_add(self._save_collapsed)
+
+
+    def _save_collapsed(self) -> bool:
+        self._collapsed_save_pending = False
+        self.app.config.set('collapsed_tasks', sorted(self.collapsed_ids))
+        return False
+
+
+    def forget_collapsed(self) -> None:
+        """Explicitly expanding everything also clears the memory."""
+        self.collapsed_ids.clear()
+        self._save_collapsed()
+
+
     def expand_selected(self, expand) -> None:
         """Get the box widgets of the selected tasks."""
 
@@ -454,8 +514,15 @@ class TaskPane(Gtk.ScrolledWindow):
         task_RMB_controller.connect('end', self.on_task_RMB_click)
         box.add_controller(task_RMB_controller)
 
-        self.connect('expand-all', lambda s: box.expander.activate_action('listitem.expand'))
-        self.connect('collapse-all', lambda s: box.expander.activate_action('listitem.collapse'))
+        def expand_unless_remembered(pane):
+            task = box.props.task
+            if task is not None and str(task.id) in pane.collapsed_ids:
+                return
+            box.expander.activate_action('listitem.expand')
+
+        self.connect('expand-all', expand_unless_remembered)
+        self.connect('collapse-all',
+                     lambda s: box.expander.activate_action('listitem.collapse'))
 
         box.append(label)
         box.append(description)
@@ -490,7 +557,15 @@ class TaskPane(Gtk.ScrolledWindow):
         item = unwrap(listitem, Task)
 
         box.props.task = item
-        box.expander.set_list_row(listitem.get_item())
+        row = listitem.get_item()
+        box.expander.set_list_row(row)
+        arrow_press = Gtk.GestureClick()
+        arrow_press.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        arrow_press.connect('pressed', self._on_expander_pressed, item)
+        box.expander.add_controller(arrow_press)
+        listitem.arrow_gesture = arrow_press
+        listitem.expanded_handler = row.connect(
+            'notify::expanded', self._on_row_expanded_changed, item)
 
         config = self.app.config
 
@@ -544,7 +619,9 @@ class TaskPane(Gtk.ScrolledWindow):
         for binding in listitem.bindings:
             binding.unbind()
         listitem.bindings.clear()
+        listitem.get_item().disconnect(listitem.expanded_handler)
         box = listitem.get_child()
+        box.expander.remove_controller(listitem.arrow_gesture)
         box.check.disconnect_by_func(self.on_checkbox_toggled)
 
 


### PR DESCRIPTION
fix: remember collapsed tasks again on the new task pane

Fixes #595, fixes #724.

The GTK4 port left the collapsed-tasks memory disconnected: the old
handlers still existed but nothing emitted their signals, and the
stored tree paths no longer matched the new TreeListModel world.

What this does:
- Remember collapsed tasks by task id instead of fragile tree paths.
- Restore them at startup: every row is born collapsed (autoexpand is
  off), so the pane expands everything except what the user collapsed,
  the same way the sidebar filters already do.
- Record a fold change only when the row's own expander arrow was
  pressed (or a collapse/expand-all menu action). Gtk.TreeListRow's
  notify::expanded fires just as much for mechanical collapses
  (loading, refiltering, teardown); listening to it unfiltered slowly
  poisons the stored list with tasks the user never touched. Verified
  on a fresh dataset: idle sessions and heavy sidebar filtering write
  nothing; only arrow presses and menu actions do.
- Expand all clears the memory; Collapse all records it.
- Prune legacy stringified-path entries at load time: the config
  reader's tuple regex otherwise swallows every bare id stored next to
  them.

Known limitations, left out on purpose:
- Folding via keyboard is not recorded yet, only the arrow and the
  menu actions.
- Pre-existing on master, unchanged here: the expand-all signal only
  reaches materialized rows, and sidebar filter changes emit it before
  the refilter, so deep rows can appear collapsed after a filter
  switch. Worth its own issue.
- The dead expanded_tags handlers for the sidebar have the same
  disease and could adopt this pattern in a follow-up.