### PR TITLE
fix(caldav): push local task deletions to the server

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -158,15 +158,19 @@ class Backend(PeriodicImportBackend):
         self._set_task(task)
 
     @interruptible
-    def remove_task(self, tid: str) -> None:
+    def remove_task(self, tid) -> None:
+        """Push a local deletion to the server. The task is already
+        gone from the local store (that removal is what triggered the
+        'removed' signal), so this must only delete the remote todo."""
         if self._parameters["is-first-run"] or not self._cache.initialized:
-            logger.warning("not loaded yet, ignoring set_task")
+            logger.warning("not loaded yet, ignoring remove_task")
             return
         if not tid:
             logger.warning("no task id passed to remove_task call, ignoring")
             return
-        with self.datastore.mutex:
-            return self.datastore.tasks.remove(UUID(tid) if isinstance(tid, str) else tid)
+        # tid may arrive as a UUID object (task.id) from the queue;
+        # the todo cache is keyed by str(task.id), so normalize.
+        self._remove_task(str(tid))
 
     #
     # real main methods
@@ -222,11 +226,13 @@ class Backend(PeriodicImportBackend):
             self._create_todo(task, calendar)
 
     def _remove_task(self, tid: str) -> None:
-        todo = self._cache.get_todo(tid)
+        todo = self._cache.get_todo(str(tid))
         if todo:
-            self._remove_todo(tid, todo)
+            self._remove_todo(str(tid), todo)
         else:
-            logger.error("Could not find todo for task(%s)", tid)
+            # Not an error: the task may never have reached the server
+            # or may belong to another calendar. Nothing to delete.
+            logger.info("No known todo for task(%s), nothing to remove", tid)
 
     #
     # Dav functions

--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -256,6 +256,10 @@ class Backend(PeriodicImportBackend):
         self._cache.del_todo(str(uid_to_task_id(uid)))  # cleaning cache
         try:  # deleting through caldav
             todo.delete()
+        except caldav.lib.error.NotFoundError:
+            # Already gone server-side: the goal (the todo no longer
+            # exists) is reached, deletion is idempotent.
+            logger.info('Todo for Task(%s) already gone from server', uid)
         except caldav.lib.error.DAVError:
             logger.exception('Something went wrong while deleting %r => %r',
                              uid, todo)

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -169,6 +169,17 @@ class Datastore:
                     backend.queue_set_task(task.id)
         self.tasks.connect('task-filterably-changed', _on_task_changed)
 
+        # Notify backends when a task is removed, so local deletions
+        # are pushed to the server. base_store.remove() cascades one
+        # 'removed' signal per descendant (children first), so every
+        # subtask gets its own queue_remove_task without any tree
+        # walking here or in the backends.
+        def _on_task_removed(_, task):
+            for backend in self.backends.values():
+                if backend.is_enabled():
+                    backend.queue_remove_task(task.id)
+        self.tasks.connect('removed', _on_task_removed)
+
         self.data_path: Optional[str] = None
         self._activate_non_default_backends()
 

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -621,3 +621,99 @@ class NonUuidUidRegressionTest(TestCase):
         canonical = '1f0ac2a2-2e44-4f9c-89e2-6dd00b78ef34'
         self.assertEqual(_UUID(canonical),
                          uid_to_task_id(canonical.upper()))
+
+
+class LocalDeletionPushTest(TestCase):
+    """Deleting a task in GTG must delete the matching todo on the
+    CalDAV server, otherwise it reappears on the next import.
+
+    Follow-up to #1265, whose scope note read "this PR does not cover
+    pushing local deletions to the server": the public remove_task
+    used to mutate GTG's own store (the exact inverse of a push)
+    while the real DAV deletion, _remove_task, had no caller."""
+
+    UUID_UID = '5241ab4d-05ef-4b2e-ab1e-1699ba222eef'
+    VTODO_UUID = ("BEGIN:VTODO\r\n"
+                  "CREATED:20201212T092155Z\r\n"
+                  "DTSTAMP:20201212T172830Z\r\n"
+                  "LAST-MODIFIED:20201212T172558Z\r\n"
+                  "STATUS:NEEDS-ACTION\r\n"
+                  "SUMMARY:todo to be deleted\r\n"
+                  "UID:" + UUID_UID + "\r\n"
+                  "END:VTODO\r\n")
+    NON_UUID_UID = '19960401T080045Z-4000F192713@example.com'
+    VTODO_NON_UUID = ("BEGIN:VTODO\r\n"
+                      "CREATED:20201212T092155Z\r\n"
+                      "DTSTAMP:20201212T172830Z\r\n"
+                      "LAST-MODIFIED:20201212T172558Z\r\n"
+                      "STATUS:NEEDS-ACTION\r\n"
+                      "SUMMARY:todo with a non-uuid uid\r\n"
+                      "UID:" + NON_UUID_UID + "\r\n"
+                      "END:VTODO\r\n")
+
+    @staticmethod
+    def _todo(raw):
+        todo = Mock()
+        todo.instance.vtodo = vobject.readOne(raw)
+        todo.parent.name = 'My Calendar'
+        return todo
+
+    @staticmethod
+    def _backend():
+        parameters = {'pid': 'test', 'service-url': 'unittest',
+                      'username': 'u', 'password': 'p', 'period': 1,
+                      'is-first-run': False}
+        backend = Backend(parameters)
+        backend.datastore = Datastore()
+        return backend
+
+    def _synced_backend(self, raw_vtodo):
+        """A backend whose cache holds one imported todo."""
+        backend = self._backend()
+        calendar = Mock()
+        calendar.name = 'My Calendar'
+        todo = self._todo(raw_vtodo)
+        calendar.todos.return_value = [todo]
+        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
+        backend._import_calendar_todos(
+            calendar, datetime.now(LOCAL_TIMEZONE), counts)
+        backend._cache.initialized = True  # done by _do_periodic_import
+        self.assertEqual(1, counts['created'])
+        task = next(iter(backend.datastore.tasks.lookup.values()))
+        return backend, todo, task
+
+    def test_remove_task_deletes_the_remote_todo(self):
+        backend, todo, task = self._synced_backend(self.VTODO_UUID)
+        backend.remove_task(str(task.id))
+        todo.delete.assert_called_once_with()
+        self.assertIsNone(backend._cache.get_todo(str(task.id)))
+
+    def test_remove_task_does_not_touch_the_local_store(self):
+        # regression: the old remove_task deleted the task from GTG's
+        # own store instead of pushing the deletion to the server
+        backend, todo, task = self._synced_backend(self.VTODO_UUID)
+        backend.remove_task(str(task.id))
+        self.assertIn(task.id, backend.datastore.tasks.lookup)
+
+    def test_remove_task_accepts_a_uuid_object(self):
+        # regression: the queue hands over task.id (a UUID object)
+        # while the todo cache is keyed by str(task.id)
+        backend, todo, task = self._synced_backend(self.VTODO_UUID)
+        backend.remove_task(task.id)
+        todo.delete.assert_called_once_with()
+
+    def test_remove_task_with_non_uuid_server_uid(self):
+        backend, todo, task = self._synced_backend(self.VTODO_NON_UUID)
+        backend.remove_task(task.id)
+        todo.delete.assert_called_once_with()
+        self.assertIsNone(backend._cache.get_todo(str(task.id)))
+
+    def test_remove_task_for_unknown_tid_is_a_noop(self):
+        backend, todo, task = self._synced_backend(self.VTODO_UUID)
+        backend.remove_task('11111111-2222-3333-4444-555555555555')
+        todo.delete.assert_not_called()
+
+    def test_remove_task_before_cache_is_ready_is_ignored(self):
+        backend = self._backend()
+        # cache not initialized: nothing to look up, must not raise
+        backend.remove_task('5241ab4d-05ef-4b2e-ab1e-1699ba222eef')

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -717,3 +717,18 @@ class LocalDeletionPushTest(TestCase):
         backend = self._backend()
         # cache not initialized: nothing to look up, must not raise
         backend.remove_task('5241ab4d-05ef-4b2e-ab1e-1699ba222eef')
+
+    def test_deleting_an_already_gone_todo_is_a_success(self):
+        # DELETE must be idempotent: a 404 means the goal (the todo
+        # no longer exists server-side) is already reached
+        backend, todo, task = self._synced_backend(self.VTODO_UUID)
+        todo.delete.side_effect = NotFoundError('410 Gone')
+        # assertNoLogs is Python 3.10+ and CI runs 3.9: capture the
+        # records and check none is error-level instead
+        with self.assertLogs('GTG.backends.backend_caldav',
+                             level='INFO') as captured:
+            backend.remove_task(task.id)  # must not raise
+        self.assertFalse(
+            [r.getMessage() for r in captured.records
+             if r.levelname in ('ERROR', 'CRITICAL')])
+        self.assertIsNone(backend._cache.get_todo(str(task.id)))

--- a/tests/core/test_datastore_removal_sync.py
+++ b/tests/core/test_datastore_removal_sync.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from GTG.core.datastore import Datastore
+
+
+class DatastoreRemovalSyncTest(TestCase):
+    """Removing a task locally must be propagated to the enabled
+    backends via queue_remove_task, so the deletion is pushed to the
+    server instead of the task reappearing on the next import
+    (follow-up to #1265, which only wired the 'set' direction)."""
+
+    def setUp(self):
+        self.ds = Datastore()
+        self.backend = Mock()
+        self.backend.is_enabled.return_value = True
+        self.ds.backends['test-backend'] = self.backend
+
+    def test_removing_a_task_queues_its_removal(self):
+        task = self.ds.tasks.new('a task')
+        tid = task.id
+        self.ds.tasks.remove(tid)
+        self.backend.queue_remove_task.assert_called_once_with(tid)
+
+    def test_removing_a_parent_queues_every_descendant(self):
+        parent = self.ds.tasks.new('parent')
+        child_a = self.ds.tasks.new('child a', parent=parent.id)
+        child_b = self.ds.tasks.new('child b', parent=parent.id)
+        self.backend.queue_remove_task.reset_mock()
+
+        self.ds.tasks.remove(parent.id)
+
+        removed = [c.args[0]
+                   for c in self.backend.queue_remove_task.call_args_list]
+        self.assertEqual(3, len(removed))
+        self.assertEqual({parent.id, child_a.id, child_b.id}, set(removed))
+        # children are cascaded before their parent
+        self.assertEqual(parent.id, removed[-1])
+
+    def test_disabled_backend_is_not_notified(self):
+        self.backend.is_enabled.return_value = False
+        task = self.ds.tasks.new('a task')
+        self.ds.tasks.remove(task.id)
+        self.backend.queue_remove_task.assert_not_called()


### PR DESCRIPTION
Follow-up to #1265, closing its explicit scope note: *"this PR does not
cover pushing local deletions to the server"*. Deleting a task in GTG
currently never deletes it on the CalDAV server, so it reappears on the
next import. This is not a regression (master never pushed deletions),
but it is the last missing piece of two-way sync.

## What was missing

The deletion plumbing already existed and worked — `queue_remove_task`,
the worker draining `to_remove` (with remove taking priority over set),
and `base_store.remove()` cascading one `removed` signal per descendant.
Only two wires were missing:

1. **Core** — nothing connected the TaskStore `removed` signal to
   `queue_remove_task` (the symmetric of what #1265 did for
   `queue_set_task`). *(commit 1)*
2. **Backend** — the public `remove_task` was inverted: it deleted the
   task from GTG's *own store* (which is where the signal came from in
   the first place) instead of deleting the remote todo. The real DAV
   deletion, `_remove_task`, was dead code with no caller. It now
   delegates to it, normalizing the tid with `str()` since the todo
   cache is keyed by `str(task.id)` while the queue hands over `UUID`
   objects (regression-tested). *(commit 2)*

Commit 3 makes the deletion idempotent: a todo already gone server-side
(404/NotFound) is a success — the goal, that it no longer exists, is
reached — logged as info instead of an exception.

## What was deliberately *not* reimplemented

`base_store.remove()` already cascades `removed` over the whole subtree
(children first), so deleting a parent naturally yields one
`queue_remove_task` — and one DELETE — per descendant. No tree walking
was added in the backend; a test pins this behavior instead.

## Tests

- `tests/core/test_datastore_removal_sync.py` (new): a removal on a
  Datastore with an enabled backend queues `queue_remove_task(task.id)`;
  a parent with 2 subtasks queues all three (children first); a disabled
  backend is not notified.
- `tests/backend/backend_caldav_test.py`, new `LocalDeletionPushTest`
  class written against the new core API (same style as
  `NonUuidUidRegressionTest` from #1265): the right `todo.delete()` is
  issued; the local store is *not* touched (regression on the inverted
  behavior); a `UUID` object tid still finds the todo (regression on the
  str-keyed cache); a task imported through `uid_to_task_id` (non-UUID
  server UID) is deleted; an unknown tid is a no-op; a call before the
  cache is ready is ignored; a 404 on delete is a success with no
  error-level log.
- Each commit is green in isolation. The pre-existing `CalDAVTest` class
  remains `@unittest.skip` (legacy old-core API); migrating it is a
  separate, mechanical follow-up I'm happy to take next.
- Live testing (Nextcloud ✅): created a parent with two subtasks,
  synced, verified server-side; deleted the parent in GTG → three
  DELETEs issued, children first, parent last; all three todos gone
  server-side; two full import cycles later, zero `created` — the tasks
  do not come back. The original symptom is gone.

## Known limitations, and where the answers live

- **The `to_remove` queue is in-memory** (same as `to_set`): a deletion
  made while the server is unreachable, or pending when GTG quits, is
  lost and the task will come back on import. A persistent
  deletion-journal replayed at startup would be the natural follow-up —
  a separate piece of work, same design for both queues.
- **Flush-at-quit is fragile**: `GenericBackend.quit()` runs
  `Thread(target=self.sync).run()`, which executes synchronously in the
  calling thread instead of spawning one. It happens to work today; a
  one-line follow-up (`self.sync()` directly, or `.start()`+`join()`)
  would make the shutdown flush deliberate rather than accidental.
- **Beat with the periodic import**: if an import runs while a DELETE is
  still queued, the todo can be re-imported just before being deleted,
  then deleted again next cycle — correct convergence, one cycle of
  flapping. The datastore mutex and the `to_remove > to_set` priority
  already bound this; documenting it beats over-engineering it. (Note
  the pending #1294 "Synchronize now" button currently triggers two
  imports per click, which would make this beat easier to observe
  manually — not a regression of this PR.)

Also closes #1240, made obsolete by #1265 (the added-date guard now
lives in `fill_task` on the new API).