### PR TITLE
WIP: fix FREQ→term parsing in the dormant CalDAV recurrence mapping (groundwork for #645)

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -1015,6 +1015,9 @@ class OrderField(Field):
 
 class Recurrence(Field):
     DAV_DAYS = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']
+    # iCalendar FREQ -> GTG recurring term (see dates.py parsing)
+    FREQ_TO_TERM = {'DAILY': 'day', 'WEEKLY': 'week',
+                    'MONTHLY': 'month', 'YEARLY': 'year'}
 
     def get_gtg(self, task: Task, namespace: str = None) -> tuple:
         return task._is_recurring, task.recurring_term
@@ -1030,7 +1033,9 @@ class Recurrence(Field):
         if interval and freq and interval[0] == '2' and freq[0] == 'DAILY':
             return True, 'other-day'
         if freq:
-            return True, freq[0].lower()[:-2]
+            term = self.FREQ_TO_TERM.get(freq[0])
+            if term:
+                return True, term
         return False, None
 
     def write_dav(self, vtodo: iCalendar, value: tuple):

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -8,6 +8,7 @@ import vobject
 from caldav.lib.error import NotFoundError
 from dateutil.tz import UTC
 from GTG.backends.backend_caldav import (CATEGORIES, CHILDREN_FIELD,
+                                         Recurrence,
                                          DAV_IGNORE, PARENT_FIELD, UID_FIELD,
                                          Backend, DueDateField, SORT_ORDER,
                                          Translator, uid_to_task_id)
@@ -617,6 +618,56 @@ class NonUuidUidRegressionTest(TestCase):
         # the projection decodes back to the exact calendar name
         stem = dav_tags[0][len('DAV_'):]
         self.assertEqual('Deck: Server', stem.replace('_', ' '))
+class RecurrenceRRuleTest(TestCase):
+    """The CalDAV Recurrence field maps between iCalendar RRULE FREQ and
+    GTG recurring terms. Reading a DAILY rule used to go through
+    freq.lower()[:-2], which turns 'WEEKLY'->'week' but 'DAILY'->'dai',
+    a term GTG's date parser doesn't know. Every FREQ we write must read
+    back as a term GTG actually accepts."""
+
+    GTG_TERMS = {'day', 'other-day', 'week', 'month', 'year'}
+
+    def _vtodo_with_rrule(self, **params):
+        cal = vobject.iCalendar()
+        todo = cal.add('vtodo')
+        rrule = todo.add('rrule')
+        rrule.params = {k: (v if isinstance(v, list) else [v])
+                        for k, v in params.items()}
+        return todo
+
+    def test_daily_reads_back_as_a_valid_gtg_term(self):
+        field = Recurrence('rrule', 'get_recurring_term', 'set_recurring')
+        vtodo = self._vtodo_with_rrule(FREQ='DAILY')
+        enabled, term = field.get_dav(vtodo=vtodo)
+        self.assertTrue(enabled)
+        self.assertEqual('day', term)
+        self.assertIn(term, self.GTG_TERMS)
+
+    def test_every_freq_maps_to_a_term_gtg_accepts(self):
+        field = Recurrence('rrule', 'get_recurring_term', 'set_recurring')
+        for freq in ('DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'):
+            vtodo = self._vtodo_with_rrule(FREQ=freq)
+            enabled, term = field.get_dav(vtodo=vtodo)
+            self.assertTrue(enabled, f'{freq} should be recurring')
+            self.assertIn(term, self.GTG_TERMS,
+                          f'{freq} read back as {term!r}, not a GTG term')
+
+    def test_every_other_day_is_recognised(self):
+        field = Recurrence('rrule', 'get_recurring_term', 'set_recurring')
+        vtodo = self._vtodo_with_rrule(FREQ='DAILY', INTERVAL='2')
+        enabled, term = field.get_dav(vtodo=vtodo)
+        self.assertTrue(enabled)
+        self.assertEqual('other-day', term)
+
+    def test_unsupported_freq_is_ignored_not_mangled(self):
+        field = Recurrence('rrule', 'get_recurring_term', 'set_recurring')
+        vtodo = self._vtodo_with_rrule(FREQ='HOURLY')
+        enabled, term = field.get_dav(vtodo=vtodo)
+        self.assertFalse(enabled)
+        self.assertIsNone(term)
+
+
+
 class LocalDeletionPushTest(TestCase):
     """Deleting a task in GTG must delete the matching todo on the
     CalDAV server, otherwise it reappears on the next import.


### PR DESCRIPTION
**Groundwork for the recurrence discussion in #645. Not for merge as-is — help welcome.**

The CalDAV `Recurrence` field maps between iCalendar RRULE `FREQ` and GTG's recurring terms. It's currently commented out of the `Translator` field list, so it isn't active on the sync path yet.

The bug: `get_dav` derived the term with `freq.lower()[:-2]`, which works for `WEEKLY`→`week`, `MONTHLY`→`month`, `YEARLY`→`year`, but turns `DAILY` into `'dai'`, which GTG's date parser doesn't recognise. Replaced with an explicit `FREQ_TO_TERM` table that also ignores unsupported frequencies cleanly.

Red-before/green-after tests cover the round-trip. The wider design question (duplication-on-close vs a rule-based model) should be settled first — see #645, where I've laid out where GTG stands and what the field does now.