### PR TITLE
Fix CalDAV sync crashes on auth failure and offline edits (#1322, #1324)

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -29,12 +29,14 @@ from gettext import gettext as _
 from hashlib import md5
 
 import caldav
+import requests
 from dateutil.tz import UTC
 from GTG.backends.backend_signals import BackendSignals
 from GTG.backends.generic_backend import GenericBackend
 from GTG.backends.periodic_import_backend import PeriodicImportBackend
 from GTG.core.dates import LOCAL_TIMEZONE, Accuracy, Date
 from GTG.core.interruptible import interruptible
+from GTG.core.networkmanager import is_connection_up
 from GTG.core.tasks import Task, Status as TaskStatus
 from vobject import iCalendar
 
@@ -89,6 +91,25 @@ def remote_uid(task: Task, namespace: str) -> str:
     """
     return (task.get_attribute(REMOTE_UID_ATTR, namespace=namespace)
             or str(task.id))
+
+
+def _dav_failure_errno(error):
+    """Map a raised exception to the BackendSignals error code that best
+    describes it, or None when it is not a known CalDAV failure and must
+    propagate untouched.
+
+    AuthorizationError is checked first on purpose: it is a subclass of
+    DAVError. Anything that is a transport problem (a requests error such
+    as a refused connection or DNS failure, or any other DAV protocol
+    error) is reported as a network failure, which the GUI shows as a
+    transient warning and the periodic timer will retry on its own.
+    """
+    if isinstance(error, caldav.lib.error.AuthorizationError):
+        return BackendSignals.ERRNO_AUTHENTICATION
+    if isinstance(error, (caldav.lib.error.DAVError,
+                          requests.exceptions.RequestException)):
+        return BackendSignals.ERRNO_NETWORK
+    return None
 
 
 class Backend(PeriodicImportBackend):
@@ -150,8 +171,27 @@ class Backend(PeriodicImportBackend):
 
     @interruptible
     def do_periodic_import(self) -> None:
-        with self.datastore.mutex:
-            self._do_periodic_import()
+        # Don't even try while the OS reports no connectivity: it would
+        # only produce a cascade of connection tracebacks (#1324). The
+        # periodic timer will call us again once the machine is back
+        # online.
+        if not is_connection_up():
+            logger.debug("No network connectivity, skipping CalDAV import "
+                         "for %r", self.get_id())
+            return
+        try:
+            with self.datastore.mutex:
+                self._do_periodic_import()
+        except Exception as error:
+            errno = _dav_failure_errno(error)
+            if errno is None:
+                # Not a known auth/network failure: let it surface.
+                raise
+            # Report it to the GUI (a clear banner) instead of killing the
+            # sync thread; the next periodic cycle will retry (#1322, #1324).
+            logger.warning("CalDAV sync failed for %r, reporting %s: %s",
+                           self.get_id(), errno, error)
+            BackendSignals().backend_failed(self.get_id(), errno)
 
     @interruptible
     def set_task(self, task: Task) -> None:
@@ -272,18 +312,13 @@ class Backend(PeriodicImportBackend):
 
     def _refresh_calendar_list(self):
         """Will browse calendar list available after principal call and cache
-        them"""
-        try:
-            principal = self._dav_client.principal()
-        except caldav.lib.error.AuthorizationError as error:
-            message = _(
-                "You need a correct login to CalDAV\n"
-                "Configure CalDAV with login information.\n Error:"
-            )
-            BackendSignals().interaction_requested(
-                self.get_id(), f"{message} {error!r}",
-                BackendSignals().INTERACTION_INFORM, "on_continue_clicked")
-            raise error
+        them.
+
+        Auth and network failures raised here (principal() hits the server)
+        are classified and reported by do_periodic_import so the whole
+        backend has a single, consistent error path -- see _dav_failure_errno.
+        """
+        principal = self._dav_client.principal()
         for calendar in principal.calendars():
             self._cache.set_calendar(calendar)
 

--- a/GTG/backends/generic_backend.py
+++ b/GTG/backends/generic_backend.py
@@ -34,8 +34,14 @@ from GTG.backends.backend_signals import BackendSignals
 from GTG.core.dirs import SYNC_DATA_DIR
 from GTG.core.interruptible import _cancellation_point
 from GTG.core.keyring import Keyring
+from GTG.core.networkmanager import is_connection_up, register_for_retry
 
 log = logging.getLogger(__name__)
+
+# How many consecutive times launch_setting_thread will retry pushing a
+# single task before giving up on it, so one task that always fails (a
+# "poison" task) cannot block the queue head or retry forever.
+MAX_SYNC_ATTEMPTS = 3
 PICKLE_BACKUP_NBR = 2
 
 ALLTASKS_TAG = 'gtg-tags-all'
@@ -303,6 +309,12 @@ class GenericBackend():
             lambda: self.please_quit)
         self.to_set = deque()
         self.to_remove = deque()
+        # Per-task consecutive push/delete failure counters, reset on
+        # success and capped by MAX_SYNC_ATTEMPTS (see launch_setting_thread).
+        self._sync_failures = {}
+        # Retry pending writes as soon as connectivity comes back, instead
+        # of waiting for the next local change (see networkmanager).
+        register_for_retry(self)
 
     def get_attached_tags(self):
         """
@@ -660,16 +672,68 @@ class GenericBackend():
             if tid not in self.to_remove:
                 task = self.datastore.tasks.lookup.get(tid)
                 if task:
-                    self.set_task(task)
+                    try:
+                        self.set_task(task)
+                        self._sync_failures.pop(tid, None)
+                    except Exception:
+                        log.exception("Backend %s failed to push task %s",
+                                      self.get_id(), tid)
+                        if self.__handle_sync_failure(tid, self.to_set):
+                            break
 
         while not self.please_quit or bypass_quit_request:
             try:
                 tid = self.to_remove.pop()
             except IndexError:
                 break
-            self.remove_task(tid)
+            try:
+                self.remove_task(tid)
+                self._sync_failures.pop(tid, None)
+            except Exception:
+                log.exception("Backend %s failed to delete task %s",
+                              self.get_id(), tid)
+                if self.__handle_sync_failure(tid, self.to_remove):
+                    break
         # we release the weak lock
         self.to_set_timer = None
+
+    def __handle_sync_failure(self, tid, queue):
+        """React to a set_task/remove_task that raised.
+
+        Returns True when the caller should stop the current drain cycle
+        (the task was re-queued and will be retried later), False when the
+        task was abandoned after too many attempts -- in that case the
+        caller keeps draining so a single poison task cannot block the
+        queue head (HoL) indefinitely.
+
+        Only failures that happen while the OS reports connectivity count
+        toward MAX_SYNC_ATTEMPTS: a failure while offline is transient, so
+        the task stays queued (counter frozen) and network-changed will
+        retry it once connectivity returns (see networkmanager).
+        """
+        if is_connection_up():
+            count = self._sync_failures.get(tid, 0) + 1
+            self._sync_failures[tid] = count
+        else:
+            count = self._sync_failures.get(tid, 0)
+        if count >= MAX_SYNC_ATTEMPTS:
+            log.error("Backend %s giving up on task %s after %d attempts",
+                      self.get_id(), tid, count)
+            self._sync_failures.pop(tid, None)
+            self._signal_manager.backend_failed(self.get_id(),
+                                                BackendSignals.ERRNO_NETWORK)
+            return False
+        queue.appendleft(tid)
+        return True
+
+    def retry_pending_sync(self):
+        """Relaunch the setting thread if writes are still queued.
+
+        Called when network connectivity comes back so tasks edited while
+        offline are pushed without waiting for the next local change.
+        """
+        if self.to_set or self.to_remove:
+            self.__try_launch_setting_thread()
 
     def queue_set_task(self, tid):
         """ Save the task in the backend. In particular, it just enqueues the

--- a/GTG/core/networkmanager.py
+++ b/GTG/core/networkmanager.py
@@ -19,7 +19,17 @@
 
 """ Communicate with Network Manager """
 
+import logging
+import weakref
+
 from gi.repository import Gio # type: ignore[import-untyped]
+
+log = logging.getLogger(__name__)
+
+# Backends that want their pending writes retried when connectivity comes
+# back. Weak so a deleted backend drops out on its own.
+_retry_registry = weakref.WeakSet()
+_watching_network = False
 
 
 def is_connection_up():
@@ -27,6 +37,46 @@ def is_connection_up():
 
     network_monitor = Gio.NetworkMonitor.get_default()
     return network_monitor.get_network_available()
+
+
+def register_for_retry(backend):
+    """Register a backend to be retried when connectivity returns.
+
+    On the next 'network is back up' event, backend.retry_pending_sync()
+    is called so tasks edited offline are pushed without waiting for the
+    next local change. See GenericBackend.retry_pending_sync.
+    """
+    _retry_registry.add(backend)
+    _ensure_network_watch()
+
+
+def _ensure_network_watch():
+    """Connect to NetworkMonitor::network-changed exactly once."""
+    global _watching_network
+    if _watching_network:
+        return
+    try:
+        Gio.NetworkMonitor.get_default().connect('network-changed',
+                                                 _on_network_changed)
+        _watching_network = True
+    except Exception:
+        # No usable network monitor: retries just won't be automatic.
+        log.warning("Could not watch network state; offline writes will be "
+                    "retried on the next local change instead.")
+
+
+def _on_network_changed(_monitor, available):
+    if available:
+        _notify_network_available()
+
+
+def _notify_network_available():
+    """Ask every registered backend with queued writes to retry now."""
+    for backend in list(_retry_registry):
+        try:
+            backend.retry_pending_sync()
+        except Exception:
+            log.exception("Failed to retry pending sync for a backend")
 
 
 if __name__ == "__main__":

--- a/tests/backend/backend_caldav_test.py
+++ b/tests/backend/backend_caldav_test.py
@@ -80,6 +80,9 @@ X-APPLE-SORT-ORDER:1\r
 END:VTODO\r\n"""
 
 
+# do_periodic_import now skips when the OS reports no connectivity; keep
+# these network-mocked tests deterministic regardless of the runner.
+@patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
 class CalDAVTest(TestCase):
     """The historical CalDAV test suite, migrated to the new core API.
 
@@ -668,6 +671,7 @@ class RecurrenceRRuleTest(TestCase):
 
 
 
+@patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
 class LocalDeletionPushTest(TestCase):
     """Deleting a task in GTG must delete the matching todo on the
     CalDAV server, otherwise it reappears on the next import.
@@ -779,6 +783,7 @@ class LocalDeletionPushTest(TestCase):
         self.assertIsNone(backend._cache.get_todo(str(task.id)))
 
 
+@patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
 class ServerSideSubtaskDeletionTest(TestCase):
     """A subtask deleted on the server must be removed locally too.
 

--- a/tests/backend/test_caldav_error_taxonomy.py
+++ b/tests/backend/test_caldav_error_taxonomy.py
@@ -1,0 +1,120 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) - The Getting Things GNOME Team
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+"""CalDAV backend error handling: a failing sync must report a clear
+error to the GUI (a BackendSignals errno the info bar knows how to show)
+and never let the exception kill the sync thread, and it must not even
+try while the machine is offline (#1322, #1324)."""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+import caldav
+import requests
+
+from GTG.backends.backend_caldav import Backend, _dav_failure_errno
+from GTG.backends.backend_signals import BackendSignals
+from GTG.core.datastore import Datastore
+
+
+class DavFailureErrnoTest(TestCase):
+    """The exception -> errno classifier."""
+
+    def test_authorization_error_is_authentication(self):
+        err = caldav.lib.error.AuthorizationError(url='u', reason='Unauthorized')
+        self.assertEqual(_dav_failure_errno(err),
+                         BackendSignals.ERRNO_AUTHENTICATION)
+
+    def test_connection_error_is_network(self):
+        err = requests.exceptions.ConnectionError('name resolution failed')
+        self.assertEqual(_dav_failure_errno(err),
+                         BackendSignals.ERRNO_NETWORK)
+
+    def test_other_dav_error_is_network(self):
+        # AuthorizationError is a DAVError subclass, so a plain DAVError
+        # must still fall through to the network branch, not authentication.
+        self.assertEqual(_dav_failure_errno(caldav.lib.error.DAVError()),
+                         BackendSignals.ERRNO_NETWORK)
+
+    def test_unknown_error_propagates(self):
+        # Anything unexpected returns None so do_periodic_import re-raises it.
+        self.assertIsNone(_dav_failure_errno(ValueError('boom')))
+
+
+class DoPeriodicImportErrorHandlingTest(TestCase):
+    """do_periodic_import turns a raised failure into a reported error."""
+
+    @staticmethod
+    def _backend(dav_client):
+        datastore = Datastore()
+        parameters = {'pid': 'favorite', 'service-url': 'x',
+                      'username': 'u', 'password': 'p', 'period': 1,
+                      'is-first-run': False}
+        backend = Backend(parameters)
+        backend.register_datastore(datastore)
+        backend.initialize()
+        return backend
+
+    @patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
+    @patch('GTG.backends.periodic_import_backend.threading.Timer')
+    @patch('GTG.backends.backend_caldav.caldav.DAVClient')
+    def test_auth_failure_is_reported_not_raised(self, dav_client, timer):
+        backend = self._backend(dav_client)
+        dav_client.return_value.principal.side_effect = \
+            caldav.lib.error.AuthorizationError(url='u', reason='Unauthorized')
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed') as failed:
+            backend.do_periodic_import()  # must not raise
+        failed.assert_called_once_with(backend.get_id(),
+                                       BackendSignals.ERRNO_AUTHENTICATION)
+
+    @patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
+    @patch('GTG.backends.periodic_import_backend.threading.Timer')
+    @patch('GTG.backends.backend_caldav.caldav.DAVClient')
+    def test_network_failure_is_reported_not_raised(self, dav_client, timer):
+        backend = self._backend(dav_client)
+        dav_client.return_value.principal.side_effect = \
+            requests.exceptions.ConnectionError('temporary failure in name '
+                                                'resolution')
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed') as failed:
+            backend.do_periodic_import()  # must not raise
+        failed.assert_called_once_with(backend.get_id(),
+                                       BackendSignals.ERRNO_NETWORK)
+
+    @patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: True)
+    @patch('GTG.backends.periodic_import_backend.threading.Timer')
+    @patch('GTG.backends.backend_caldav.caldav.DAVClient')
+    def test_unexpected_error_still_propagates(self, dav_client, timer):
+        backend = self._backend(dav_client)
+        dav_client.return_value.principal.side_effect = ValueError('boom')
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed') as failed:
+            with self.assertRaises(ValueError):
+                backend.do_periodic_import()
+        failed.assert_not_called()
+
+    @patch('GTG.backends.backend_caldav.is_connection_up', new=lambda: False)
+    @patch('GTG.backends.periodic_import_backend.threading.Timer')
+    @patch('GTG.backends.backend_caldav.caldav.DAVClient')
+    def test_offline_skips_the_import_entirely(self, dav_client, timer):
+        backend = self._backend(dav_client)
+        with patch.object(backend, '_do_periodic_import') as inner:
+            backend.do_periodic_import()  # offline: must be a no-op
+        inner.assert_not_called()
+        dav_client.return_value.principal.assert_not_called()

--- a/tests/backend/test_sync_queue_resilience.py
+++ b/tests/backend/test_sync_queue_resilience.py
@@ -1,0 +1,167 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) - The Getting Things GNOME Team
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+"""Write-path resilience of the sync queue (#1324).
+
+A push that raises (e.g. a lost connection mid-write) used to escape
+launch_setting_thread, killing the sync thread AND leaving to_set_timer
+set so the queue never ran again -- the offline edit was lost silently.
+The drain now catches the failure, re-queues the task, and only gives up
+after MAX_SYNC_ATTEMPTS so one poison task can't loop or block the queue.
+When connectivity returns, network-changed relaunches the pending drain.
+"""
+
+import weakref
+from collections import deque
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import requests
+
+import GTG.core.networkmanager as networkmanager
+from GTG.backends.backend_caldav import Backend
+from GTG.backends.backend_signals import BackendSignals
+from GTG.backends.generic_backend import MAX_SYNC_ATTEMPTS
+from GTG.core.datastore import Datastore
+
+_MANGLED_LAUNCH = '_GenericBackend__try_launch_setting_thread'
+
+
+def _make_backend():
+    """A CalDAV backend (the only concrete user of the sync queue) wired
+    to a fresh datastore, without touching the network."""
+    datastore = Datastore()
+    backend = Backend({'pid': 'favorite', 'service-url': 'x',
+                       'username': 'u', 'password': 'p', 'period': 1,
+                       'is-first-run': False})
+    backend.register_datastore(datastore)
+    return backend
+
+
+class LaunchSettingThreadResilienceTest(TestCase):
+
+    @patch('GTG.backends.generic_backend.is_connection_up', new=lambda: True)
+    def test_failed_push_is_requeued_and_queue_not_wedged(self):
+        backend = _make_backend()
+        tid = 'task-1'
+        backend.datastore.tasks.lookup[tid] = object()
+        backend.set_task = Mock(
+            side_effect=requests.exceptions.ConnectionError('down'))
+        backend.to_set.appendleft(tid)
+
+        backend.launch_setting_thread()  # must not raise
+
+        self.assertIn(tid, backend.to_set)        # re-queued, not lost
+        self.assertIsNone(backend.to_set_timer)   # queue not wedged (line 672)
+        backend.set_task.assert_called_once()
+
+    @patch('GTG.backends.generic_backend.is_connection_up', new=lambda: True)
+    def test_poison_task_abandoned_after_three_attempts(self):
+        backend = _make_backend()
+        tid = 'task-1'
+        backend.datastore.tasks.lookup[tid] = object()
+        backend.set_task = Mock(
+            side_effect=requests.exceptions.ConnectionError('down'))
+        backend.to_set.appendleft(tid)
+
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed') as failed:
+            for _ in range(MAX_SYNC_ATTEMPTS):
+                backend.launch_setting_thread()
+
+        self.assertNotIn(tid, backend.to_set)     # abandoned, no HoL block
+        self.assertIsNone(backend.to_set_timer)
+        self.assertEqual(backend.set_task.call_count, MAX_SYNC_ATTEMPTS)
+        failed.assert_called_once_with(backend.get_id(),
+                                       BackendSignals.ERRNO_NETWORK)
+
+    @patch('GTG.backends.generic_backend.is_connection_up', new=lambda: False)
+    def test_offline_failures_do_not_count_toward_the_cap(self):
+        # A failure while offline is transient: the task must stay queued
+        # forever (until network-changed), never abandoned as a poison.
+        backend = _make_backend()
+        tid = 'task-1'
+        backend.datastore.tasks.lookup[tid] = object()
+        backend.set_task = Mock(
+            side_effect=requests.exceptions.ConnectionError('down'))
+        backend.to_set.appendleft(tid)
+
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed') as failed:
+            for _ in range(MAX_SYNC_ATTEMPTS + 2):
+                backend.launch_setting_thread()
+
+        self.assertIn(tid, backend.to_set)        # still queued
+        failed.assert_not_called()
+
+    @patch('GTG.backends.generic_backend.is_connection_up', new=lambda: True)
+    def test_a_healthy_task_behind_a_poison_one_still_syncs(self):
+        # The poison task is abandoned (not re-queued), so the drain keeps
+        # going and the good task behind it is pushed.
+        backend = _make_backend()
+        poison, good = 'poison', 'good'
+        backend.datastore.tasks.lookup[poison] = object()
+        backend.datastore.tasks.lookup[good] = object()
+        backend._sync_failures[poison] = MAX_SYNC_ATTEMPTS - 1  # one away
+
+        pushed = []
+
+        def push(task):
+            # identity of the task object tells us which tid it was
+            if task is backend.datastore.tasks.lookup[poison]:
+                raise requests.exceptions.ConnectionError('down')
+            pushed.append(task)
+
+        backend.set_task = Mock(side_effect=push)
+        backend.to_set.appendleft(good)     # popped last
+        backend.to_set.appendleft(poison)   # popped first (head)
+
+        signals = BackendSignals()
+        with patch.object(signals, 'backend_failed'):
+            backend.launch_setting_thread()
+
+        self.assertNotIn(poison, backend.to_set)
+        self.assertIn(backend.datastore.tasks.lookup[good], pushed)
+
+
+class NetworkReturnTriggerTest(TestCase):
+
+    def test_network_changed_retries_registered_backends(self):
+        saved = networkmanager._retry_registry
+        networkmanager._retry_registry = weakref.WeakSet()
+        try:
+            backend = Mock()
+            networkmanager.register_for_retry(backend)
+            networkmanager._notify_network_available()
+            backend.retry_pending_sync.assert_called_once()
+        finally:
+            networkmanager._retry_registry = saved
+
+    def test_retry_pending_sync_relaunches_only_when_writes_are_queued(self):
+        backend = _make_backend()
+
+        backend.to_set.appendleft('t')
+        with patch.object(backend, _MANGLED_LAUNCH) as launch:
+            backend.retry_pending_sync()
+        launch.assert_called_once()
+
+        backend.to_set = deque()
+        backend.to_remove = deque()
+        with patch.object(backend, _MANGLED_LAUNCH) as launch:
+            backend.retry_pending_sync()
+        launch.assert_not_called()


### PR DESCRIPTION
CalDAV synchronization killed its sync thread on several error paths, with a silent data loss in one case. This PR addresses all of them.

## 1. Authentication failure (#1322)

**Symptom:** a wrong password raised an AuthorizationError that killed the sync thread, with no clear message.

**Mechanism:** `_refresh_calendar_list` did catch the error to notify the UI, but then re-raised it (`raise`), and nothing caught it on the thread path.

**Fix:** classify the failure (`_dav_failure_errno`: auth vs network) and report it to the UI via `backend_failed` (clear banner, Configure button) instead of re-raising. The thread survives, the periodic cycle retries.

## 2. Offline traceback cascade (#1324, import side)

**Symptom:** while the machine was offline, the backend kept attempting syncs, producing a cascade of connection errors.

**Fix:** an `is_connection_up()` guard at the top of `do_periodic_import`. Offline, the import is skipped cleanly; the cycle resumes when the network returns.

## 3. Silent data loss on offline edits (#1324, write side)

**Symptom:** a task edited offline was lost. When the network returned, the push failed, killed the write thread, and the edit never reached the server.

**Mechanism:** in `launch_setting_thread`, the tid is popped from the queue before the push. If the push raised a non-DAVError (typically a network error), it propagated, killed the thread, and the tid was never re-queued. Worse, the cleanup line (`to_set_timer = None`) was skipped, locking the queue for good until restart.

**Fix:** wrap the push and delete in a try/except that re-queues the task and stops the current drain cleanly (no spin), always reaching the cleanup line (no more lock). A retry cap (N=3) bounds a task that would fail in a loop, without blocking the queue head. An offline failure does not count toward that cap (transient). Finally, a trigger on connectivity return (`network-changed`) relaunches pending writes without waiting for a new edit.

**Scope:** the write-side fix lives in `generic_backend.py` (shared by all backends). In practice, CalDAV is the only concrete backend taking this path in the new core. The semantics change for any future backend: an exception from `set_task` no longer kills the thread, which is strictly safer.

## Tests

Red-before / green-after demonstrated. Unit tests added (`test_caldav_error_taxonomy.py`, `test_sync_queue_resilience.py`). Verified live: wrong password (banner, no crash), offline edit then network return (the change reaches the server, confirmed on the Nextcloud side, with no loss).

These three error paths were surfaced by @nekohayo's feedback during the hackfest; a retest on your side, especially on the offline scenario, would be valuable to confirm the behavior before merge.