### PR TITLE
fix(core): load stores whose tasks have no added date

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -913,10 +913,20 @@ class TaskStore(BaseStore[Task]):
             task.date_modified = Date(datetime.datetime.fromisoformat(modified))
 
             added_element = dates.find('added')
-            assert added_element is not None, 'Added element not found in task '+str(tid)
-            assert added_element.text is not None, 'Added text not found in task '+str(tid)
-            added = added_element.text
-            task.date_added = Date(datetime.datetime.fromisoformat(added))
+            if added_element is not None and added_element.text:
+                added = added_element.text
+                task.date_added = Date(datetime.datetime.fromisoformat(added))
+            else:
+                # Stores written while a task had no added date -- e.g.
+                # after importing a CalDAV VTODO without a CREATED
+                # field, before the fill_task guard -- lack the <added>
+                # element or leave it empty. Refusing to load them makes
+                # GTG crash at startup (#1033): heal the task instead,
+                # falling back on the modification date parsed above,
+                # like the import side does.
+                log.warning('Task %s has no added date, falling back '
+                            'on the modification date', tid)
+                task.date_added = task.date_modified
 
             if status == 'Done':
                 task.status = Status.DONE

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -676,3 +676,45 @@ class TestTask(TestCase):
         task_store.sort(tasks, key='title')
         expected = [task1, task2, task4]
         self.assertEqual(tasks, expected)
+
+
+class LoadStoreWithoutAddedDateTest(TestCase):
+    """Regression test for #1033: a gtg_data.xml written while a task
+    had no added date (e.g. after importing a CalDAV VTODO without a
+    CREATED field, before the fill_task guard) lacks the <added>
+    element or leaves it empty. Refusing to load such a file makes
+    GTG crash at startup; the store must heal the task instead,
+    falling back on the modification date like the import side does."""
+
+    TASK_XML = ('<tasklist>'
+                '<task id="0ab33328-4bd0-4d1b-8b06-58bdd8fc4d05"'
+                ' status="Active">'
+                '<title>Sturm des Wissens</title>'
+                '<dates>'
+                '<modified>2023-11-08 14:14:27.529767</modified>'
+                '{added}'
+                '</dates>'
+                '<subtasks/>'
+                '<content>from a Nextcloud Deck card</content>'
+                '</task>'
+                '</tasklist>')
+
+    def _load(self, added_fragment):
+        task_store = TaskStore()
+        xml = XML(self.TASK_XML.format(added=added_fragment))
+        task_store.from_xml(xml, TagStore())
+        return next(iter(task_store.lookup.values()))
+
+    def test_missing_added_element_falls_back_on_modified(self):
+        task = self._load('')
+        self.assertTrue(task.date_added)
+        self.assertEqual(str(task.date_modified), str(task.date_added))
+
+    def test_empty_added_element_falls_back_on_modified(self):
+        task = self._load('<added></added>')
+        self.assertTrue(task.date_added)
+        self.assertEqual(str(task.date_modified), str(task.date_added))
+
+    def test_valid_added_element_is_still_honored(self):
+        task = self._load('<added>2020-01-02 03:04:05</added>')
+        self.assertIn('2020-01-02', str(task.date_added))


### PR DESCRIPTION
Closes the remaining half of #1033.

The bug had two halves. The **prevention** half — never *writing* a
store with a missing added date again — was fixed by #1265: `fill_task`
now falls back on `date_modified` when a CalDAV VTODO has no CREATED
field (`backend_caldav.py:1143-1150`, pinned by
`test_import_todo_without_created_date`, which covers the exact
Nextcloud Deck VTODO from the report: no CREATED, no LAST-MODIFIED,
non-UUID UID).

This PR is the **healing** half: a `gtg_data.xml` already damaged while
the bug was live still made GTG crash at startup, since `from_xml`
asserted on the missing (or empty) `<added>` element — the file could
never be opened again. It now heals the task at load, falling back on
the modification date, with a warning in the log. The 0.6 migration
path already had its own fallback (`versioning.py` stamps today's
date), so new-format files were the one remaining entry point.

Red-before/green-after: the two corruption forms from the report
(element absent, element empty) crashed before the fix and load after
it; a third test pins that a valid `<added>` is still honored.

The commit message carries `Fixes #1033`, so merging this closes the
issue.