### PR TITLE
fix(caldav): survive malformed VTODOs instead of aborting the import

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -227,7 +227,8 @@ class Backend(PeriodicImportBackend):
         start = datetime.now()
         self._refresh_calendar_list()
         # browsing calendars
-        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0}
+        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0,
+                  'failed': 0}
         for cal_url, calendar in self._cache.calendars:
             # retrieving todos and updating various cache
             logger.info('Fetching todos from %r', cal_url)
@@ -374,9 +375,41 @@ class Backend(PeriodicImportBackend):
             CHILDREN_FIELD.write_dav(vtodo, [UID_FIELD.get_dav(child)
                                              for child in children])
 
+    @staticmethod
+    def _quarantine_unparsable_todos(todos: list, counts: dict) -> list:
+        """Filter out todos whose data cannot be parsed.
+
+        Calendars are written to by many clients and may contain
+        malformed objects (#1312: a bad folded line gluing PRIORITY
+        onto a datetime value). Parsing is lazy: force it here, object
+        by object, so that a single broken VTODO is skipped and logged
+        instead of aborting the import for the whole calendar. This is
+        a last-resort error boundary, hence the broad except: whatever
+        goes wrong with one object must not take the backend down."""
+        healthy = []
+        for todo in todos:
+            try:
+                todo.instance  # force lazy parsing
+            except Exception:
+                # logging the URL, not the UID: the UID may be exactly
+                # what could not be parsed
+                logger.warning('Skipping unparsable todo at %r',
+                               getattr(todo, 'url', None), exc_info=True)
+                counts['failed'] += 1
+                continue
+            healthy.append(todo)
+        return healthy
+
     def _import_calendar_todos(self, calendar: iCalendar,
                                import_started_on: datetime, counts: dict):
-        todos = calendar.todos(include_completed=not self._cache.initialized)
+        # GTG does its own hierarchical sort below (__sort_todos) and
+        # never uses the order returned by the library. An empty
+        # sort_keys also keeps the library from eagerly parsing every
+        # object just to sort them: with the default keys, one
+        # malformed VTODO on the server aborts the whole import (#1312).
+        todos = calendar.todos(include_completed=not self._cache.initialized,
+                               sort_keys=())
+        todos = self._quarantine_unparsable_todos(todos, counts)
         todo_uids = {str(uid_to_task_id(uid))
                      for uid in (UID_FIELD.get_dav(todo) for todo in todos)
                      if uid}

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -621,6 +621,83 @@ class NonUuidUidRegressionTest(TestCase):
         # the projection decodes back to the exact calendar name
         stem = dav_tags[0][len('DAV_'):]
         self.assertEqual('Deck: Server', stem.replace('_', ' '))
+
+
+class MalformedTodoQuarantineTest(TestCase):
+    """Server data is written by many clients and may be malformed.
+
+    Regression test for #1312: a VTODO with a bad folded line (a
+    continuation line gluing PRIORITY onto a datetime value) made the
+    whole periodic import crash inside the caldav library sorting step.
+    One broken object on the server must not take the backend down."""
+
+    VTODO_HEALTHY = ("BEGIN:VTODO\r\n"
+                     "CREATED:20201212T092155Z\r\n"
+                     "DTSTAMP:20201212T172830Z\r\n"
+                     "LAST-MODIFIED:20201212T172558Z\r\n"
+                     "STATUS:NEEDS-ACTION\r\n"
+                     "SUMMARY:healthy todo\r\n"
+                     "UID:HEALTHY-UID\r\n"
+                     "END:VTODO\r\n")
+
+    class BrokenTodo:
+        """A todo whose lazy parsing fails on first access."""
+
+        url = 'https://my.fa.ke/calendar/broken.ics'
+        parent = None
+
+        @property
+        def instance(self):
+            raise ValueError("Expected datetime, date, or time. "
+                             "Got: '20240808T120000ZPRIORITY:0'")
+
+    @staticmethod
+    def _todo(raw):
+        todo = Mock()
+        todo.instance.vtodo = vobject.readOne(raw)
+        todo.parent.name = 'My Calendar'
+        return todo
+
+    @staticmethod
+    def _backend():
+        parameters = {'pid': 'test', 'service-url': 'unittest',
+                      'username': 'u', 'password': 'p', 'period': 1}
+        backend = Backend(parameters)
+        backend.datastore = Datastore()
+        return backend
+
+    def test_malformed_todo_is_quarantined(self):
+        backend = self._backend()
+        calendar = Mock()
+        calendar.name = 'My Calendar'
+        calendar.todos.return_value = [self._todo(self.VTODO_HEALTHY),
+                                       self.BrokenTodo()]
+        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0,
+                  'failed': 0}
+        start = datetime.now(LOCAL_TIMEZONE)
+        backend._import_calendar_todos(calendar, start, counts)
+        self.assertEqual(1, counts['failed'],
+                         'the broken todo should be counted as failed')
+        self.assertEqual(1, counts['created'],
+                         'the healthy todo should still be imported')
+        self.assertEqual(1, len(backend.datastore.tasks.lookup))
+
+    def test_todos_are_fetched_without_library_sorting(self):
+        """GTG sorts todos itself (__sort_todos): asking the library to
+        sort makes it eagerly parse every object, which is where #1312
+        crashed."""
+        backend = self._backend()
+        calendar = Mock()
+        calendar.name = 'My Calendar'
+        calendar.todos.return_value = []
+        counts = {'created': 0, 'updated': 0, 'unchanged': 0, 'deleted': 0,
+                  'failed': 0}
+        backend._import_calendar_todos(
+            calendar, datetime.now(LOCAL_TIMEZONE), counts)
+        _, kwargs = calendar.todos.call_args
+        self.assertEqual((), kwargs.get('sort_keys'))
+
+
 class RecurrenceRRuleTest(TestCase):
     """The CalDAV Recurrence field maps between iCalendar RRULE FREQ and
     GTG recurring terms. Reading a DAILY rule used to go through


### PR DESCRIPTION
Draft for #1312, opened while the design discussion in the issue is ongoing — see the diagnosis comment there for the full mechanism and the caldav version compatibility check.

## The bug

One malformed VTODO on the server (a bad folded line gluing `PRIORITY:0` onto a datetime value) crashed the entire periodic import inside the caldav library's sorting step, making the backend unusable. The data is genuinely invalid per RFC 5545 and both icalendar 6.x and 7.x rightly refuse it; the GTG bug is the all-or-nothing failure mode, not the parsing.

## The fix, two independent layers

**1. `sort_keys=()`** — GTG already does its own hierarchical sort (`__sort_todos`) and never uses the order returned by the library. Dropping the redundant library sort also removes the eager mass parsing that was the crash site. The empty tuple is falsy on every caldav version from 0.11.0 to 3.2.1 (checked, including 1.4.0 as pinned in our flatpak manifest), so no version branching.

**2. Per-object quarantine** — parsing is now lazy, so it is forced object by object before the import loop: a broken VTODO is skipped with a warning (logging its server URL — the UID may itself be what could not be parsed), counted in `counts['failed']`, and the import carries on with the healthy tasks. This boundary stays valid even if the parsing path changes later (the vobject `.instance` shim is deprecated in caldav 3.x), and the structured counter leaves room for the new synchronization UI (#897) to surface skipped tasks in 0.8.

**Deliberate non-goal**: no repair/normalization of malformed data before parsing — that would mean maintaining a fragile half-parser and would hide the corruption instead of surfacing it.

## Tests

Red/green demonstrated: without the fix, the new `MalformedTodoQuarantineTest` crashes exactly like the report; with it, the healthy todo is imported, the broken one is counted as failed, and `calendar.todos` is asserted to be called without library sorting. Full caldav test suite passes (30 passed, 1 pre-existing xfail).

Fixes #1312