### PR TITLE
Fix CalDAV configuration dialog crashes (#1323, completes #1322)

### DIFF
--- a/GTG/gtk/backends/backendstree.py
+++ b/GTG/gtk/backends/backendstree.py
@@ -113,6 +113,11 @@ class BackendsTree(Gtk.TreeView):
             b_iter = self.backendid_to_iter[backend_id]
             b_path = self.liststore.get_path(b_iter)
             backend = self.ds.get_backend(backend_id)
+            if not backend:
+                # The backend was removed between the signal and this
+                # callback (e.g. a failed account being torn down);
+                # nothing left to refresh in the row.
+                return
             backend_name = backend.get_human_name()
             self.liststore[b_path][self.COLUMN_TEXT] = backend_name
             self.liststore[b_path][self.COLUMN_ENABLED] = backend.is_enabled()

--- a/GTG/gtk/backends/configurepanel.py
+++ b/GTG/gtk/backends/configurepanel.py
@@ -40,6 +40,12 @@ class ConfigurePanel(Gtk.Box):
         self.should_spinner_be_shown = False
         self.task_deleted_handle = None
         self.task_added_handle = None
+        # No backend is selected until set_backend() is called, but the
+        # signals below are global (they fire for every backend, e.g. a
+        # CalDAV account syncing in the background) and can reach this
+        # panel before then. Keep the attribute defined so the handlers
+        # can bail out cleanly instead of raising AttributeError.
+        self.backend = None
         self.ds = ds
         self._create_widgets()
         self._connect_signals()
@@ -135,6 +141,8 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param data: not used, here only for signal callback compatibility
         """
+        if self.backend is None:
+            return
         markup = "<big><big><big><b>%s</b></big></big></big>" % \
             self.backend.get_human_name()
         self.human_name_label.set_markup(markup)
@@ -170,6 +178,8 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param data: not used, here only for signal callback compatibility
         """
+        if self.backend is None:
+            return
         self.refresh_sync_button()
         self.refresh_sync_status_label()
 
@@ -191,7 +201,7 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param backend_id: the id of the backend that emitted this signal
         """
-        if backend_id == self.backend.get_id():
+        if self.backend is not None and backend_id == self.backend.get_id():
             self.spinner_set_active(True)
 
     def on_sync_ended(self, sender, backend_id):
@@ -203,7 +213,7 @@ class ConfigurePanel(Gtk.Box):
         @param backend_id: the id of the backend that emitted this signal
         """
 
-        if backend_id == self.backend.get_id():
+        if self.backend is not None and backend_id == self.backend.get_id():
             self.spinner_set_active(False)
 
     def on_spinner_show(self, sender):

--- a/GTG/gtk/colors.py
+++ b/GTG/gtk/colors.py
@@ -80,8 +80,6 @@ def background_color(tags, bgcolor=None, galpha_scale=1, use_alpha=True):
     if not bgcolor:
         bgcolor = Gdk.RGBA()
         bgcolor.parse("#FFFFFF")
-    if type(bgcolor) is Gdk.Color: # TODO remove on gtk4 port, caused by liblarch
-        bgcolor = Gdk.RGBA.from_color(bgcolor)
     # Compute color
     my_color = None
     color_count = 0.0
@@ -89,7 +87,7 @@ def background_color(tags, bgcolor=None, galpha_scale=1, use_alpha=True):
     green = 0
     blue = 0
     for my_tag in tags:
-        my_color_str = my_tag.get_attribute("color")
+        my_color_str = my_tag.color
         if my_color_str is not None and my_color_str not in used_color:
             used_color.append(my_color_str)
         if my_color_str:
@@ -125,12 +123,18 @@ def get_colored_tag_markup(ds, tag_name, html=False):
     tag name
     if html, returns a string insertable in html
     """
-    tag = ds.tags.find(tag_name)
+    try:
+        tag = ds.tags.find(tag_name)
+    except KeyError:
+        # The name is attached to a backend but no longer in the store
+        # (e.g. the tag was deleted): find() raises KeyError rather than
+        # returning None, so a stale attached tag must not crash markup.
+        tag = None
     if tag is None:
         # no task loaded with that tag, color cannot be taken
         return tag_name
     else:
-        tag_color = tag.get_attribute("color")
+        tag_color = tag.color
         if tag_color:
             if html:
                 format_string = '<span style="color:%s">%s</span>'

--- a/GTG/gtk/editor/text_tags.py
+++ b/GTG/gtk/editor/text_tags.py
@@ -238,7 +238,7 @@ class TaskTagTag(Gtk.TextTag):
         """Change tag appareance when hovering."""
 
         try:
-            color = self.tag.get_attribute('color') or '#EBDB34'
+            color = self.tag.color or '#EBDB34'
             self.set_property('background', color)
         except AttributeError:
             self.set_property('background', '#EBDB34')

--- a/tests/gtk/test_backends_signal_guards.py
+++ b/tests/gtk/test_backends_signal_guards.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest import TestCase, skipUnless
+
+import gi
+gi.require_version('Gdk', '4.0')
+gi.require_version('Gtk', '4.0')
+
+from gi.repository import Gdk, Gtk
+
+from GTG.gtk.backends.backendstree import BackendsTree
+from GTG.gtk.backends.configurepanel import ConfigurePanel
+
+try:
+    _init_ok = Gtk.init_check()
+except Exception:
+    _init_ok = False
+DISPLAY_OK = bool(_init_ok) and Gdk.Display.get_default() is not None
+
+
+def _fake_backend(backend_id='backend@1'):
+    return SimpleNamespace(
+        get_id=lambda: backend_id,
+        get_icon=lambda: 'gtg-symbolic',
+        get_human_name=lambda: 'TestService',
+        is_enabled=lambda: True,
+        is_default=lambda: False,
+        get_attached_tags=lambda: [])
+
+
+@skipUnless(DISPLAY_OK, 'needs a display')
+class BackendsTreeStateChangeGuardTest(TestCase):
+    """on_backend_state_changed must survive a backend that vanished.
+
+    The row can still be listed while the backend itself is already
+    gone from the datastore (a failed CalDAV account being torn down,
+    #1322). get_backend() then returns None and the callback used to
+    call None.get_human_name(), crashing the backends dialog. The other
+    callbacks in this file (add_backend, on_backend_added) already guard
+    against a missing backend; this one now does too."""
+
+    def _tree(self):
+        live = {'backend': _fake_backend()}
+        ds = SimpleNamespace(
+            get_all_backends=lambda disabled=False: (
+                [live['backend']] if live['backend'] else []),
+            get_backend=lambda backend_id: live['backend'],
+            tags=SimpleNamespace(find=lambda name: None))
+        tree = BackendsTree(SimpleNamespace(ds=ds))
+        return tree, live
+
+    def test_state_change_on_present_backend(self):
+        tree, _live = self._tree()
+        # Sanity: the row was built and refreshed during construction.
+        self.assertIn('backend@1', tree.backendid_to_iter)
+
+    def test_state_change_after_backend_removed(self):
+        tree, live = self._tree()
+        live['backend'] = None  # datastore no longer knows this backend
+        # Must not raise even though the row id is still tracked.
+        tree.on_backend_state_changed(None, 'backend@1')
+
+
+@skipUnless(DISPLAY_OK, 'needs a display')
+class ConfigurePanelSignalGuardTest(TestCase):
+    """The configure panel's global signal handlers must tolerate the
+    'no backend selected yet' state.
+
+    BACKEND_SYNC_STARTED / _ENDED (and rename / state-toggle) are global
+    signals: a CalDAV account syncing in the background fires them for
+    every open panel, including one whose set_backend() has not run yet.
+    self.backend was then undefined and each callback raised
+    AttributeError in a flood (#1323, #1324). self.backend now defaults
+    to None and every handler bails out cleanly."""
+
+    def _panel(self):
+        ds = SimpleNamespace()
+        return ConfigurePanel(SimpleNamespace(ds=ds), ds)
+
+    def test_backend_defaults_to_none(self):
+        panel = self._panel()
+        self.assertIsNone(panel.backend)
+
+    def test_sync_started_without_backend(self):
+        panel = self._panel()
+        panel.on_sync_started(None, 'backend@1')
+
+    def test_sync_ended_without_backend(self):
+        panel = self._panel()
+        panel.on_sync_ended(None, 'backend@1')
+
+    def test_refresh_title_without_backend(self):
+        panel = self._panel()
+        panel.refresh_title()
+
+    def test_refresh_sync_status_without_backend(self):
+        panel = self._panel()
+        panel.refresh_sync_status()

--- a/tests/gtk/test_colors_tag_markup.py
+++ b/tests/gtk/test_colors_tag_markup.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest import TestCase
+
+import gi
+gi.require_version('Gdk', '4.0')
+gi.require_version('Gtk', '4.0')
+
+from GTG.core.tags import TagStore
+from GTG.gtk.colors import (background_color, get_colored_tag_markup,
+                            get_colored_tags_markup)
+
+
+class ColoredTagMarkupTest(TestCase):
+    """Tag coloring must read the Tag.color property, not the removed
+    get_attribute() API.
+
+    The new GTK4 core turned tag attributes into GObject properties:
+    a Tag no longer answers get_attribute("color"), it exposes .color.
+    colors.py kept calling the old method, so every code path that
+    renders an attached tag with a color raised AttributeError. In the
+    backends dialog that meant a flood of tracebacks as soon as a
+    CalDAV account was configured to sync a tag (#1323, #1324); in the
+    task editor the same call was swallowed by a broad except, silently
+    falling back to a default color (tags never showed their real one).
+    """
+
+    def _ds_with_tags(self):
+        store = TagStore()
+        red = store.new('red')
+        red.color = '#ff0000'
+        store.new('plain')  # color stays None by default
+        return SimpleNamespace(tags=store)
+
+    def test_colored_tag_gets_pango_span(self):
+        ds = self._ds_with_tags()
+        self.assertEqual(get_colored_tag_markup(ds, 'red'),
+                         '<span color="#ff0000">red</span>')
+
+    def test_colored_tag_gets_html_span(self):
+        ds = self._ds_with_tags()
+        self.assertEqual(get_colored_tag_markup(ds, 'red', html=True),
+                         '<span style="color:#ff0000">red</span>')
+
+    def test_uncolored_tag_is_plain_name(self):
+        ds = self._ds_with_tags()
+        self.assertEqual(get_colored_tag_markup(ds, 'plain'), 'plain')
+
+    def test_missing_tag_is_plain_name(self):
+        # A name still attached to a backend but gone from the store:
+        # TagStore.find() raises KeyError rather than returning None,
+        # which used to crash the backends dialog when it colored the
+        # attached-tag list (#1323).
+        ds = self._ds_with_tags()
+        self.assertEqual(get_colored_tag_markup(ds, 'ghost'), 'ghost')
+        # and the same through the list helper the dialog actually calls
+        self.assertEqual(get_colored_tags_markup(ds, ['ghost']), 'ghost')
+
+    def test_markup_for_list_does_not_raise(self):
+        ds = self._ds_with_tags()
+        markup = get_colored_tags_markup(ds, ['red', 'plain'])
+        self.assertIn('red', markup)
+        self.assertIn('plain', markup)
+
+    def test_background_color_reads_color_property(self):
+        # background_color() iterates real Tag objects and used to hit
+        # the same removed get_attribute("color"); it must now derive a
+        # color from a colored tag instead of raising.
+        ds = self._ds_with_tags()
+        color = background_color([ds.tags.find('red')])
+        self.assertIsNotNone(color)
+        self.assertTrue(color.startswith('#'))


### PR DESCRIPTION
Two distinct crashes hit the backend configuration dialog around CalDAV. This PR fixes both.

## 1. Flood of tracebacks when syncing by tag (#1323)

**Symptom:** configuring a CalDAV account to sync only certain tags triggered a cascade of AttributeError.

**Mechanism:** the GTK4 port turned tag attributes into GObject properties. A Tag no longer answers `get_attribute("color")`, it exposes `.color`. `colors.py` and the editor still called the removed method, raising AttributeError on every tag-color render. In the backends dialog this surfaced as a flood of tracebacks as soon as an account was set to sync a tag.

**Fix:** read `.color` instead of `get_attribute("color")`. While here, drop the dead GTK3 `Gdk.Color` branch (it does not exist under GTK4 and was itself raising, hidden by a broad except), and guard `find()`, which now raises KeyError rather than returning None.

## 2. Crash when removing a failed account (completes #1322)

**Symptom:** removing a broken CalDAV account raised an AttributeError that left the user stuck.

**Mechanism:** `on_backend_state_changed` looked up the backend by id then called `get_human_name()` on it, but a removed account can already be gone from the datastore by the time the callback runs (`get_backend` returns None). Likewise, `ConfigurePanel` connects global signals that can reach a panel whose `set_backend()` has not run, with `self.backend` undefined.

**Fix:** guard against a missing backend in the callback, default `self.backend` to None, and bail out cleanly from the handlers when no backend is selected.

## Tests

Red-before / green-after demonstrated, unit tests added (`test_colors_tag_markup.py`, `test_backends_signal_guards.py`), verified live on a real CalDAV account (sync-by-tag with no traceback, account removal with no crash).

@nekohayo having reported these crashes from the field, a retest on your side under real conditions would be especially welcome before merge.