### PR TITLE
fix(core): marshal store signals to the main loop from worker threads

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -19,10 +19,11 @@
 """Base for all store classes."""
 
 
-from gi.repository import GObject # type: ignore[import-untyped]
+from gi.repository import GObject, GLib # type: ignore[import-untyped]
 
 from uuid import UUID
 import logging
+import threading
 
 from lxml.etree import _Element
 from typing import Dict, Optional, TypeVar, Generic
@@ -107,6 +108,23 @@ class BaseStore(GObject.Object,Generic[S]):
     # BASIC MANIPULATION
     # --------------------------------------------------------------------------
 
+    def _emit(self, signal: str, *args) -> None:
+        """Emit a store signal, marshalled to the main loop when needed.
+
+        These stores are GObject-based and their signals fire
+        synchronously; sidebar counters and list models react on the
+        spot. GTK 4 is not thread-safe, so when a background worker
+        (e.g. a backend's sync thread) mutates the store, emitting from
+        that thread reaches GTK off the main loop and can raise a
+        GLib ref-count assertion or segfault (#1279). Defer to the main
+        loop with idle_add in that case; on the main thread, emit
+        directly so existing callers keep their synchronous behaviour.
+        """
+        if threading.current_thread() is threading.main_thread():
+            self.emit(signal, *args)
+        else:
+            GLib.idle_add(self.emit, signal, *args)
+
     def new(self) -> S:
         """Creates a new item in the store.
         NOTE: Subclasses may override the signature of this method.
@@ -140,7 +158,7 @@ class BaseStore(GObject.Object,Generic[S]):
             self.data.append(item)
 
         self.lookup[item.id] = item
-        self.emit('added', item)
+        self._emit('added', item)
         log.debug('Added %s', item)
 
 
@@ -180,7 +198,7 @@ class BaseStore(GObject.Object,Generic[S]):
             self.data.remove(item)
         del self.lookup[item_id]
 
-        self.emit('removed', item)
+        self._emit('removed', item)
 
 
     def batch_remove(self,item_ids: list[UUID]) -> None:
@@ -211,7 +229,7 @@ class BaseStore(GObject.Object,Generic[S]):
             log.error("item not found in data: " + str(item_id))
 
         self.lookup[parent_id].add_child(item)
-        self.emit('parent-change', item, self.lookup[parent_id])
+        self._emit('parent-change', item, self.lookup[parent_id])
 
 
     def unparent(self, item_id: UUID) -> None:
@@ -229,7 +247,7 @@ class BaseStore(GObject.Object,Generic[S]):
         self.data.append(child)
         child.parent = None
 
-        self.emit('parent-removed',child,parent)
+        self._emit('parent-removed',child,parent)
 
 
     # --------------------------------------------------------------------------

--- a/tests/core/test_base_store.py
+++ b/tests/core/test_base_store.py
@@ -175,3 +175,43 @@ class TestBaseStoreUnparent(TestCase):
     def test_unparenting_root_element_has_no_effect(self):
         self.store.unparent(self.root.id)
         self.assertEqual(self.store.data,[self.root])
+
+
+class TestBaseStoreThreadMarshalling(TestCase):
+    """Regression test for #1279: a background worker (a backend's sync
+    thread) mutating the store used to emit GObject signals synchronously
+    from that thread. GTK 4 is not thread-safe, so that reached the UI off
+    the main loop and could raise a GLib ref-count assertion or segfault.
+    _emit must fire directly on the main thread (keeping the synchronous
+    behaviour existing callers rely on) and defer to the main loop via
+    GLib.idle_add from any other thread."""
+
+    def setUp(self):
+        self.store = BaseStore()
+
+    def test_emit_is_synchronous_on_the_main_thread(self):
+        import threading
+        self.assertIs(threading.current_thread(), threading.main_thread())
+        received = []
+        self.store.connect('added', lambda s, item: received.append(item))
+        item = StoreItem(uuid4())
+        self.store.add(item)
+        # on the main thread the signal has already fired, no loop needed
+        self.assertEqual([item], received)
+
+    def test_emit_is_deferred_off_the_main_thread(self):
+        import threading
+        from unittest.mock import patch
+        calls = []
+        # capture what _emit routes to GLib.idle_add from a worker thread
+        with patch('GTG.core.base_store.GLib.idle_add',
+                   side_effect=lambda *a: calls.append(a)):
+            def worker():
+                self.store._emit('added', StoreItem(uuid4()))
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+        # off the main thread the emit was handed to idle_add, not called inline
+        self.assertEqual(1, len(calls))
+        self.assertEqual(self.store.emit, calls[0][0])
+        self.assertEqual('added', calls[0][1])


### PR DESCRIPTION
Backend sync runs in a worker thread and mutates the task store directly (add/remove/parent). Those stores are GObject-based and emit their signals synchronously, so sidebar counters and list models react on the spot -- from the worker thread. GTK 4 is not thread-safe, so that reaches GTK off the main loop and can raise
'g_atomic_ref_count_inc: assertion old_value > 0 failed' and segfault, or freeze the UI (#1279). Backend *signals* were already marshalled in backend_signals.py; the store's own *data* signals were not.

Route the four store emits (added, removed, parent-change, parent-removed) through a _emit helper that emits directly when called on the main thread -- preserving the synchronous behaviour existing callers rely on -- and defers via GLib.idle_add from any other thread. Fixing this in BaseStore covers every backend on the new core, not just CalDAV.

The race itself is intermittent and can't be pinned by a test; the added tests instead pin the marshalling contract (synchronous on the main thread, deferred off it).

Fixes #1279