### PR TITLE
fix(core): refuse a second parent claim instead of corrupting the tree

### DIFF
--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -221,6 +221,22 @@ class BaseStore(GObject.Object,Generic[S]):
             raise KeyError("parent_id is not in store: "+str(parent_id))
 
         item = self.lookup[item_id]
+
+        if item.parent is not None:
+            if item.parent.id == parent_id:
+                return
+            # Multi-parenting is not supported in the new core, but real
+            # 0.6 data files can claim the same task as subtask of
+            # several parents (#1307). Honoring the second claim used to
+            # overwrite item.parent and leave the child in several
+            # children lists at once, an inconsistent tree. The first
+            # parent wins; moving an item requires unparent() first, as
+            # every UI call site already does.
+            log.warning('Refusing to parent %s to %s: already a child of '
+                        '%s (first parent wins, see #1307)',
+                        item_id, parent_id, item.parent.id)
+            return
+
         item.parent = self.lookup[parent_id]
 
         try:

--- a/tests/core/test_base_store.py
+++ b/tests/core/test_base_store.py
@@ -136,6 +136,57 @@ class TestBaseStoreParent(TestCase):
 
 
 
+class TestBaseStoreDoubleParenting(TestCase):
+    """A child claimed by several parents must not corrupt the tree.
+
+    Regression tests for #1307: the second claim used to overwrite
+    item.parent and append the child to the new parent's children
+    without detaching it from the first one, leaving the child in
+    several children lists at once. Multi-parenting is not legitimate
+    in the new core: the first parent wins, further claims are refused
+    with a warning."""
+
+
+    def setUp(self):
+        self.store = BaseStore()
+
+        self.parent1 = StoreItem(uuid4())
+        self.parent2 = StoreItem(uuid4())
+        self.child = StoreItem(uuid4())
+
+        self.store.add(self.parent1)
+        self.store.add(self.parent2)
+        self.store.add(self.child)
+        self.store.parent(self.child.id,self.parent1.id)
+
+
+    def test_second_claim_keeps_first_parent(self):
+        self.store.parent(self.child.id,self.parent2.id)
+        self.assertEqual(self.child.parent,self.parent1)
+
+
+    def test_second_claim_does_not_update_new_parent_children(self):
+        self.store.parent(self.child.id,self.parent2.id)
+        self.assertTrue(self.child not in self.parent2.children)
+
+
+    def test_second_claim_keeps_child_in_first_parent_children(self):
+        self.store.parent(self.child.id,self.parent2.id)
+        self.assertEqual(self.parent1.children.count(self.child),1)
+
+
+    def test_second_claim_does_not_update_root_elements(self):
+        self.store.parent(self.child.id,self.parent2.id)
+        self.assertEqual(self.store.count(root_only=True),2)
+
+
+    def test_reclaim_by_same_parent_is_idempotent(self):
+        self.store.parent(self.child.id,self.parent1.id)
+        self.assertEqual(self.parent1.children.count(self.child),1)
+        self.assertEqual(self.child.parent,self.parent1)
+        self.assertEqual(self.store.count(root_only=True),2)
+
+
 class TestBaseStoreUnparent(TestCase):
 
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -491,6 +491,88 @@ class TestTask(TestCase):
         self.assertEqual(len(task_store.get(TASK_ID_1).children), 2)
 
 
+    def test_xml_load_multiparented_sub_first_parent_wins(self):
+        """Regression test for #1307: real 0.6 data files can list the
+        same task as <sub> of several parents (the bryce sample does,
+        36 times). Loading such a file must not corrupt the tree: the
+        first parent wins, further claims are refused."""
+        task_store = TaskStore()
+
+        TASK_ID_1 = uuid4()
+        TASK_ID_2 = uuid4()
+        TASK_ID_3 = uuid4()
+
+        parsed_xml = XML(f'''
+        <tasklist>
+            <task id="{TASK_ID_1}" status="Active" recurring="False">
+                <title>First parent</title>
+                <dates>
+                    <added>2020-10-23T00:00:00</added>
+                    <modified>2021-03-20T14:55:46.219761</modified>
+                    <done></done>
+                    <fuzzyDue></fuzzyDue>
+                    <start>2010-07-20</start>
+                </dates>
+                <recurring enabled="false">
+                    <term>None</term>
+                </recurring>
+                <subtasks>
+                    <sub>{TASK_ID_3}</sub>
+                </subtasks>
+
+                <content><![CDATA[ My Content ]]></content>
+            </task>
+
+            <task id="{TASK_ID_2}" status="Active" recurring="False">
+                <title>Second parent claiming the same child</title>
+                <dates>
+                    <added>2020-10-23T00:00:00</added>
+                    <modified>2021-03-20T14:55:46.219761</modified>
+                    <done></done>
+                    <fuzzyDue></fuzzyDue>
+                    <start>2010-07-20</start>
+                </dates>
+                <recurring enabled="false">
+                    <term>None</term>
+                </recurring>
+                <subtasks>
+                    <sub>{TASK_ID_3}</sub>
+                </subtasks>
+
+                <content><![CDATA[ My Content ]]></content>
+            </task>
+
+            <task id="{TASK_ID_3}" status="Active" recurring="False">
+                <title>Child claimed twice</title>
+                <dates>
+                    <added>2020-10-23T00:00:00</added>
+                    <modified>2021-03-20T14:55:46.219761</modified>
+                    <done></done>
+                    <fuzzyDue></fuzzyDue>
+                    <start>2010-07-20</start>
+                </dates>
+                <recurring enabled="false">
+                    <term>None</term>
+                </recurring>
+                <subtasks/>
+                <content><![CDATA[ My Content ]]></content>
+            </task>
+        </tasklist>
+        ''')
+
+        task_store.from_xml(parsed_xml, None)
+
+        child = task_store.get(TASK_ID_3)
+        first = task_store.get(TASK_ID_1)
+        second = task_store.get(TASK_ID_2)
+
+        self.assertEqual(task_store.count(), 3)
+        self.assertEqual(child.parent, first)
+        self.assertEqual(first.children.count(child), 1)
+        self.assertTrue(child not in second.children)
+        self.assertEqual(task_store.count(root_only=True), 2)
+
+
     def test_xml_load_bad(self):
         task_store = TaskStore()
 


### PR DESCRIPTION
First part of the fix agreed with Diego on #1307 (the bryce sample cleanup will come as a separate PR).

## The bug

Real 0.6 data files can list the same task as `<sub>` of several parents: the bryce sample does it 36 times, and it came from a real database. `BaseStore.parent()` honored every claim: the second one overwrote `item.parent`, failed `self.data.remove` (producing the misleading `item not found in data` error first seen while investigating #109: the item exists, it just is not a root anymore), and `add_child` appended the child to the new parent without detaching it from the previous one. The child ended up in several children lists at once while `parent` pointed at the last claimer — an inconsistent tree, built silently at load time.

## The fix

Multi-parenting was a liblarch feature, never exposed to the UI, and deliberately dropped from the new core (see Diego's confirmation in the issue). `parent()` now enforces that decision: **the first parent wins**, a further claim for a different parent is refused with an accurate warning, and a re-claim by the same parent is a silent no-op. Moving an item still works through `unparent()` first — which is what every UI call site already does (task and tag drag-and-drop, multi-selection reparenting all call `unparent()` before `parent()`), so no behavior change for healthy flows.

## Tests

Red/green demonstrated at two levels: new unit tests on `BaseStore` reproduce the corruption exactly (parent overwritten, child duplicated into the second parent's children, the same `item not found in data` log as on bryce), and an integration test loads an XML file where two tasks claim the same `<sub>` — the bryce scenario. Full test suite passes (287 passed, 1 pre-existing xfail).

@nekohayo regarding your question whether this could explain #1153 and #924: quite possibly for some occurrences — both are `get_parents`-flavored crashes on inconsistent objects, and this bug did build inconsistent trees from valid-looking files. I would suggest retesting them once this lands rather than closing them blindly; I can help with that.

Fixes #1307