### PR TITLE
fix(core): load the 0.6 'Dismiss' status as DISMISSED

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -964,10 +964,18 @@ class TaskStore(BaseStore[Task]):
                             'on the modification date', tid)
                 task.date_added = task.date_modified
 
+            # 0.6 wrote the dismissed status as 'Dismiss'; 0.7 renamed
+            # it to 'Dismissed'. Accept both so migrated files keep
+            # their dismissed tasks (#1308). Set is_active alongside:
+            # set_status() is avoided on purpose here, as it would
+            # overwrite date_closed with today and trigger the
+            # recurrence duplication logic.
             if status == 'Done':
                 task.status = Status.DONE
-            elif status == 'Dismissed':
+                task.is_active = False
+            elif status in ('Dismissed', 'Dismiss'):
                 task.status = Status.DISMISSED
+                task.is_active = False
 
             # Dates
             done_element = dates.find('done')

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -835,3 +835,28 @@ class LoadStoreWithNonUuidIdsTest(TestCase):
         task_store = TaskStore()
         task_store.from_xml(XML(xml), TagStore())
         self.assertIn(canonical, [str(t.id) for t in task_store.lookup.values()])
+
+
+class TestDismissStatusMigration(TestCase):
+    """0.6 files spell the dismissed status 'Dismiss' (#1308)."""
+
+    XML = """<gtgData appVersion="0.6" xmlVersion="2">
+    <taglist/><searchlist/>
+    <tasklist>
+    <task id="9a4bf6dd-0001-4a5c-8f11-000000000001" status="Dismiss" recurring="False">
+    <title>dismissed in 0.6</title>
+    <dates><added>2024-01-01T00:00:00</added><modified>2024-01-02T00:00:00</modified></dates>
+    <recurring enabled="false"><term>None</term></recurring>
+    <subtasks/><tags/><content/>
+    </task>
+    </tasklist>
+    </gtgData>"""
+
+    def test_dismiss_spelling_loads_as_dismissed(self):
+        from lxml import etree
+        from GTG.core.tags import TagStore
+        store = TaskStore()
+        store.from_xml(etree.fromstring(self.XML), TagStore())
+        task = list(store.lookup.values())[0]
+        self.assertEqual(task.status, Status.DISMISSED)
+        self.assertFalse(task.is_active)


### PR DESCRIPTION
Fixes #1308.

A 0.6 data file stores dismissed tasks as `Dismiss`. The loader only matched `Dismissed`, so those tasks silently came back as active after migration (verified on a real 274-task production file: all 8 dismissed tasks resurrected). This accepts both spellings and sets `is_active` alongside, which also makes the dimmed closed-task style consistent. `set_status()` is deliberately not used in the load path, as it would overwrite `date_closed` and trigger recurrence duplication.

Red/green: the included test fails on master (`Dismiss` loads as `ACTIVE`) and passes with the fix. Full `tests/core/test_task.py` suite green (43 passed). Verified live against the production file: the 8 dismissed tasks are back in the Closed tab and the closed rows dim consistently.