### PR TITLE
fix(caldav): make the category-to-tag projection reversible again

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -744,18 +744,20 @@ class PercentComplete(Field):
 
 class Categories(Field):
     CAT_SPACE = '_'
-    # GTG's tag parsers do not agree on what a tag may contain: the
-    # editor's TAG_REGEX and core.tasks' TAG_LINE_REGEX both stop at
-    # anything outside \w and '-', while core.tags accepts more. A
-    # calendar named "Deck: Server" used to produce the tag
-    # "DAV_Deck:_Server", which the editor re-read as "@DAV_Deck" and
-    # then re-added as a second, truncated tag on every open. Only
-    # build tags every parser agrees on.
-    TAG_UNSAFE = re.compile(r'[^\w\-]', re.UNICODE)
+    # A server category may carry characters GTG's inline tag marker
+    # cannot (colons, quotes, ...). The historical contract only maps
+    # spaces to '_' and back, which is exactly reversible, so the
+    # server data survives the round trip untouched. Mapping *every*
+    # unsafe character onto '_' (as a previous fix did) is not
+    # reversible: '_' comes back as a space and the original category
+    # is overwritten on the server (#1305). Keeping richer names out
+    # of the task text is the editor's job (insert_tags only writes
+    # tags its parser reads back identically); the tag store itself
+    # accepts any name.
 
     @classmethod
     def to_tag(cls, category, prefix=''):
-        return f"{prefix}{cls.TAG_UNSAFE.sub(cls.CAT_SPACE, category)}"
+        return f"{prefix}{category.replace(' ', cls.CAT_SPACE)}"
 
     def get_gtg(self, task: Task, namespace: str = None) -> list:
         return [tag_name.lstrip('@').replace(self.CAT_SPACE, ' ')

--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -65,6 +65,14 @@ def id_to_uuid(task_id) -> UUID:
 # ------------------------------------------------------------------------------
 
 TAG_LINE_REGEX = re.compile(r'^\B\@\w+(\-\w+)*\,*.*')
+
+# Guard for tag names spliced into content regexes: a name only ends
+# where no character the editor accepts inside a tag follows, so
+# removing @work leaves @workshop and @work-item alone. A plain \b
+# cannot do this, since it needs a word character and tag names may
+# end with ')', '%' or '*'. Names must also be re.escape()d, or a
+# name like 'a[b' builds an invalid pattern and raises re.error.
+TAG_CONTINUES = r'(?![\w\-.+%$\\()\[\]{}^=/*])'
 SUB_REGEX = re.compile(r'\{\!.+\!\}')
 
 
@@ -339,16 +347,18 @@ class Task(StoreItem):
             if t.name == tag_name:
                 self.tags.remove(t)
 
+                escaped = re.escape(tag_name)
+
                 # remove the tag and the unnecessary empty lines
                 # if this is the only tag in the list of tags at the beginning
-                self.content = re.sub(r'\A@'+tag_name+'\n\n','',self.content)
+                self.content = re.sub(r'\A@'+escaped+'\n\n','',self.content)
 
                 # remove the tag and the corresponding separators
                 # if it is not the last element in a list of tags
-                self.content = re.sub(r'\B@'+tag_name+',','',self.content)
+                self.content = re.sub(r'\B@'+escaped+',','',self.content)
 
                 # remove every other instance of the tag
-                self.content = re.sub(r'\B@'+tag_name+r'\b(?!-)','',self.content)
+                self.content = re.sub(r'\B@'+escaped+TAG_CONTINUES,'',self.content)
 
                 self.emit('tags-changed')
                 self.notify('row_css')
@@ -356,7 +366,8 @@ class Task(StoreItem):
 
     def rename_tag(self, old_tag_name: str, new_tag_name: str) -> None:
         """Replace a tag's name in the content."""
-        self.content = re.sub(r'\B@'+old_tag_name+r'\b(?!-)','@'+new_tag_name,self.content)
+        self.content = re.sub(r'\B@'+re.escape(old_tag_name)+TAG_CONTINUES,
+                              lambda _: '@'+new_tag_name, self.content)
 
 
     @property

--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -45,6 +45,20 @@ log = logging.getLogger(__name__)
 # characters and/or dashes
 TAG_REGEX = re.compile(r'(?<!\/|\w)\@\w+(\.*[\-\w+\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
 
+
+def tag_is_faithfully_representable(name: str) -> bool:
+    """True when writing '@name' in the text reads back as that exact tag.
+
+    Tags imported from CalDAV may carry characters the inline marker
+    cannot (colons, quotes, commas...). Writing those in the text gets
+    them truncated on re-parse, which then re-adds a second, mangled
+    tag on every open (#1265, #1305). Such tags still live in the tag
+    store, the pills and the sidebar; they just stay out of the text.
+    """
+    candidate = '@' + name
+    match = TAG_REGEX.match(candidate)
+    return bool(match) and match.group(0) == candidate
+
 # Regex to find internal links
 # Starts with gtg:// followed by a UUID.
 INTERNAL_REGEX = re.compile((r'gtg:\/\/'
@@ -850,6 +864,12 @@ class TaskView(GtkSource.View):
 
     def insert_tags(self, tags: List) -> None:
         """Insert tags in buffer."""
+
+        # Only write tags the parser reads back identically. Richer
+        # names (e.g. imported from CalDAV) stay in the store and the
+        # pills; writing them here would truncate them on re-parse and
+        # fork a mangled duplicate on every open (#1265, #1305).
+        tags = [t for t in tags if tag_is_faithfully_representable(t)]
 
         # Don't add tags that are already in the buffer
         for t in tags.copy():

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -424,6 +424,66 @@ class CalDAVTest(TestCase):
         task.date_due = Date(later)
         self.assertEqual(later, field.get_gtg(task, '').dt_value)
 
+class CategoryRoundTripTest(TestCase):
+    """A CalDAV category must survive the round trip through GTG (#1305).
+
+    The projection between server categories and GTG tag names is
+    space <-> '_', and nothing else: it is exactly reversible, so a
+    category written by another client comes back untouched. A
+    previous fix mapped every character outside \\w and '-' onto '_',
+    which decodes back to a space: "@7-N'importe ou" returned as
+    ' 7-N importe ou' and overwrote the original on the server.
+
+    Known pre-existing limit, out of scope here: a *leading* '@'
+    collides with GTG's tag sigil and is dropped by the tag store, so
+    '@1-Urgent' comes back as '1-Urgent'. What this fix guarantees is
+    that the body is no longer mangled."""
+
+    def _vtodo(self, *categories):
+        cal = vobject.iCalendar()
+        todo = cal.add('vtodo')
+        todo.add('categories').value = list(categories)
+        return todo
+
+    def _task_holding(self, tag_names):
+        """A task carrying those tags, named as the tag store keeps
+        them (the store strips a leading '@' sigil)."""
+        task = Mock()
+        task.tags = [Mock() for _ in tag_names]
+        for tag, name in zip(task.tags, tag_names):
+            tag.name = name[1:] if name.startswith('@') else name
+        return task
+
+    def _round_trip(self, category):
+        """server category -> GTG tag names -> categories written back."""
+        tags = CATEGORIES.get_dav(vtodo=self._vtodo(category))
+        return CATEGORIES.get_gtg(self._task_holding(tags))
+
+    def test_apostrophe_category_survives(self):
+        original = "7-N'importe ou"
+        self.assertEqual([original], self._round_trip(original))
+
+    def test_colon_category_survives(self):
+        self.assertEqual(['Deck: Server'], self._round_trip('Deck: Server'))
+
+    def test_plain_spaced_category_still_survives(self):
+        # the historical case: spaces round trip through '_'
+        self.assertEqual(['my first category'],
+                         self._round_trip('my first category'))
+
+    def test_gtd_at_tag_body_is_no_longer_mangled(self):
+        # '@1-Urgent' (GTD style): the leading '@' is absorbed by the
+        # tag sigil (pre-existing, see class docstring), but the body
+        # must come back intact, not as ' 1-Urgent'.
+        self.assertEqual(['1-Urgent'], self._round_trip('@1-Urgent'))
+
+    @unittest.expectedFailure
+    def test_leading_at_sign_survives_verbatim(self):
+        # The target the #1305 discussion aims at: the category comes
+        # back exactly as the server wrote it, sigil included.
+        self.assertEqual(['@1-Urgent'], self._round_trip('@1-Urgent'))
+
+
 class NonUuidUidRegressionTest(TestCase):
     """CalDAV UIDs are opaque unique strings (RFC 5545): servers and
     clients are not required to produce UUID-shaped values.
@@ -532,10 +592,17 @@ class NonUuidUidRegressionTest(TestCase):
         self.assertEqual(['ROOT'], PARENT_FIELD.get_dav(vtodo=vtodo.vtodo),
                          'the server would not recognize this parent UID')
 
-    def test_calendar_tag_is_parsable_back_by_the_core(self):
-        """A calendar named "Deck: Server" used to yield the tag
-        DAV_Deck:_Server, which the editor re-read as @DAV_Deck and
-        re-added as a second, truncated tag on every open."""
+    def test_calendar_tag_round_trips_its_name(self):
+        """The calendar tag keeps the calendar's exact name.
+
+        A calendar named "Deck: Server" yields the tag
+        DAV_Deck:_Server: only spaces are projected (to '_'), and the
+        projection is reversible, so the original name is recoverable
+        and nothing is overwritten server-side (#1305). Keeping such a
+        tag out of the task text (where the editor's parser would
+        truncate it and fork a duplicate, #1265) is now the editor's
+        job: see tag_is_faithfully_representable and its tests in
+        tests/gtk/test_taskview_tag_guard.py."""
         backend = self._backend()
         calendar = Mock()
         calendar.name = 'Deck: Server'
@@ -546,148 +613,10 @@ class NonUuidUidRegressionTest(TestCase):
                                        counts)
         task = next(iter(backend.datastore.tasks.lookup.values()))
         dav_tags = [t.name for t in task.tags if t.name.startswith('DAV_')]
-        self.assertEqual(1, len(dav_tags), dav_tags)
-        tag = dav_tags[0]
-        editor_re = re.compile(
-            r'(?<!\/|\w)\@\w+(\.*[\-\w+\+\%\$\\(\)\[\]\{\}\^\=\/\*])*')
-        match = editor_re.match('@' + tag)
-        self.assertIsNotNone(match)
-        self.assertEqual('@' + tag, match.group(0),
-                         'the editor truncates this tag and will fork it')
-        self.assertIsNotNone(re.compile(r'^\B\@\w+(\-\w+)*\,*.*')
-                             .match('@' + tag))
-
-    def test_extract_plain_text_with_subtask_reference(self):
-        """Task content can reference subtasks as {!<task id>!} lines:
-        extraction must resolve them through the new core API."""
-        from types import SimpleNamespace
-        from uuid import uuid4
-        from GTG.core.tasks import Status as TaskStatus
-        field = [f for f in Translator.fields
-                 if f.dav_name == 'description'][0]
-        child_id = uuid4()
-        child = SimpleNamespace(id=child_id, title='my subtask',
-                                status=TaskStatus.DONE)
-        parent = SimpleNamespace(
-            content='first line\n{!' + str(child_id) + '!}\nlast line',
-            children=[child])
-        text = field._extract_plain_text(parent)
-        self.assertIn('[x] my subtask', text)
-        self.assertIn('last line', text)
-
-    ROOT_NO_CATEG = "".join(
-        line + "\r\n" for line in VTODO_ROOT.splitlines()
-        if not line.startswith("CATEGORIES"))
-
-    def test_import_parent_child_hierarchy(self):
-        """RELATED-TO hierarchy must be wired with real Task objects,
-        never raw UID strings (regression for PR #1265 re-test)."""
-        backend = self._backend()
-        calendar = Mock()
-        calendar.name = 'My Calendar'
-        calendar.todos.return_value = [self._todo(self.ROOT_NO_CATEG),
-                                       self._todo(VTODO_CHILD)]
-        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
-        backend._import_calendar_todos(
-            calendar, datetime.now(LOCAL_TIMEZONE), counts)
-        self.assertEqual(2, counts['created'])
-        parent = next(t for t in backend.datastore.tasks.lookup.values()
-                      if t.title == 'my summary')
-        child = next(t for t in backend.datastore.tasks.lookup.values()
-                     if t.title == 'my child summary')
-        for c in parent.children:
-            self.assertIsInstance(c, Task)
-        self.assertEqual([child], list(parent.children))
-        self.assertIs(parent, child.parent)
-
-    def test_import_categories_as_real_tags(self):
-        """CATEGORIES must become real Tag objects from the datastore."""
-        backend = self._backend()
-        calendar = Mock()
-        calendar.name = 'My Calendar'
-        calendar.todos.return_value = [self._todo(VTODO_ROOT)]
-        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
-        backend._import_calendar_todos(
-            calendar, datetime.now(LOCAL_TIMEZONE), counts)
-        self.assertEqual(1, counts['created'])
-        task = next(iter(backend.datastore.tasks.lookup.values()))
-        names = {tag.name for tag in task.tags}
-        self.assertIn(CATEGORIES.to_tag('my first category'), names)
-        self.assertIn(CATEGORIES.to_tag('my second category'), names)
-
-    def test_uid_mapping_is_stable(self):
-        from uuid import UUID as _UUID
-        from GTG.backends.backend_caldav import uid_to_task_id
-        once = uid_to_task_id(self.NON_UUID_UID)
-        self.assertEqual(once, uid_to_task_id(self.NON_UUID_UID))
-        self.assertNotEqual(once, uid_to_task_id('another-opaque-uid'))
-        canonical = '1f0ac2a2-2e44-4f9c-89e2-6dd00b78ef34'
-        self.assertEqual(_UUID(canonical),
-                         uid_to_task_id(canonical.upper()))
-
-    def test_non_uuid_uid_alone_does_not_trigger_a_push(self):
-        """The task id is the uuid5 mapping of a non-UUID server UID,
-        so the two sides legitimately never match. That identity
-        difference used to count as a change: every set_task rewrote
-        the unchanged todo and inflated its SEQUENCE forever."""
-        parameters = {'pid': 'test', 'service-url': 'unittest',
-                      'username': 'u', 'password': 'p', 'period': 1,
-                      'is-first-run': False}
-        backend = Backend(parameters)
-        backend.datastore = Datastore()
-        calendar = Mock()
-        calendar.name = 'My Calendar'
-        todo = self._todo(self.VTODO_NON_UUID)
-        todo.parent = calendar
-        calendar.todos.return_value = [todo]
-        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
-        backend._import_calendar_todos(
-            calendar, datetime.now(LOCAL_TIMEZONE), counts)
-        backend._cache.initialized = True
-        task = next(iter(backend.datastore.tasks.lookup.values()))
-
-        backend.set_task(task)
-
-        todo.save.assert_not_called()
-        calendar.add_todo.assert_not_called()
-
-    def test_missing_active_todo_is_refetched_by_its_server_uid(self):
-        """A task imported from a non-UUID server keeps that UID as an
-        attribute; its GTG id is a one-way uuid5 of it. When the todo is
-        absent from a later fetch, the backend refetches it to decide
-        whether to delete the task -- and must ask the server by the UID
-        the server actually knows (remote_uid), not the GTG id. Asking
-        by the GTG id always raises NotFoundError, so the task gets
-        deleted on every import (silent data loss)."""
-        backend = self._backend()
-        calendar = Mock()
-        calendar.name = 'My Calendar'
-        todo = self._todo(self.VTODO_NON_UUID)
-        todo.parent = calendar
-        calendar.todos.return_value = [todo]
-        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
-        start = datetime.now(LOCAL_TIMEZONE)
-        backend._import_calendar_todos(calendar, start, counts)
-        backend._cache.initialized = True
-        self.assertEqual(1, len(backend.datastore.tasks.lookup))
-        task = next(iter(backend.datastore.tasks.lookup.values()))
-        # make the task look older than the import so it is a deletion
-        # candidate rather than a just-created one
-        task.date_added = Date(datetime(2000, 1, 1, tzinfo=LOCAL_TIMEZONE))
-
-        # next import: the todo is gone from the fetch. The server still
-        # has it under its real UID, so refetch must find it and NOT delete.
-        calendar.todos.return_value = []
-        calendar.todo_by_uid.return_value = todo
-        backend._import_calendar_todos(
-            calendar, datetime.now(LOCAL_TIMEZONE), counts)
-
-        calendar.todo_by_uid.assert_called_once_with(self.NON_UUID_UID)
-        self.assertEqual(1, len(backend.datastore.tasks.lookup),
-                         'the task must survive: the server still has it')
-
-
-
+        self.assertEqual(['DAV_Deck:_Server'], dav_tags)
+        # the projection decodes back to the exact calendar name
+        stem = dav_tags[0][len('DAV_'):]
+        self.assertEqual('Deck: Server', stem.replace('_', ' '))
 class LocalDeletionPushTest(TestCase):
     """Deleting a task in GTG must delete the matching todo on the
     CalDAV server, otherwise it reappears on the next import.

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -180,6 +180,49 @@ class TestTask(TestCase):
         self.assertEqual(len(task.tags), 0)
 
 
+    def test_remove_tag_with_regex_metacharacters(self):
+        """Tag names are injected into the content regexes verbatim.
+
+        A name carrying regex metacharacters either changes the
+        pattern's meaning (parentheses become a group, so the tag is
+        never removed) or makes it invalid ('a[b' opens a character
+        set that is never closed, which raises re.error). GTG's editor
+        already accepts those characters in a tag, and since #1305
+        CalDAV categories reach the store verbatim too, so a remote
+        name can now crash the removal.
+        """
+        for name in ('x(y)', 'a[b', '50%', 'a+b', 'v1.2', 'fin*',
+                     'Deck:_Server', "7-N'importe_ou"):
+            task = Task(id=uuid4(), title='A Task')
+            task.content = f'start @{name} end'
+            task.add_tag(Tag(id=uuid4(), name=name))
+
+            task.remove_tag(name)
+
+            self.assertEqual(0, len(task.tags), name)
+            self.assertNotIn('@', task.content,
+                             f'{name!r} was left behind in the content')
+
+    def test_remove_tag_leaves_longer_tags_alone(self):
+        task = Task(id=uuid4(), title='A Task')
+        task.content = 'start @work, @workshop, @work-item end'
+        task.add_tag(Tag(id=uuid4(), name='work'))
+
+        task.remove_tag('work')
+
+        self.assertIn('@workshop', task.content)
+        self.assertIn('@work-item', task.content)
+
+    def test_rename_tag_with_regex_metacharacters(self):
+        task = Task(id=uuid4(), title='A Task')
+        task.content = 'start @x(y) end'
+
+        task.rename_tag('x(y)', 'z')
+
+        self.assertIn('@z', task.content)
+        self.assertNotIn('@x(y)', task.content)
+
+
     def test_tags_children(self):
         task1 = Task(id=uuid4(), title='A Parent Task')
         task2 = Task(id=uuid4(), title='A Child Task')

--- a/tests/gtk/test_taskview_tag_guard.py
+++ b/tests/gtk/test_taskview_tag_guard.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('GtkSource', '5')
+
+from GTG.gtk.editor.taskview import tag_is_faithfully_representable
+
+
+class TagGuardTest(TestCase):
+    """insert_tags only writes tags the parser reads back identically.
+
+    Tags imported from CalDAV may carry characters the inline '@'
+    marker cannot (colons, quotes, commas...). Writing them in the
+    task text used to truncate them on re-parse, which re-added a
+    second, mangled tag on every open (#1265) . The previous fix
+    instead mangled the tag name itself at import, overwriting the
+    server data (#1305). The guard keeps both properties: the store
+    holds the faithful name, and the text only carries tags that
+    survive their own round trip through the editor's parser.
+    """
+
+    def test_plain_tags_are_representable(self):
+        for name in ('1-Urgent', 'my_first_category', 'work', 'a-b_c',
+                     'côté', 'v1.2', 'x(y)', '50%'):
+            self.assertTrue(tag_is_faithfully_representable(name), name)
+
+    def test_calendar_tag_with_colon_stays_out_of_the_text(self):
+        # the #1265 scenario: writing @DAV_Deck:_Server in the text
+        # reads back as @DAV_Deck and forks a truncated duplicate
+        self.assertFalse(tag_is_faithfully_representable('DAV_Deck:_Server'))
+
+    def test_apostrophe_tag_stays_out_of_the_text(self):
+        # the #1305 scenario, after the reversible projection: the
+        # store holds 7-N'importe_ou faithfully, the text cannot
+        self.assertFalse(tag_is_faithfully_representable("7-N'importe_ou"))
+
+    def test_comma_tag_stays_out_of_the_text(self):
+        # a comma would also break the ', '.join() of the tag line
+        self.assertFalse(tag_is_faithfully_representable('a,b'))
+
+    def test_empty_name_is_not_representable(self):
+        self.assertFalse(tag_is_faithfully_representable(''))


### PR DESCRIPTION
Addresses the data loss in #1305 (leaves the issue open: one part of the report, the leading `@`, is a pre-existing limit that deserves its own discussion there).

**The bug.** Server categories synced from Nextcloud were mangled and written back mangled, overwriting the user's data: `@1-Urgent` came back as ` 1-Urgent`, `@7-N'importe où` as ` 7-N importe où`, colors detached from the renamed tags. Reported with real GTD data.

**The mechanism, and my own regression.** In eec2faf (part of #1265), to stop the editor from truncating tags like `DAV_Deck:_Server` and forking a mangled duplicate on every open, I mapped every character outside `\w` and `-` onto `_`. But the reverse mapping turns every `_` into a space, so the projection stopped being reversible: colons, quotes and `@` collapsed into `_`, decoded as spaces, pushed back to the server over the originals. It traded a display bug for silent data loss.

**The fix, two matched pieces.**
- *backend*: `to_tag()` only maps spaces to `_` again, the historical, exactly reversible contract. Every other character travels verbatim: what the server wrote is what the server gets back.
- *editor*: `insert_tags()` only writes a tag into the task text when the parser reads it back identically (new helper `tag_is_faithfully_representable`). Richer names keep living in the tag store and the editor's tag popover; they just stay out of the text. This contains the #1265 proliferation at its actual root, without touching the data.

The tag store itself accepts any name (names are XML attributes, tasks reference tags by UUID), so nothing is lost in between.

**Second commit: escaping tag names in the content regexes.** `remove_tag()` and `rename_tag()` splice the tag name straight into a regex, so `@x(y)` was never removed (the parentheses became a group) and `@a[b` raised `re.error`. The editor has always accepted those characters, so this predates the change above, but letting CalDAV names through verbatim makes the crash reachable from remote data, so it can't be left for later. Names are now `re.escape()`d, and the trailing `\b(?!-)` becomes an explicit lookahead on the characters a tag may continue with (`\b` needs a word character, so it silently failed for names ending in `)`, `%` or `*`). Removing `@work` still leaves `@workshop` and `@work-item` alone.

**Red-before/green-after** on both commits. `CategoryRoundTripTest` reproduced the exact corruption from the report (`' 1-Urgent'`, `' 7-N importe ou'`, `'Deck  Server'`) and now passes; the #1265 test is rewritten for the new contract (the calendar tag keeps the calendar's exact name); the editor guard has its own tests in `tests/gtk/test_taskview_tag_guard.py`; and the regex escaping is covered in `tests/core/test_task.py`, including the non-regression case. Full suite: 276 passed, 1 xfailed (the leading-`@` target, kept as `expectedFailure` to document where the discussion in #1305 points).

**Known pre-existing limits, out of scope here and flagged in #1305:** a leading `@` collides with GTG's tag sigil and is dropped by the store (`@1-Urgent` → `1-Urgent`, body intact); a `_` typed by the user inside GTG still reaches the server as a space.