### PR TITLE
fix(core): repair backup purge targeting, then archive old dailies with gzip (#443)

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -18,6 +18,7 @@
 
 """The datastore ties together all the basic type stores and backends."""
 
+import gzip
 import os
 import re
 import threading
@@ -443,15 +444,68 @@ class Datastore:
         if not os.path.exists(daily_backup):
             shutil.copy(path, daily_backup)
 
-        self.purge_backups(path)
+        self.archive_old_backups(path)
 
 
     # Dated daily backups: gtg_data.xml.2026-08-02.bak
     DAILY_BACKUP_RE = re.compile(r'\.\d{4}-\d{2}-\d{2}\.bak$')
 
     @staticmethod
+    def archive_old_backups(path: str, days: int = 30) -> None:
+        """Compress dated daily backups older than X days (#443).
+
+        Instead of deleting history, old daily backups are gzipped in
+        place (XML compresses to a few percent of its size), keeping a
+        space-efficient long-term archive. The compressed copy is read
+        back and compared before the original is removed: on any
+        failure the plain file is left untouched and will be retried
+        on the next run. Archives (.gz) are never removed
+        automatically."""
+
+        cutoff = time() - days * 86_400
+        backup_dir = os.path.dirname(Datastore.get_backup_path(path))
+
+        try:
+            filenames = os.listdir(backup_dir)
+        except FileNotFoundError:
+            return
+
+        for filename in filenames:
+            if not Datastore.DAILY_BACKUP_RE.search(filename):
+                continue
+
+            filepath = os.path.join(backup_dir, filename)
+            archive_path = filepath + '.gz'
+
+            try:
+                if os.stat(filepath).st_mtime >= cutoff:
+                    continue
+
+                with open(filepath, 'rb') as plain:
+                    original = plain.read()
+
+                with gzip.open(archive_path, 'wb') as archive:
+                    archive.write(original)
+
+                # Never delete the plain copy before proving the
+                # archive holds the exact same bytes.
+                with gzip.open(archive_path, 'rb') as archive:
+                    if archive.read() != original:
+                        raise IOError('archive verification failed')
+
+                os.remove(filepath)
+            except OSError as error:
+                log.warning('Could not archive backup %r: %r',
+                            filepath, error)
+
+    @staticmethod
     def purge_backups(path: str, days: int = 30) -> None:
         """Remove dated daily backups older than X days.
+
+        Not called automatically anymore: write_backups archives old
+        dailies instead of deleting them (#443). Kept as a manual
+        cleanup helper. Compressed archives (*.bak.gz) are not
+        matched and always survive.
 
         Only the dated daily backups (*.YYYY-MM-DD.bak) inside the
         backup directory are subject to age-based removal. The rotating

--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -19,6 +19,7 @@
 """The datastore ties together all the basic type stores and backends."""
 
 import os
+import re
 import threading
 import logging
 import shutil
@@ -445,21 +446,41 @@ class Datastore:
         self.purge_backups(path)
 
 
+    # Dated daily backups: gtg_data.xml.2026-08-02.bak
+    DAILY_BACKUP_RE = re.compile(r'\.\d{4}-\d{2}-\d{2}\.bak$')
+
     @staticmethod
     def purge_backups(path: str, days: int = 30) -> None:
-        """Remove backups older than X days."""
+        """Remove dated daily backups older than X days.
 
-        now = time()
-        day_in_secs = 86_400
-        basedir = os.path.dirname(path)
+        Only the dated daily backups (*.YYYY-MM-DD.bak) inside the
+        backup directory are subject to age-based removal. The rotating
+        .bak.0 to .bak.N copies are managed by count in write_backups
+        and must survive long periods without opening the app, and the
+        data directory itself must never be touched: it can contain
+        the pre-migration 0.6 files (gtg_tasks.xml, tags.xml,
+        projects.xml) among others."""
 
-        for filename in os.listdir(basedir):
-            filename = os.path.join(basedir, filename)
-            filestamp = os.stat(filename).st_mtime
-            filecompare = now - (days * day_in_secs)
+        cutoff = time() - days * 86_400
+        backup_dir = os.path.dirname(Datastore.get_backup_path(path))
 
-            if filestamp < filecompare:
-                os.remove(filename)
+        try:
+            filenames = os.listdir(backup_dir)
+        except FileNotFoundError:
+            return
+
+        for filename in filenames:
+            if not Datastore.DAILY_BACKUP_RE.search(filename):
+                continue
+
+            filepath = os.path.join(backup_dir, filename)
+
+            try:
+                if os.stat(filepath).st_mtime < cutoff:
+                    os.remove(filepath)
+            except OSError as error:
+                log.warning('Could not purge backup %r: %r',
+                            filepath, error)
 
 
     def find_and_load_file(self, path: str) -> None:

--- a/tests/core/test_datastore_backups.py
+++ b/tests/core/test_datastore_backups.py
@@ -120,3 +120,66 @@ class TestPurgeBackups(BackupDirTestCase):
         shutil.rmtree(self.backup_dir)
 
         Datastore.purge_backups(self.main)  # must not raise
+
+
+class TestArchiveOldBackups(BackupDirTestCase):
+    """#443: old daily backups are gzipped, not deleted."""
+
+
+    def test_old_daily_is_gzipped_with_identical_content(self):
+        import gzip
+        old_daily = self._daily('2025-01-01', OLD)
+        original = open(old_daily, 'rb').read()
+
+        Datastore.archive_old_backups(self.main)
+
+        self.assertFalse(os.path.exists(old_daily),
+                         'plain copy removed after successful archive')
+        with gzip.open(old_daily + '.gz', 'rb') as archive:
+            self.assertEqual(original, archive.read())
+
+
+    def test_recent_daily_stays_plain(self):
+        recent_daily = self._daily('2026-08-01', RECENT)
+
+        Datastore.archive_old_backups(self.main)
+
+        self.assertTrue(os.path.exists(recent_daily))
+        self.assertFalse(os.path.exists(recent_daily + '.gz'))
+
+
+    def test_rotating_baks_are_never_archived(self):
+        rotating = self._write(
+            os.path.join(self.backup_dir, 'gtg_data.xml.bak.3'), OLD)
+
+        Datastore.archive_old_backups(self.main)
+
+        self.assertTrue(os.path.exists(rotating))
+        self.assertFalse(os.path.exists(rotating + '.gz'))
+
+
+    def test_archives_survive_archive_and_purge_runs(self):
+        archive = self._write(
+            os.path.join(self.backup_dir, 'gtg_data.xml.2024-01-01.bak.gz'),
+            OLD)
+
+        Datastore.archive_old_backups(self.main)
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(archive))
+
+
+    def test_archive_survives_missing_backup_dir(self):
+        shutil.rmtree(self.backup_dir)
+
+        Datastore.archive_old_backups(self.main)  # must not raise
+
+
+    def test_write_backups_archives_old_dailies(self):
+        old_daily = self._daily('2025-01-01', OLD)
+
+        datastore = Datastore()
+        datastore.write_backups(self.main)
+
+        self.assertFalse(os.path.exists(old_daily))
+        self.assertTrue(os.path.exists(old_daily + '.gz'))

--- a/tests/core/test_datastore_backups.py
+++ b/tests/core/test_datastore_backups.py
@@ -1,0 +1,122 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) 2008-2026 - the GTG contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import os
+import time
+import shutil
+import tempfile
+from unittest import TestCase
+
+from GTG.core.datastore import Datastore
+
+
+OLD = time.time() - 40 * 86_400
+RECENT = time.time() - 2 * 86_400
+
+
+class BackupDirTestCase(TestCase):
+    """Common scaffolding: a fake data directory with its backup/ dir."""
+
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.data_dir = os.path.join(self.root, 'gtg')
+        self.backup_dir = os.path.join(self.data_dir, 'backup')
+        os.makedirs(self.backup_dir)
+        self.main = os.path.join(self.data_dir, 'gtg_data.xml')
+        self._write(self.main)
+
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+
+    def _write(self, filepath, mtime=None, content='<data/>'):
+        with open(filepath, 'w') as filedesc:
+            filedesc.write(content)
+        if mtime:
+            os.utime(filepath, (mtime, mtime))
+        return filepath
+
+
+    def _daily(self, date, mtime=OLD):
+        name = f'gtg_data.xml.{date}.bak'
+        return self._write(os.path.join(self.backup_dir, name), mtime)
+
+
+class TestPurgeBackups(BackupDirTestCase):
+    """Regression tests for the purge targeting the wrong directory.
+
+    purge_backups() used to walk the data directory instead of the
+    backup directory: dated daily backups were never removed, while
+    any file older than the cutoff in the data directory was silently
+    deleted, including the pre-migration 0.6 files of users coming
+    from 0.6."""
+
+
+    def test_purge_does_not_touch_data_directory(self):
+        for name in ('gtg_tasks.xml', 'tags.xml', 'projects.xml'):
+            self._write(os.path.join(self.data_dir, name), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        for name in ('gtg_tasks.xml', 'tags.xml', 'projects.xml'):
+            self.assertTrue(
+                os.path.exists(os.path.join(self.data_dir, name)),
+                f'{name} must survive: the data directory is not a backup')
+
+
+    def test_purge_removes_old_dated_dailies(self):
+        old_daily = self._daily('2025-01-01', OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertFalse(os.path.exists(old_daily))
+
+
+    def test_purge_keeps_recent_dailies(self):
+        recent_daily = self._daily('2026-08-01', RECENT)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(recent_daily))
+
+
+    def test_purge_keeps_rotating_baks_regardless_of_age(self):
+        rotating = self._write(
+            os.path.join(self.backup_dir, 'gtg_data.xml.bak.3'), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(rotating),
+                        'rotating copies are managed by count, not age')
+
+
+    def test_purge_ignores_foreign_files_in_backup_dir(self):
+        foreign = self._write(
+            os.path.join(self.backup_dir, 'notes.txt'), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(foreign))
+
+
+    def test_purge_survives_missing_backup_dir(self):
+        shutil.rmtree(self.backup_dir)
+
+        Datastore.purge_backups(self.main)  # must not raise


### PR DESCRIPTION
Draft pending design validation on #443 — two commits, deliberately separable:

**Commit 1 — the purge fix** (see #1316 for the full story): `purge_backups()` pruned the data directory instead of `backup/`. Dated dailies were never removed, and files older than 30 days in the data directory — including 0.6 migrants' pre-migration files — were silently deleted. The purge now targets `backup/`, matches only dated daily backups, never touches the rotating `.bak.0-N` copies (managed by count, and they must survive long periods without opening the app), and logs instead of crashing. If the archival design below needs more discussion, this commit can be cherry-picked on its own — the data-loss half is the urgent part.

**Commit 2 — #443, the archival**: `write_backups` now gzips dailies older than 30 days instead of deleting them (design rationale posted on #443). Byte-for-byte verification before removing any plain file; `.gz` archives kept forever; automatic restore path untouched.

**Tests**: 12 new tests in `tests/core/test_datastore_backups.py`, red/green demonstrated for the purge bug (both faces: data directory survival, old dailies removal). Full suite passes (293 passed, 1 pre-existing xfail). Also verified live: a staged data directory with 0.6 leftover files and a 40-day-old daily goes through `write_backups` with the leftovers intact and the old daily gzipped byte-identical.

Fixes #1316. Closes #443 if the design is accepted.