### PR TITLE
fix(editor): keep indented subtask bullets from leaking into the title

### DIFF
--- a/GTG/gtk/editor/taskview.py
+++ b/GTG/gtk/editor/taskview.py
@@ -59,6 +59,26 @@ def tag_is_faithfully_representable(name: str) -> bool:
     match = TAG_REGEX.match(candidate)
     return bool(match) and match.group(0) == candidate
 
+
+def subtask_bullet_span(text: str):
+    """Locate the "- " subtask bullet on a line, tolerating indentation.
+
+    Returns (offset, title) where offset is the number of characters to
+    delete from the start of the line (leading whitespace plus the "- ")
+    and title is the subtask name, or None when the line is not a subtask
+    bullet. Computing both from the same stripped position keeps the
+    buffer deletion and the stored title consistent, so an indented
+    bullet no longer leaks its leading whitespace into the task title.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith('- '):
+        return None
+    title = stripped[2:]
+    if not title:
+        return None
+    offset = (len(text) - len(stripped)) + 2
+    return offset, title
+
 # Regex to find internal links
 # Starts with gtg:// followed by a UUID.
 INTERNAL_REGEX = re.compile((r'gtg:\/\/'
@@ -327,16 +347,22 @@ class TaskView(GtkSource.View):
         # </subtask>
 
         # Add a new subtask
-        if text.lstrip().startswith('- ') and len(text[2:]) > 0:
-            # Remove the -
+        bullet = subtask_bullet_span(text)
+        if bullet is not None:
+            bullet_offset, title = bullet
+
+            # Remove the leading whitespace and the "- ". The offset is
+            # computed once so the buffer deletion and the subtask title
+            # stay consistent even when the line is indented (otherwise the
+            # leading whitespace leaked into the stored title).
             delete_end = start.copy()
-            delete_end.forward_chars(2)
+            delete_end.forward_chars(bullet_offset)
             self.buffer.begin_irreversible_action()
             self.buffer.delete(start, delete_end)
             self.buffer.end_irreversible_action()
 
             # Add new subtask
-            task = self.new_subtask_cb(text[2:])
+            task = self.new_subtask_cb(title)
             status = task.status if task else Status.ACTIVE
 
             # Add the checkbox

--- a/tests/gtk/test_taskview_subtask_bullet.py
+++ b/tests/gtk/test_taskview_subtask_bullet.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('GtkSource', '5')
+
+from GTG.gtk.editor.taskview import subtask_bullet_span
+
+
+class SubtaskBulletTest(TestCase):
+    """The "- " bullet removal must be consistent with its detection.
+
+    detect_subtasks() accepts a bullet line after leading whitespace
+    (text.lstrip().startswith('- ')), but the removal used to cut a
+    fixed 2 characters from the raw line and build the title from
+    text[2:]. On an indented bullet those 2 characters were not the
+    "- ", so the leftover whitespace or dash leaked into the stored
+    <title> (e.g. a line " - sousou" produced the title " sousou").
+    subtask_bullet_span() computes the offset and the title from the
+    same stripped position, keeping them in sync.
+    """
+
+    def test_plain_bullet(self):
+        self.assertEqual(subtask_bullet_span('- sousou'), (2, 'sousou'))
+
+    def test_single_indented_bullet(self):
+        # regression: used to yield the title ' sousou'
+        self.assertEqual(subtask_bullet_span(' - sousou'), (3, 'sousou'))
+
+    def test_double_indented_bullet(self):
+        # regression: used to yield the title '- sousou'
+        self.assertEqual(subtask_bullet_span('  - sousou'), (4, 'sousou'))
+
+    def test_tab_indented_bullet(self):
+        self.assertEqual(subtask_bullet_span('\t- tabbed'), (3, 'tabbed'))
+
+    def test_title_keeps_inner_content(self):
+        # only the leading whitespace and the first "- " are stripped:
+        # a genuine second dash typed by the user stays in the title
+        self.assertEqual(subtask_bullet_span('- - dashed'), (2, '- dashed'))
+
+    def test_not_a_bullet(self):
+        self.assertIsNone(subtask_bullet_span('just text'))
+
+    def test_bullet_without_title_is_ignored(self):
+        self.assertIsNone(subtask_bullet_span('- '))
+        self.assertIsNone(subtask_bullet_span('   - '))
+
+    def test_dash_without_space_is_not_a_bullet(self):
+        self.assertIsNone(subtask_bullet_span('-nospace'))


### PR DESCRIPTION
Fixes #1319.

`detect_subtasks()` accepts a `- ` bullet after leading whitespace (`text.lstrip().startswith('- ')`), but the removal cut a fixed 2 characters from the raw line and built the title from `text[2:]`. On an indented bullet those 2 characters were not the `- `, so the leftover whitespace or dash leaked into the stored `<title>`: a line ` - sousou` produced the title ` sousou`, and `  - sousou` produced `- sousou`. Confirmed as persisted data in `gtg_data.xml`, not just a display glitch.

The bullet span (leading whitespace + `- `) and the title are now computed once from the same stripped position in a small pure helper, `subtask_bullet_span()`, so the buffer deletion and the title stay in sync regardless of indentation. A genuine second dash typed by the user (`- - foo`) is preserved in the title.

**Tests**: 8 unit tests in `tests/gtk/test_taskview_subtask_bullet.py`, following the display-less pattern of `test_taskview_tag_guard.py`. Red/green verified (the indented cases fail without the fix). Full suite: 295 passed, 1 xfailed. Also verified live on master: typing ` - test` in an editor stores the title `test` cleanly, with correct parenting confirmed in the XML.