### PR TITLE
fix(caldav): refetch a missing todo by its server UID, not the GTG id

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -308,7 +308,7 @@ class Backend(PeriodicImportBackend):
                 logger.warning("Couldn't find calendar for %r", task)
                 return
             try:  # fetching missing todo from server
-                todo = calendar.todo_by_uid(uid)
+                todo = calendar.todo_by_uid(remote_uid(task, self.namespace))
             except caldav.lib.error.NotFoundError:
                 do_delete = True
             else:

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -651,6 +651,42 @@ class NonUuidUidRegressionTest(TestCase):
         todo.save.assert_not_called()
         calendar.add_todo.assert_not_called()
 
+    def test_missing_active_todo_is_refetched_by_its_server_uid(self):
+        """A task imported from a non-UUID server keeps that UID as an
+        attribute; its GTG id is a one-way uuid5 of it. When the todo is
+        absent from a later fetch, the backend refetches it to decide
+        whether to delete the task -- and must ask the server by the UID
+        the server actually knows (remote_uid), not the GTG id. Asking
+        by the GTG id always raises NotFoundError, so the task gets
+        deleted on every import (silent data loss)."""
+        backend = self._backend()
+        calendar = Mock()
+        calendar.name = 'My Calendar'
+        todo = self._todo(self.VTODO_NON_UUID)
+        todo.parent = calendar
+        calendar.todos.return_value = [todo]
+        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
+        start = datetime.now(LOCAL_TIMEZONE)
+        backend._import_calendar_todos(calendar, start, counts)
+        backend._cache.initialized = True
+        self.assertEqual(1, len(backend.datastore.tasks.lookup))
+        task = next(iter(backend.datastore.tasks.lookup.values()))
+        # make the task look older than the import so it is a deletion
+        # candidate rather than a just-created one
+        task.date_added = Date(datetime(2000, 1, 1, tzinfo=LOCAL_TIMEZONE))
+
+        # next import: the todo is gone from the fetch. The server still
+        # has it under its real UID, so refetch must find it and NOT delete.
+        calendar.todos.return_value = []
+        calendar.todo_by_uid.return_value = todo
+        backend._import_calendar_todos(
+            calendar, datetime.now(LOCAL_TIMEZONE), counts)
+
+        calendar.todo_by_uid.assert_called_once_with(self.NON_UUID_UID)
+        self.assertEqual(1, len(backend.datastore.tasks.lookup),
+                         'the task must survive: the server still has it')
+
+
 
 class LocalDeletionPushTest(TestCase):
     """Deleting a task in GTG must delete the matching todo on the


### PR DESCRIPTION
When an active task is absent from a fetch, the backend refetches it
from the server to decide whether it was really deleted there. It asked
with the task's GTG id (`str(task.id)`), but the server knows the task
by its own UID.

Those two only coincide for UUID-shaped server UIDs. `uid_to_task_id`
is deliberately one-way (uuid5), so for any server that issues
non-UUID UIDs — Nextcloud Deck, Evolution, `name@host`… — the GTG id
is a uuid5 the server never emitted. `todo_by_uid` then raises
`NotFoundError` every time, the task is treated as server-deleted, and
`datastore.tasks.remove()` runs: **the task is deleted on every
import.** Silent data loss, exactly on the users with a long
CalDAV-synced history.

The helper for this already exists — `remote_uid()`, which returns the
UID stored at import time and falls back on the id for GTG-created
tasks — it just wasn't wired in here.

**Verified live against a Nextcloud Deck calendar** (cards have
`deck-card-N` UIDs): importing the cards, then dropping one from the
next fetch while the server still holds it, deletes the card on
`master` and preserves it on this branch. Also covered by a
red-before/green-after unit test asserting the refetch asks for the
real UID and the task survives.

Found via a static audit of the CalDAV backend against the current
core; this was its highest-severity finding.