### PR TITLE
fix(core): load 0.6 data files whose task ids are not UUIDs

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -22,7 +22,7 @@
 from gi.repository import GObject, Gio, Gtk, Gdk # type: ignore[import-untyped]
 from gettext import gettext as _
 
-from uuid import uuid4, UUID
+from uuid import uuid4, uuid5, UUID, NAMESPACE_URL
 import logging
 from typing import Callable, Any, List, Optional, Set, Dict, Tuple, Union
 from enum import Enum
@@ -37,6 +37,27 @@ from GTG.core.tags import Tag, TagStore
 from GTG.core.dates import Date
 
 log = logging.getLogger(__name__)
+
+
+# Task ids are UUIDs, but 0.6 data files can carry non-canonical ids:
+# the old CalDAV backend used the remote iCalendar UID verbatim as the
+# local id, and RFC 5545 makes that UID an opaque string (name@host is
+# even the traditional form). Map anything that is not already a valid
+# UUID to a stable name-based one (RFC 4122, uuid5), so the same
+# original string always yields the same task id and subtask/parent
+# references written with that string keep pointing to the same task.
+# This mirrors uid_to_task_id in the CalDAV backend, kept separate to
+# avoid the core depending on a backend.
+ID_NAMESPACE = uuid5(NAMESPACE_URL, 'gtg://core/tasks')
+
+
+def id_to_uuid(task_id) -> UUID:
+    if isinstance(task_id, UUID):
+        return task_id
+    try:
+        return UUID(task_id)
+    except (TypeError, AttributeError, ValueError):
+        return uuid5(ID_NAMESPACE, str(task_id))
 
 
 # ------------------------------------------------------------------------------
@@ -894,7 +915,11 @@ class TaskStore(BaseStore[Task]):
         elements = list(xml.iter(self.XML_TAG))
 
         for element in elements:
-            tid = UUID(element.get('id'))
+            raw_id = element.get('id')
+            tid = id_to_uuid(raw_id)
+            if str(tid) != raw_id:
+                log.warning('Task id %r is not a UUID, mapped to %s',
+                            raw_id, tid)
             title_element = element.find('title')
             assert title_element is not None, 'Title element not found for task '+str(tid)
             assert title_element.text is not None, 'Title text not found for task '+str(tid)
@@ -979,12 +1004,12 @@ class TaskStore(BaseStore[Task]):
 
         # All tasks have been added, now we parent them
         for element in elements:
-            parent_tid = UUID(element.get('id'))
+            parent_tid = id_to_uuid(element.get('id'))
             subtasks = element.find('subtasks')
             assert subtasks is not None, 'Subtasks element not found in task '+str(tid)
 
             for sub in subtasks.findall('sub'):
-                self.parent(UUID(sub.text), parent_tid)
+                self.parent(id_to_uuid(sub.text), parent_tid)
 
 
     def to_xml(self) -> _Element:

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -469,7 +469,7 @@ class TestTask(TestCase):
                     <term>None</term>
                 </recurring>
                 <subtasks>
-                    <sub>lol</sub>
+                    <sub>ghost-subtask-that-matches-no-task</sub>
                 </subtasks>
 
                 <content><![CDATA[ My Content ]]></content>
@@ -493,7 +493,10 @@ class TestTask(TestCase):
         </tasklist>
         ''')
 
-        with self.assertRaises(ValueError):
+        # a <sub> pointing at no existing task is still rejected, now as
+        # a KeyError from parent() (missing task) rather than a ValueError
+        # from casting the id: non-canonical ids no longer crash the cast
+        with self.assertRaises(KeyError):
             task_store.from_xml(parsed_xml, None)
 
 
@@ -718,3 +721,74 @@ class LoadStoreWithoutAddedDateTest(TestCase):
     def test_valid_added_element_is_still_honored(self):
         task = self._load('<added>2020-01-02 03:04:05</added>')
         self.assertIn('2020-01-02', str(task.date_added))
+
+
+class LoadStoreWithNonUuidIdsTest(TestCase):
+    """Regression test for #1289: a 0.6 data file that ever synced tasks
+    created by another CalDAV client can carry task ids that are not
+    canonical UUIDs (RFC 5545 makes the iCalendar UID an opaque string;
+    the 0.6 CalDAV backend used it verbatim as the local id). from_xml
+    cast every id with UUID() and no guard, so a single non-UUID id
+    raised ValueError, aborted find_and_load_file, and GTG failed to
+    start entirely -- one bad id made all the other tasks unreachable.
+
+    The store must instead map any non-canonical id to a deterministic
+    UUID (uuid5), exactly as the CalDAV backend already does on the sync
+    side, so the same original string always yields the same task id and
+    parent/child references stay intact."""
+
+    NON_UUID_XML = ('<tasklist>'
+                    '<task id="deck-card-986" status="Active">'
+                    '<title>Sturm des Wissens</title>'
+                    '<dates>'
+                    '<added>2023-11-08 14:14:27</added>'
+                    '<modified>2023-11-08 14:14:27</modified>'
+                    '</dates>'
+                    '<subtasks>'
+                    '<sub>task-1772@someclient</sub>'
+                    '</subtasks>'
+                    '<content>from a Nextcloud Deck card</content>'
+                    '</task>'
+                    '<task id="task-1772@someclient" status="Active">'
+                    '<title>A child with a mail-style id</title>'
+                    '<dates>'
+                    '<added>2023-11-08 14:14:27</added>'
+                    '<modified>2023-11-08 14:14:27</modified>'
+                    '</dates>'
+                    '<subtasks/>'
+                    '<content>child content</content>'
+                    '</task>'
+                    '</tasklist>')
+
+    def test_non_uuid_ids_load_instead_of_crashing(self):
+        task_store = TaskStore()
+        task_store.from_xml(XML(self.NON_UUID_XML), TagStore())
+        self.assertEqual(task_store.count(), 2)
+
+    def test_non_uuid_ids_are_mapped_deterministically(self):
+        # the same original string must always yield the same task id,
+        # otherwise a reload would orphan every subtask
+        first = TaskStore()
+        first.from_xml(XML(self.NON_UUID_XML), TagStore())
+        second = TaskStore()
+        second.from_xml(XML(self.NON_UUID_XML), TagStore())
+        self.assertEqual(sorted(str(t.id) for t in first.lookup.values()),
+                         sorted(str(t.id) for t in second.lookup.values()))
+
+    def test_non_uuid_parent_child_link_survives(self):
+        task_store = TaskStore()
+        task_store.from_xml(XML(self.NON_UUID_XML), TagStore())
+        parents = [t for t in task_store.lookup.values() if t.children]
+        self.assertEqual(1, len(parents))
+        self.assertEqual(1, len(parents[0].children))
+
+    def test_canonical_uuid_ids_are_left_untouched(self):
+        canonical = '1d34df07-4185-43ad-adbd-698a86193411'
+        xml = ('<tasklist><task id="' + canonical + '" status="Active">'
+               '<title>T</title>'
+               '<dates><added>2020-01-01 00:00:00</added>'
+               '<modified>2020-01-01 00:00:00</modified></dates>'
+               '<subtasks/><content>c</content></task></tasklist>')
+        task_store = TaskStore()
+        task_store.from_xml(XML(xml), TagStore())
+        self.assertIn(canonical, [str(t.id) for t in task_store.lookup.values()])


### PR DESCRIPTION
Fixes #1289.

`from_xml` cast every task id with `UUID()` and no guard. A 0.6 data
file that ever synced tasks created by another CalDAV client can carry
ids that are not canonical UUIDs — the old CalDAV backend used the
remote iCalendar UID verbatim as the local id, and RFC 5545 makes that
UID an opaque string (`name@host` is even the traditional form). A
single such id raised `ValueError`, aborted `find_and_load_file`, and
GTG failed to start entirely: one bad id made every other task
unreachable. This hits exactly the users a release wants to keep —
people upgrading with years of synced data.

Any non-canonical id is now mapped to a deterministic UUID (uuid5) at
all three conversion points in `from_xml` (the task id, the parent id,
and each `<sub>` reference). Deterministic mapping means references
written with the same original string keep pointing to the same task,
so hierarchies survive without a remapping pass. This mirrors
`uid_to_task_id` in the CalDAV backend (#1265), kept as a separate
helper so the core doesn't depend on a backend. Canonical UUIDs are
used as-is, so nothing changes for files that already use them; one
warning is logged per converted id.

Verified against a real reproduction: a `gtg_data.xml` carrying a
Nextcloud-Deck-style id (`deck-card-986`) crashes GTG at startup on
`master` (`ValueError` in `from_xml`) and loads cleanly on this branch.
Red-before/green-after unit tests cover the crash, the deterministic
mapping, the parent/child link survival, and that canonical UUIDs are
left untouched.