### PR TITLE
feat(browser): add a 'Show Empty Tags' toggle in the main menu

### DIFF
--- a/GTG/core/config.py
+++ b/GTG/core/config.py
@@ -53,6 +53,7 @@ DEFAULTS = {
         'autoclean': True,
         'autoclean_days': 30,
         'dark_mode': False,
+        'show_empty_tags': True,
         'maximized': False,
         'sort_mode_open': 'title',
         'sort_mode_active': 'title',

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -348,6 +348,16 @@ class MainWindow(Gtk.ApplicationWindow):
         order_action.connect('change-state', self.on_sort_order)
         self.add_action(order_action)
 
+        show_empty = self.config.get('show_empty_tags')
+        empty_variant = GLib.Variant.new_boolean(show_empty)
+        empty_action = Gio.SimpleAction.new_stateful('show_empty_tags',
+                                                     None,
+                                                     empty_variant)
+
+        empty_action.connect('change-state', self.on_show_empty_tags)
+        self.add_action(empty_action)
+        self.sidebar.set_show_empty_tags(show_empty)
+
     def _init_icon_theme(self):
         """
         sets the deafault theme for icon and its directory
@@ -1134,6 +1144,16 @@ class MainWindow(Gtk.ApplicationWindow):
         else:
             self.get_pane().set_sort_order(reverse=True)
             self.change_sort_icon('DESC')
+
+
+    def on_show_empty_tags(self, action, value) -> None:
+        """Callback when toggling the display of tags without tasks."""
+
+        action.set_state(value)
+        show = value.get_boolean()
+        self.config.set('show_empty_tags', show)
+        self.sidebar.set_show_empty_tags(show)
+
 
     def store_sorting(self, mode: str) -> None:
         """Store sorting mode."""

--- a/GTG/gtk/browser/sidebar.py
+++ b/GTG/gtk/browser/sidebar.py
@@ -158,6 +158,7 @@ class Sidebar(Gtk.ScrolledWindow):
         tags_signals.connect('unbind', self.tags_unbind_cb)
 
         view = Gtk.ListView.new(self.tag_selection, tags_signals)
+        self.tags_view = view
         view.get_style_context().add_class('navigation-sidebar')
         view.set_vexpand(True)
         view.set_hexpand(True)
@@ -213,6 +214,18 @@ class Sidebar(Gtk.ScrolledWindow):
 
         self.tags_filter.pane = pane
         self.tags_filter.changed(Gtk.FilterChange.DIFFERENT)
+
+
+    def set_show_empty_tags(self, value: bool) -> None:
+        """Show or hide tags that have no task in the current pane."""
+
+        self.tags_filter.show_zero = value
+        self.refresh_tags()
+
+        # The bulk splice emitted by the FilterListModel confuses the
+        # list view allocation; re-anchor it at the top to avoid
+        # leaving a gap where the filtered rows used to be.
+        self.tags_view.scroll_to(0, Gtk.ListScrollFlags.NONE, None)
 
 
     @GObject.Signal

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -256,6 +256,10 @@
         <attribute name="action">win.sidebar</attribute>
         <attribute name="label" translatable="yes">Show Sidebar</attribute>
       </item>
+      <item>
+        <attribute name="action">win.show_empty_tags</attribute>
+        <attribute name="label" translatable="yes">Show Empty Tags</attribute>
+      </item>
     </section>
     <section>
       <item>


### PR DESCRIPTION
This implements the proposal from #1310.

Since the GTK4 port the sidebar shows every tag in the store, including tags whose task count for the current pane is zero. Commit bfcb78a8, which fixed #1007, introduced the show_zero field in TagEmptyFilter for exactly this purpose, but the field is hardcoded to True and nothing in the code changes it. In 0.6 the sidebar applied the activetag filter through Tag.is_actively_used(), so tags without active tasks were hidden. Users migrating from 0.6 therefore see their sidebar grow considerably on old datasets, as described in the issue.

The change wires show_zero to a new stateful window action, exposed as a Show Empty Tags check item in the main menu next to Show Sidebar, and persisted in the browser configuration as show_empty_tags. The default is True, so the current 0.7 behavior is preserved exactly for anyone who does not touch the toggle. When unchecked, tags with no task in the current pane are hidden, matching the 0.6 behavior. The filter logic itself is untouched: the toggle only flips the existing field and notifies the filter.

Tested on a real six-year-old dataset migrated from 0.6 (54 tags, 276 tasks): the item appears in the menu, unchecking it hides the 19 tags that only have closed tasks, checking it brings them back, and the state survives a restart. The mechanism is also covered by a red and green check on TagEmptyFilter directly: a tag with zero open and five closed tasks matches by default, stops matching in the open view once show_zero is False, and still matches in the closed view.

Marked as draft pending feedback on #1310, in particular on the placement of the control, since a preference checkbox could be preferred over a menu item. If wanted I can add a line for the release notes.