### PR TITLE
chore(data): remove multi-parent subtask claims from the bryce sample

### DIFF
--- a/data/test-data/bryce/xdg/data/gtg/gtg_tasks.xml
+++ b/data/test-data/bryce/xdg/data/gtg/gtg_tasks.xml
@@ -505,7 +505,6 @@ m mmmmmmmmmmmmmmmmmmmmmmm</content>
 		<startdate>2010-04-19</startdate>
 		<donedate>2010-04-27</donedate>
 		<subtask>312@1</subtask>
-		<subtask>67@1</subtask>
 		<content>mmmmmm mmmmmmmmmmmmmmmmm
  mmmmmmmmmmmmmmmmmmmmmmmm
  </content>
@@ -1471,13 +1470,11 @@ m </content>
 		<title>mmmm mmm mmmmmmm mmmmm mmm mmmm mmmmmmmmm</title>
 		<modified>2010-05-02T19:45:41</modified>
 		<startdate>2010-05-01</startdate>
-		<subtask>261@1</subtask>
 	</task>
 	<task id="261@1" status="Active" tags="@gtg" uuid="b9692c76-5f4c-4490-8fe0-a0b1879ba700">
 		<title>mmmmmmm mmmmm mm mmmm mmmmmmmm mmmmmm mm mmmmmmmm</title>
 		<modified>2010-05-02T19:45:47</modified>
 		<startdate>2010-05-01</startdate>
-		<subtask>259@1</subtask>
 	</task>
 	<task id="262@1" status="Done" tags="@gtg" uuid="c506c1f2-403f-4d03-9500-c7db3a840e52">
 		<title>mmmmmm mmmmmmmm mmm mmmmmmmmm</title>
@@ -2804,7 +2801,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmmm mmmm mmmm mm mmmmmmm mmmmm mmm m mmmmmm mmmmmmmmm mmmm mmm mm mmm mmmmmmmmmm mmmm</title>
 		<modified>2010-04-26T11:33:06</modified>
 		<startdate>2010-02-23</startdate>
-		<subtask>1180@1</subtask>
 		<content>mmmmm
 
 m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
@@ -2876,13 +2872,11 @@ m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmm mmmmmmmmmmmmm mmmmmm mm mmmm mmmmmmmm mmm mm mmmmmm</title>
 		<modified>2010-03-14T23:39:58</modified>
 		<startdate>2010-03-15</startdate>
-		<subtask>606@1</subtask>
 	</task>
 	<task id="608@1" status="Active" tags="@arsenal" uuid="57cd2481-2efd-4fa2-91cd-2957f574a70b">
 		<title>mmmmmm mmm mmmmmmm mm mmmmm mmmmmmm mm mmmmmm</title>
 		<modified>2010-03-14T23:39:58</modified>
 		<startdate>2010-03-15</startdate>
-		<subtask>606@1</subtask>
 	</task>
 	<task id="618@1" status="Active" tags="@x,@goal-x-tech-depth" uuid="321b37e6-a7b5-4489-983f-5441deb12aa6">
 		<title>mmm mm mmmmmmmm mm mmm mm mmmm mmmmmmmm mmmmmm</title>
@@ -3318,7 +3312,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 	<task id="757@1" status="Active" tags="@webserver" uuid="3677ddaf-c3b5-4b15-a51c-cbd1c17bcc20">
 		<title>mmmm mmm mmmmmmmmmmmm mmmmmmm</title>
 		<modified>2010-04-05T10:53:39</modified>
-		<subtask>480@1</subtask>
 		<subtask>758@1</subtask>
 		<subtask>761@1</subtask>
 		<subtask>764@1</subtask>
@@ -3757,7 +3750,6 @@ m
 		<modified>2010-04-14T18:34:28</modified>
 		<startdate>2010-04-10</startdate>
 		<donedate>2010-04-14</donedate>
-		<subtask>831@1</subtask>
 		<subtask>956@1</subtask>
 		<content>mmmmmmmmmmmmmm
 
@@ -3970,7 +3962,6 @@ m </content>
 		<startdate>2010-04-13</startdate>
 		<subtask>1034@1</subtask>
 		<subtask>197@1</subtask>
-		<subtask>917@1</subtask>
 		<content>mmmmmmmmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmmm
  mmmmmmmmmmmmmmmmmmmmmmmm
@@ -5541,7 +5532,6 @@ m mmmmmm</content>
 	<task id="1161@1" status="Active" tags="@webserver" uuid="73029bc6-10ce-43f6-ac6a-a7e356050d62">
 		<title>mmmm mmm mmmmmmmm mmmm mmmm mmmmmm mmm mmmmmm</title>
 		<modified>2010-02-23T11:59:00</modified>
-		<subtask>1158@1</subtask>
 	</task>
 	<task id="1162@1" status="Active" tags="@webserver" uuid="3fba3405-9e77-49f5-8008-02275671a239">
 		<title>mmmm mmmmm mmmmmmm</title>
@@ -5591,7 +5581,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm
 		<title>mmmmmmmmm m mmmm mmmm mmmmmm</title>
 		<modified>2010-06-14T14:01:11</modified>
 		<startdate>2010-06-21</startdate>
-		<subtask>1166@1</subtask>
 		<content>mmmmm
 
 m mmmmmmmmmmmmmmmmmmmmmmmmm
@@ -5602,7 +5591,6 @@ mmmmmmmmm mm mmmmmm mm mm mmmmmmmm mmmmmmm mm mmm mmmm mmmmmmm</content>
 		<title>mmmmmmmmm m mmmmmmmmm mmmmmm mmmm mmmmmm</title>
 		<modified>2010-05-04T12:57:13</modified>
 		<startdate>2010-06-29</startdate>
-		<subtask>1166@1</subtask>
 	</task>
 	<task id="1169@1" status="Done" tags="@gtg" uuid="e9dba12f-d9f3-473d-8039-1d1ba8bf2cde">
 		<title>mmmmmmmmmm mmmm mmm mmmmmmm mmmmmmmmmm mmmmmm</title>
@@ -5628,7 +5616,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<subtask>579@1</subtask>
 		<subtask>1174@1</subtask>
 		<subtask>1175@1</subtask>
-		<subtask>1180@1</subtask>
 		<subtask>293@1</subtask>
 		<content>mmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm
@@ -5642,7 +5629,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmmm mmmmmmmmmm mmmm mmmmmmmmm m mmmm</title>
 		<modified>2010-04-05T10:50:36</modified>
 		<startdate>2010-02-24</startdate>
-		<subtask>1180@1</subtask>
 		<content>mmmmm
 
 mmmmm mmmmm mm mmmmm mmmmmmm m mmmmmm mmmmm mmm mmm mmm mmmmmm mm mmmm mmmmmmmmmm mmmm mmmmmmmmmm mm mmm mmmmm  mmmmmmmmm
@@ -5656,7 +5642,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmmm mmmmmmmmm mm mmmmmmmmmm mmmmm mmmm mmmmmm mmmmmm mmmmmm</title>
 		<modified>2010-02-24T10:44:46</modified>
 		<startdate>2010-02-24</startdate>
-		<subtask>1180@1</subtask>
 	</task>
 	<task id="1176@1" status="Active" tags="@x" uuid="75a8e7b7-f872-4e11-9138-eb3388426187">
 		<title>mmm mmmmmmmm mm mmmmmmmmm mmm mmmmm</title>
@@ -6123,7 +6108,6 @@ m </content>
 		<modified>2010-04-07T19:23:11</modified>
 		<startdate>2010-03-15</startdate>
 		<donedate>2010-04-07</donedate>
-		<subtask>1217@1</subtask>
 		<subtask>1793@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmm
 
@@ -6160,7 +6144,6 @@ m </content>
 		<modified>2010-03-23T18:07:43</modified>
 		<startdate>2010-03-22</startdate>
 		<donedate>2010-03-23</donedate>
-		<subtask>1218@1</subtask>
 		<subtask>1714@1</subtask>
 		<content>mmmmmmmm
 
@@ -6265,7 +6248,6 @@ m </content>
 		<startdate>2010-03-15</startdate>
 		<donedate>2010-04-02</donedate>
 		<subtask>1324@1</subtask>
-		<subtask>1325@1</subtask>
 		<subtask>1326@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmm mmm
 m mmmmmmmmmmmmmmmmmmmmmmmmm
@@ -7010,7 +6992,6 @@ m  mmmmm mmmm mmmmmmm</content>
 		<modified>2010-03-25T17:01:25</modified>
 		<startdate>2010-03-22</startdate>
 		<donedate>2010-03-25</donedate>
-		<subtask>1324@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmm </content>
 	</task>
 	<task id="1365@1" status="Active" tags="@arsenal" uuid="7307ce8b-ef89-4e40-a0c0-a23be718d5fb">
@@ -7650,7 +7631,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmm mmmmm mmm mmmmmm mmmm</title>
 		<modified>2010-03-11T16:49:23</modified>
 		<donedate>2010-03-11</donedate>
-		<subtask>570@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmm
 m mmmmmmm mmmm mmmmm mm mmm
 m mmmmmmmmm mmmmmmmmm mmmm
@@ -7761,7 +7741,6 @@ m mmmmmm mmmmmmmm mmm mmmmmmmm mm mm mmmmmmmm</content>
 		<title>mmmmmmm mmmm mm mmmmmmm</title>
 		<modified>2010-03-07T23:12:38</modified>
 		<donedate>2010-03-07</donedate>
-		<subtask>1449@1</subtask>
 		<content>mmmmmmmmmmm
 
 m mmmmmmmmmmmmmmmmmmmmmmmmm
@@ -8314,7 +8293,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<modified>2010-03-18T01:10:27</modified>
 		<startdate>2010-03-17</startdate>
 		<donedate>2010-03-18</donedate>
-		<subtask>1483@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmm </content>
 	</task>
 	<task id="1475@1" status="Active" tags="@webserver" uuid="77ddfb22-38f2-446d-ac5f-2d183840a225">
@@ -9498,18 +9476,15 @@ m mmmmm mmmmmm</content>
 	<task id="1560@1" status="Active" tags="@webserver" uuid="8666c11a-2855-4870-a4d2-df1a34b6f668">
 		<title>mmmmmm mmmmmmmmmmmm mmmmmmmm mm mmm m mmmmm mmmmm mm mmmmmm</title>
 		<modified>2010-03-14T17:42:30</modified>
-		<subtask>1561@1</subtask>
 	</task>
 	<task id="1561@1" status="Active" tags="@webserver" uuid="60d983be-7897-4619-824d-bfddbbf79a67">
 		<title>mmm mm mmmmm mmmmmmm mmmmmmm mm mmmmmm</title>
 		<modified>2010-06-08T00:24:13</modified>
 		<startdate>2010-06-29</startdate>
-		<subtask>759@1</subtask>
 	</task>
 	<task id="1562@1" status="Active" tags="@webserver" uuid="8b213fd4-03a2-484a-a48b-c2e08bffa782">
 		<title>mmmmmmm mmmmmmm mmmmmm mmmm mmmmmm</title>
 		<modified>2010-03-14T17:42:35</modified>
-		<subtask>1561@1</subtask>
 	</task>
 	<task id="1563@1" status="Active" tags="@webserver" uuid="575a2c96-f25a-48e7-b4d4-ee945c421a07">
 		<title>mmmmm mmmmm mmm mm mmmmmm mmmmm mmmmmm mm mmmmmm mmmmmmm</title>
@@ -9598,7 +9573,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmm mm mmmmmmm mmm mmmmmm mmmmmmm</title>
 		<modified>2010-03-21T16:37:47</modified>
 		<startdate>2010-04-04</startdate>
-		<subtask>1572@1</subtask>
 		<subtask>1570@1</subtask>
 	</task>
 	<task id="1572@1" status="Done" tags="@denali" uuid="ef36e755-d3cd-4544-8954-4c07478f8427">
@@ -10200,7 +10174,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmm mmmmmmm mmmmmmm mm mmmmmmm mmmm mmmmm mmmmmm mmm  mmmmm mmmm mm mm mmmmmmmmm</title>
 		<modified>2010-03-21T15:41:40</modified>
 		<donedate>2010-03-21</donedate>
-		<subtask>1620@1</subtask>
 		<content>mmmmmmmmmm
 
 
@@ -10210,7 +10183,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmmm mmm mmmmm mm mm mmmmmmmm  mmmmmmmm</title>
 		<modified>2010-03-21T15:26:51</modified>
 		<donedate>2010-03-21</donedate>
-		<subtask>1620@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmmm
 
  mmmmmmmmmmmmmmmmmmmmmmmmm</content>
@@ -10456,7 +10428,6 @@ mmmmmmmmmmmmmmm mmm mmmmmmm mm mmmmmmmmm mmmmmm mmmmmm mmm mmm mm mm mmm mmmmm m
 		<title>mmmmm mmmmmmmmmmmmmmm mm mmmm mmmmmm mmm mmmm mmmm</title>
 		<modified>2010-04-19T14:51:53</modified>
 		<startdate>2010-04-01</startdate>
-		<subtask>1781@1</subtask>
 		<content>mmmmmmmmmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 	</task>
@@ -12749,20 +12720,17 @@ m mmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmmmmm mmm mm mmmmm mm mmmmmmmmmmmm mmmmmmmm</title>
 		<modified>2010-04-04T15:52:52</modified>
 		<startdate>2010-04-02</startdate>
-		<subtask>1860@1</subtask>
 	</task>
 	<task id="1860@1" status="Active" tags="@personal" uuid="d045ae63-7dc7-4463-a7d4-c1339693918b">
 		<title>mmmmmmm mmm mm mmmmm mm mmmmmmmmmmmm mmmmmmmm</title>
 		<modified>2010-04-04T15:52:57</modified>
 		<startdate>2010-04-02</startdate>
-		<subtask>1861@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmmm </content>
 	</task>
 	<task id="1861@1" status="Active" tags="@personal" uuid="a94a92ea-32f7-4dd2-aa1b-c5e40c86ee04">
 		<title>mmmmmmm mmm mm mmmmm mm mmmmmmmmmmmm mmmmmmmm</title>
 		<modified>2010-04-14T12:30:12</modified>
 		<startdate>2010-06-13</startdate>
-		<subtask>1862@1</subtask>
 	</task>
 	<task id="1862@1" status="Done" tags="@personal" uuid="2a2da228-dcc5-43ad-8421-c9fa8cf47ca8">
 		<title>mmmmmmm mmm mm mmmmm mm mmmmmmmmmmmm mmmmmmmm</title>
@@ -12826,7 +12794,6 @@ m mmmm mmmmm mmmmmmmm mmmmmmm  mmmmmm mm mmmmm mmm mmm</content>
 		<modified>2010-04-13T11:26:55</modified>
 		<startdate>2010-04-05</startdate>
 		<donedate>2010-04-12</donedate>
-		<subtask>14@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmm
 
 m mmmmmmmmmmmmmmmmmmmmmmm</content>
@@ -12835,13 +12802,11 @@ m mmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmm mm mmmmmmmmm mmmmmmmmmmmmm mmm mmmmmmm mmmmmmm mmmm</title>
 		<modified>2010-04-05T11:58:53</modified>
 		<startdate>2010-04-05</startdate>
-		<subtask>12@1</subtask>
 	</task>
 	<task id="12@1" status="Active" tags="@dutch" uuid="e27fc353-f031-468e-94cd-001445defbb7">
 		<title>mmmmmmmmmmm mmmm mmm mmmmmmmmmmmm mmm mmmmmmm mmmmmmm mmmm</title>
 		<modified>2010-06-13T20:38:26</modified>
 		<startdate>2010-06-20</startdate>
-		<subtask>9@1</subtask>
 		<content>mmmmmmm
 
 m mmmmmmmmmmmmmmmmmmmmmm</content>
@@ -14226,7 +14191,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<modified>2010-05-24T17:50:24</modified>
 		<startdate>2010-05-24</startdate>
 		<donedate>2010-05-24</donedate>
-		<subtask>244@1</subtask>
 		<content>mmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm
 
@@ -14482,7 +14446,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 	<task id="276@1" status="Active" tags="@crucible" uuid="4b91fb3c-e102-4734-83a5-f1a919da2f30">
 		<title>mmmmmmmmmmmmm mmm mm mmmmmmm mmmmmmmm mmmmmm</title>
 		<modified>2010-04-17T14:29:30</modified>
-		<subtask>275@1</subtask>
 		<content>mmmmmmmmmm
 
 m mmmmmm mmmmmmmmm
@@ -16627,7 +16590,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmm mmmmm mm mmmmmmm mmmm mm mmmmmmmmmmmmmm mmm mmm mmmmmmmm</title>
 		<modified>2010-06-10T19:14:24</modified>
 		<startdate>2010-06-15</startdate>
-		<subtask>858@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 	</task>
@@ -17166,7 +17128,6 @@ mmmmmmm mmmmmmmmmmmmm mmmmmm mmmmmm mmmm</content>
 		<title>mmmm mmmm mmmmmmmmmm mmmmmmmm mmm mmmmmmmmmmm</title>
 		<modified>2010-06-14T14:02:14</modified>
 		<startdate>2010-06-21</startdate>
-		<subtask>1578@1</subtask>
 		<content>mmmmmmmmm
 m mm m mmmmm mmmmmm m mmm mmmm mmm mmm mmmmmmmm mmmm mmmmmm mmmm mmm mmmm mmm mmmmm  mmm m mmmmm mmmmm mmmmmmm mmmmmmmmm mmmmmmmmm mmmm mmmm mm mmmmmm mmmmmmmmmm
 
@@ -17268,7 +17229,6 @@ m mmmmmmm mmmmmmmmm mmmm</content>
 		<modified>2010-06-14T18:28:09</modified>
 		<startdate>2010-06-14</startdate>
 		<donedate>2010-06-14</donedate>
-		<subtask>877@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 	</task>
@@ -17905,7 +17865,6 @@ m </content>
 		<title>mmmmmmmmmmm mmmmmmm mmmmm mmmmmm</title>
 		<modified>2010-06-10T19:14:03</modified>
 		<startdate>2010-06-17</startdate>
-		<subtask>877@1</subtask>
 		<content>mmmmmmmm
 
 mm mmmmmmm mmmmmmmmm mmmmm
@@ -18655,7 +18614,6 @@ mmmmm mmmmmmm</content>
 		<modified>2010-06-14T23:22:45</modified>
 		<startdate>2010-06-15</startdate>
 		<subtask>713@1</subtask>
-		<subtask>877@1</subtask>
 		<subtask>999@1</subtask>
 		<content>mmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm
@@ -18932,7 +18890,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmm mmmmmmmmmm mmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<modified>2010-05-26T15:17:48</modified>
 		<startdate>2010-05-26</startdate>
 		<donedate>2010-05-26</donedate>
-		<subtask>741@1</subtask>
 		<content>mmmmmmmmmmm
 
 
@@ -19974,7 +19931,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 		<title>mmmmmmmmmmm mm mm mmm mmmmmmmmmm mmmm mm mmmmmmmm mmmmmmmmmm mmmmmmm mm mmm mmmmm</title>
 		<modified>2010-06-14T23:22:51</modified>
 		<startdate>2010-06-15</startdate>
-		<subtask>877@1</subtask>
 	</task>
 	<task id="843@1" status="Active" tags="@launchpad" uuid="0cf2309d-ae2c-4427-8da4-14daf4445aee">
 		<title>mmmmmmmmmmmmm mmm mmmmmmm mmmm mmmmm mmmm mmmm mmmmmmmmmmm mmmmmmm mmmmmmmmmm</title>
@@ -20062,7 +20018,6 @@ mmm mmmm mmmmm mmmm mm mmmmm mm mm mmmm mmmmmmmmmmmmmm mmmmmm mmmmm mmmmmmmmmmmm
 		<modified>2010-05-28T15:28:38</modified>
 		<startdate>2010-05-26</startdate>
 		<donedate>2010-05-28</donedate>
-		<subtask>877@1</subtask>
 		<content>mmmmmmmmmmm
 
 m mmmmmm mmmm mmm mmmm mm mm mmm mmmmmmm mmm mmmmmmmmmm mmm mmmm
@@ -20563,7 +20518,6 @@ m mmmm mm mmmmmmm mmmmmm mm mmmmm mmm mmm mm mmm mmmm mmmm</content>
 		<title>mm mmmmmmmm mmmmmmmmmmm mmmmm mmm mmmm</title>
 		<modified>2010-06-10T19:14:24</modified>
 		<startdate>2010-06-15</startdate>
-		<subtask>858@1</subtask>
 		<content>mmmmmmmmmmmmmmmmmmmm
 m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 	</task>
@@ -20606,7 +20560,6 @@ m mmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<modified>2010-06-07T12:49:15</modified>
 		<startdate>2010-06-07</startdate>
 		<donedate>2010-06-07</donedate>
-		<subtask>877@1</subtask>
 		<content>mmmmmmmmmmm
 
 m mmmmmm mmm mmmm mmmm mmmm mmm
@@ -21083,7 +21036,6 @@ m mmmmmm mmmmmmmm mmmmmmmm mmm mm mm mmmm mm mmmmmmm mmmm mmmmmm mmmmm mmmmmm</c
 	<task id="914@1" status="Active" tags="@blog" uuid="c4b2fb81-77f5-4c95-9e7e-068c27d60da9">
 		<title>mmmm mmmmm mmm mmmmmmm mmmmmmmmm</title>
 		<modified>2010-06-05T00:17:51</modified>
-		<subtask>974@1</subtask>
 		<content>mmmmmm
 
 m mmm mmm mmmm mm mmmm mmmmmmmmmm mmmmmmm mmmmmmmmmm mmmmm mm mm mmmm mmmm mmmm m mm mmmmmmmmmmm mm mmmm mmm mmmmmmmm mm mmm mmmmmmmm mmmm mmmmmmmm
@@ -21744,7 +21696,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</content>
 		<title>mmmm mmmmmmmmm mm mm mmmm mmm mmmmmm mm mmmmm mm mm mmmmmm</title>
 		<modified>2010-06-05T00:18:04</modified>
 		<startdate>2010-06-01</startdate>
-		<subtask>974@1</subtask>
 	</task>
 	<task id="969@1" status="Active" tags="@arsenal" uuid="73c44434-1dfd-4018-a6fa-317221943012">
 		<title>mmmmmmm mmmmmmmmmmmmmmmmmmmmmmmmmmm mmmmm</title>
@@ -21824,7 +21775,6 @@ mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 	<task id="980@1" status="Active" tags="@webserver" uuid="91315d09-30b2-4317-af35-a8b7621cbcd0">
 		<title>mmmmm m mmmmmmmmmm mmmmm mm mmmmmmmmm m mmm mmmmmmmmmmmmmmmmm</title>
 		<modified>2010-06-05T00:26:16</modified>
-		<subtask>981@1</subtask>
 		<content>mmmmmmmmmmm
 mmmmm mmm mmmmm mm mmm mmmmm mm mmmmmmmmm mmmmm mm mmmm mmm</content>
 	</task>


### PR DESCRIPTION
Second part of the fix agreed with Diego on #1307 (the loader hardening is #1314; the two are independent and can land in any order).

## What

The bryce sample listed 36 tasks as `<subtask>` of more than one parent — 50 excess claims in total, up to 7 parents for a single task. Multi-parenting was never exposed to the UI and was deliberately dropped from the new core, so these entries only exercised the tree corruption documented in #1307 and produced `item not found in data` errors on every load of the sample.

## How

Cleanup policy matches the hardening in #1314: the first parent in document order wins, every later claim for the same child is removed. The diff is pure line deletions — 50 `<subtask>` lines removed, nothing else touched (no reformatting, no declaration change).

## Verification

- The file stays valid XML: 659 → 609 `<subtask>` entries, 0 multi-parent claims remaining, 0 ghost references
- Loaded live on the 1771-task dataset: zero `item not found in data` occurrences (previously one per excess claim), tree displays normally, the 36 affected tasks keep their first parent