### PR TITLE
flatpak: regenerate python3-requirements against SDK 50, add setproctitle

### DIFF
--- a/build-aux/python3-requirements.yaml
+++ b/build-aux/python3-requirements.yaml
@@ -1,17 +1,18 @@
-# Generated with flatpak-pip-generator --runtime=org.gnome.Sdk//47 --requirements-file=build-aux/requirements.txt --yaml --output=build-aux/python3-requirements --ignore-installed=lxml
-build-commands: []
+# Generated with flatpak-pip-generator --runtime=org.gnome.Sdk//50 --requirements-file=build-aux/requirements.txt --yaml --output=build-aux/python3-requirements --ignore-installed=lxml
+name: python3-requirements
 buildsystem: simple
+build-commands: []
 modules:
   - name: python3-lxml
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "lxml==5.3.0" --ignore-installed --no-build-isolation
+        --prefix=${FLATPAK_DEST} "lxml==6.1.0" --ignore-installed --no-build-isolation
     sources:
       - &id001
         type: file
-        url: https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz
-        sha256: 4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
+        url: https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz
+        sha256: bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13
   - name: python3-caldav
     buildsystem: simple
     build-commands:
@@ -22,48 +23,48 @@ modules:
         url: https://files.pythonhosted.org/packages/77/86/c8fff55bd0ab9410cca9dbfa92e91ebcf3cc1a7266e33888364e7aaa1222/caldav-1.4.0-py3-none-any.whl
         sha256: e75e84824092e33a9e03ac693de3d01133a3e044fd50a1c542c7f78d1aff0cb2
       - type: file
-        url: https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl
-        sha256: 1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56
+        url: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+        sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
       - type: file
-        url: https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz
-        sha256: 44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3
+        url: https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl
+        sha256: 68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5
       - type: file
-        url: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
-        sha256: 63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2
+        url: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+        sha256: e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
       - type: file
-        url: https://files.pythonhosted.org/packages/d1/cd/a1656e6db3cbb31335d1e62bb94733ad3744d51c63103196d684ed94fa27/icalendar-6.1.1-py3-none-any.whl
-        sha256: accf3a4be9a1f89bad00e0bf14103b02cd9b02dcb9b4258eb717f39d24cf58e9
+        url: https://files.pythonhosted.org/packages/f1/fd/8cbebc368afc020c979e5f9433348531215c65df93b0d6d6f1a1b13a39eb/icalendar-7.2.2-py3-none-any.whl
+        sha256: 90dd280cb4f67d1ef07b5178c2c33db4fc0a05627e50a3758b6b2aa9b117bc07
       - type: file
-        url: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
-        sha256: 946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
       - *id001
       - type: file
         url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
         sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
       - type: file
-        url: https://files.pythonhosted.org/packages/11/c3/005fcca25ce078d2cc29fd559379817424e94885510568bc1bc53d7d5846/pytz-2024.2-py2.py3-none-any.whl
-        sha256: 31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725
+        url: https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl
+        sha256: dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815
       - type: file
-        url: https://files.pythonhosted.org/packages/bb/1b/f4b3c2d105cc51bab1f441930b0c15b4d56b79096997887686ea18b564da/recurring_ical_events-3.4.1-py3-none-any.whl
-        sha256: 971bc3be38c03f208e6ad8956adda45227ce8122b63da9457c3a1cf125a56204
+        url: https://files.pythonhosted.org/packages/81/f7/d3eb4f545baf5d6daaa5881694517626fb7ad04036d94168197a4f021384/recurring_ical_events-3.8.2-py3-none-any.whl
+        sha256: 9ad605e27b4fbeb70ee1c66205ade32550be15a57cedc579606522f1c67aef6d
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
       - type: file
         url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
         sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
       - type: file
-        url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
-        sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+        url: https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl
+        sha256: dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
       - type: file
-        url: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
-        sha256: 7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639
-      - type: file
-        url: https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl
-        sha256: 1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
       - type: file
         url: https://files.pythonhosted.org/packages/68/20/6bba813bbd498c28edbbcf8253a6398cf4266ecf7bfa6129835c0a2bfbb1/vobject-0.9.9-py2.py3-none-any.whl
         sha256: 0fbdb982065cf4d1843a5d5950c88510041c6de026bda49c3502721de1c6ac3d
       - type: file
-        url: https://files.pythonhosted.org/packages/49/bc/3d16b11027e2787eb90069f96205e5f6c9871d7f72f382fd5ce0f9f801cb/x_wr_timezone-2.0.0-py3-none-any.whl
-        sha256: 37f3927ddc32970c330af97773dc12bf8e0d2deb9ede5c3c676dc13ed62feb11
+        url: https://files.pythonhosted.org/packages/0f/b7/4bac35b4079b76c07d8faddf89467e9891b1610cfe8d03b0ebb5610e4423/x_wr_timezone-2.0.1-py3-none-any.whl
+        sha256: e74a53b9f4f7def8138455c240e65e47c224778bce3c024fcd6da2cbe91ca038
   - name: python3-pytest
     buildsystem: simple
     build-commands:
@@ -71,17 +72,17 @@ modules:
         --prefix=${FLATPAK_DEST} "pytest" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
-        sha256: b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+        url: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+        sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
       - type: file
-        url: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
-        sha256: 09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
+        url: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+        sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
       - type: file
-        url: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
-        sha256: 44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
+        url: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+        sha256: 81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
       - type: file
-        url: https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl
-        sha256: 50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6
+        url: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
+        sha256: 37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
   - name: python3-Cheetah3
     buildsystem: simple
     build-commands:
@@ -109,4 +110,12 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
         sha256: 04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
-name: python3-requirements
+  - name: python3-setproctitle
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "setproctitle" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz
+        sha256: bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e

--- a/build-aux/requirements.txt
+++ b/build-aux/requirements.txt
@@ -4,3 +4,4 @@ pytest
 Cheetah3
 dbus-python==1.2.18
 typing_extensions==4.12.2
+setproctitle


### PR DESCRIPTION
Fixes #638

## What

The `setproctitle` import added in #641 has been failing silently in
the flatpak ever since, because the dependency was never added to the
manifest — so the process still shows up as `python3` in ps and
system monitors.

While adding it, this regenerates `python3-requirements.yaml` fully:
it was still generated against SDK 47 while the manifest targets
runtime 50 since #1292, and lxml had drifted from requirements.txt
(5.3.0 in the yaml vs 6.1.0 pinned). The `six` wheel hand-patched in
#1292 is kept, now resolved as a regular caldav dependency.

Command used (same as the original, bumped to SDK 50):

    flatpak-pip-generator --runtime=org.gnome.Sdk//50 \
      --requirements-file=build-aux/requirements.txt --yaml \
      --output=build-aux/python3-requirements --ignore-installed=lxml

## Why setproctitle and not GLib.set_prgname

As @chergert explained in the issue, `GLib.set_prgname()` only changes
the process-internal representation; what `ps` shows comes from
`/proc/$pid/cmdline`, which on Linux requires overwriting argv memory —
which is exactly what the `setproctitle` module does. The code in
`gtg.in` was correct all along; only the packaging was missing.

## What the regeneration pulls in

Transitive dependencies are refreshed against today's PyPI, including
some major bumps: icalendar 6.1.1 → 7.2.2, recurring_ical_events
3.4.1 → 3.8.2, pytest 8 → 9. The flatpak builds and the app starts
with the CalDAV backend loading; I have not run a full CalDAV sync
cycle against these versions.

## Verified

Built and installed locally (flatpak-builder, runtime 50):

    $ ps -eo pid,comm,args | grep gtg
    68190 bwrap    bwrap --args 76 -- gtg
    68201 bwrap    bwrap --args 76 -- gtg
    68202 gtg      gtg

The two bwrap wrapper processes remain, as expected — that's flatpak
itself, out of reach of setproctitle.

Note: since this is a small packaging-only fix labeled
low-hanging-fruit, it could be a candidate for the 0.7 milestone
rather than 0.8, if you think it fits.