### PR TITLE
Fix backup purge targeting the data directory instead of backup/ (#1316)

### DIFF
--- a/GTG/core/datastore.py
+++ b/GTG/core/datastore.py
@@ -19,6 +19,7 @@
 """The datastore ties together all the basic type stores and backends."""
 
 import os
+import re
 import threading
 import logging
 import shutil
@@ -445,21 +446,41 @@ class Datastore:
         self.purge_backups(path)
 
 
+    # Dated daily backups: gtg_data.xml.2026-08-02.bak
+    DAILY_BACKUP_RE = re.compile(r'\.\d{4}-\d{2}-\d{2}\.bak$')
+
     @staticmethod
     def purge_backups(path: str, days: int = 30) -> None:
-        """Remove backups older than X days."""
+        """Remove dated daily backups older than X days.
 
-        now = time()
-        day_in_secs = 86_400
-        basedir = os.path.dirname(path)
+        Only the dated daily backups (*.YYYY-MM-DD.bak) inside the
+        backup directory are subject to age-based removal. The rotating
+        .bak.0 to .bak.N copies are managed by count in write_backups
+        and must survive long periods without opening the app, and the
+        data directory itself must never be touched: it can contain
+        the pre-migration 0.6 files (gtg_tasks.xml, tags.xml,
+        projects.xml) among others."""
 
-        for filename in os.listdir(basedir):
-            filename = os.path.join(basedir, filename)
-            filestamp = os.stat(filename).st_mtime
-            filecompare = now - (days * day_in_secs)
+        cutoff = time() - days * 86_400
+        backup_dir = os.path.dirname(Datastore.get_backup_path(path))
 
-            if filestamp < filecompare:
-                os.remove(filename)
+        try:
+            filenames = os.listdir(backup_dir)
+        except FileNotFoundError:
+            return
+
+        for filename in filenames:
+            if not Datastore.DAILY_BACKUP_RE.search(filename):
+                continue
+
+            filepath = os.path.join(backup_dir, filename)
+
+            try:
+                if os.stat(filepath).st_mtime < cutoff:
+                    os.remove(filepath)
+            except OSError as error:
+                log.warning('Could not purge backup %r: %r',
+                            filepath, error)
 
 
     def find_and_load_file(self, path: str) -> None:

--- a/tests/core/test_datastore_backups.py
+++ b/tests/core/test_datastore_backups.py
@@ -1,0 +1,122 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) 2008-2026 - the GTG contributors
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import os
+import time
+import shutil
+import tempfile
+from unittest import TestCase
+
+from GTG.core.datastore import Datastore
+
+
+OLD = time.time() - 40 * 86_400
+RECENT = time.time() - 2 * 86_400
+
+
+class BackupDirTestCase(TestCase):
+    """Common scaffolding: a fake data directory with its backup/ dir."""
+
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.data_dir = os.path.join(self.root, 'gtg')
+        self.backup_dir = os.path.join(self.data_dir, 'backup')
+        os.makedirs(self.backup_dir)
+        self.main = os.path.join(self.data_dir, 'gtg_data.xml')
+        self._write(self.main)
+
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+
+    def _write(self, filepath, mtime=None, content='<data/>'):
+        with open(filepath, 'w') as filedesc:
+            filedesc.write(content)
+        if mtime:
+            os.utime(filepath, (mtime, mtime))
+        return filepath
+
+
+    def _daily(self, date, mtime=OLD):
+        name = f'gtg_data.xml.{date}.bak'
+        return self._write(os.path.join(self.backup_dir, name), mtime)
+
+
+class TestPurgeBackups(BackupDirTestCase):
+    """Regression tests for the purge targeting the wrong directory.
+
+    purge_backups() used to walk the data directory instead of the
+    backup directory: dated daily backups were never removed, while
+    any file older than the cutoff in the data directory was silently
+    deleted, including the pre-migration 0.6 files of users coming
+    from 0.6."""
+
+
+    def test_purge_does_not_touch_data_directory(self):
+        for name in ('gtg_tasks.xml', 'tags.xml', 'projects.xml'):
+            self._write(os.path.join(self.data_dir, name), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        for name in ('gtg_tasks.xml', 'tags.xml', 'projects.xml'):
+            self.assertTrue(
+                os.path.exists(os.path.join(self.data_dir, name)),
+                f'{name} must survive: the data directory is not a backup')
+
+
+    def test_purge_removes_old_dated_dailies(self):
+        old_daily = self._daily('2025-01-01', OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertFalse(os.path.exists(old_daily))
+
+
+    def test_purge_keeps_recent_dailies(self):
+        recent_daily = self._daily('2026-08-01', RECENT)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(recent_daily))
+
+
+    def test_purge_keeps_rotating_baks_regardless_of_age(self):
+        rotating = self._write(
+            os.path.join(self.backup_dir, 'gtg_data.xml.bak.3'), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(rotating),
+                        'rotating copies are managed by count, not age')
+
+
+    def test_purge_ignores_foreign_files_in_backup_dir(self):
+        foreign = self._write(
+            os.path.join(self.backup_dir, 'notes.txt'), OLD)
+
+        Datastore.purge_backups(self.main)
+
+        self.assertTrue(os.path.exists(foreign))
+
+
+    def test_purge_survives_missing_backup_dir(self):
+        shutil.rmtree(self.backup_dir)
+
+        Datastore.purge_backups(self.main)  # must not raise


### PR DESCRIPTION
`purge_backups()` pruned the wrong directory, with two consequences including silent data loss for users migrating from 0.6.

**Symptom:** the function walked `os.path.dirname(path)`, i.e. the *data* directory, not the `backup/` subdirectory its docstring and call site target.

**Mechanism:** before 2022 the function called `os.listdir` on a file path and crashed, so it never actually ran. Commit `3dfbae88` fixed that crash by switching to `dirname(path)`, which made the code run, but on the wrong directory. Since it stopped crashing, the slip went unnoticed.

**Two consequences, both reproduced with a scripted scenario:**
- dated daily backups (`*.YYYY-MM-DD.bak`) live in `backup/` and were therefore never removed: the unbounded accumulation described in #443 is still true on 0.7;
- any file older than 30 days in the data directory was silently deleted. For users migrating from 0.6 this includes their pre-migration `gtg_tasks.xml`, `tags.xml` and `projects.xml`, gone one month after the migration.

**Fix:** the purge now targets the `backup/` directory, only matches dated daily backups (the rotating `.bak.0-N` copies, managed by count in `write_backups`, must survive long periods without opening the app), ignores foreign files, tolerates a missing backup directory, and logs instead of crashing when a removal fails.

**Tests:** red-before / green-after demonstrated, unit tests added (`test_datastore_backups.py`, covering correct targeting, preservation of the `.bak.0-N` copies, a missing backup directory, and foreign files).

---

This extracts the critical purge fix from #1317 so it can land independently of the gzip archiving feature, which remains in #1317 pending the #443 design discussion.