### PR TITLE
fix(core): inherit recurrence when duplicating a completed recurring task (#1339)

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -887,6 +887,10 @@ class TaskStore(BaseStore[Task]):
         new_task.tags = task.tags
         new_task.content = task.content
         new_task.date_added = task.date_added
+        # Inherit the recurrence, as the 0.6 core did: without this the
+        # duplicate is born non-recurring and the chain dies at its next
+        # completion (#1339).
+        new_task.set_recurring(True, task.recurring_term)
         new_task.date_due = task.get_next_occurrence()
 
         # Only goes through for the first task

--- a/tests/core/test_recurrence_duplication.py
+++ b/tests/core/test_recurrence_duplication.py
@@ -1,0 +1,83 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) The GTG Team
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+"""Regression tests for #1339.
+
+Completing a recurring task duplicates it as its next occurrence. The
+duplicate must itself be recurring, otherwise the chain dies at its next
+completion and the task disappears from the Open and Actionable views.
+"""
+
+from unittest import TestCase
+
+from GTG.core.tasks import Status, TaskStore
+
+
+class TestRecurrenceDuplication(TestCase):
+
+    def _active_tasks(self, store):
+        return [t for t in store.lookup.values() if t.status == Status.ACTIVE]
+
+    def test_duplicate_inherits_recurrence(self):
+        store = TaskStore()
+        task = store.new('Water the plants')
+        task.set_recurring(True, 'day', newtask=True)
+
+        task.toggle_active()
+
+        actives = self._active_tasks(store)
+        self.assertEqual(len(actives), 1)
+        duplicate = actives[0]
+        self.assertTrue(duplicate.is_recurring)
+        self.assertEqual(duplicate.recurring_term, 'day')
+
+    def test_duplicate_due_date_is_next_occurrence(self):
+        store = TaskStore()
+        task = store.new('Water the plants')
+        task.set_recurring(True, 'day', newtask=True)
+
+        task.toggle_active()
+
+        duplicate = self._active_tasks(store)[0]
+        self.assertGreater(duplicate.date_due, task.date_due)
+
+    def test_recurring_chain_survives_repeated_completions(self):
+        store = TaskStore()
+        task = store.new('Water the plants')
+        task.set_recurring(True, 'day', newtask=True)
+
+        for _ in range(5):
+            actives = self._active_tasks(store)
+            self.assertEqual(len(actives), 1)
+            actives[0].toggle_active()
+
+        self.assertEqual(len(self._active_tasks(store)), 1)
+
+    def test_duplicated_children_inherit_recurrence(self):
+        store = TaskStore()
+        parent = store.new('Morning routine')
+        store.new('Stretch', parent=parent.id)
+        parent.set_recurring(True, 'day', newtask=True)
+
+        parent.toggle_active()
+
+        actives = self._active_tasks(store)
+        self.assertEqual(len(actives), 2)
+        for task in actives:
+            self.assertTrue(task.is_recurring)
+            self.assertEqual(task.recurring_term, 'day')


### PR DESCRIPTION
Completing a recurring task duplicates it as its next occurrence. On current master the duplicate is born non-recurring, so completing it produces no further occurrence and the task vanishes from the Open and Actionable lists, exactly as demonstrated in #1339. The disappearance is deterministic at the second completion at the core level.

The mechanism is a line lost in the port to the new core. The 0.6 core inherited the recurrence when duplicating, with an explicit comment reading "Inherit the recurrency". The new `duplicate_for_recurrent` copies title, tags, content and dates, but neither the recurring flag nor the recurring term, so the duplication condition in `set_status` is never met again.

The fix restores the inheritance: the duplicate receives `set_recurring(True, task.recurring_term)` before its due date is computed, which also covers children duplicated along with a recurring parent since the duplication recurses through them.

Red before, green after: four regression tests in `tests/core/test_recurrence_duplication.py`, of which three fail on unpatched master. They cover the inheritance itself, the next occurrence date, a chain of five consecutive completions, and the parent-with-children case. Verified live against the exact reproduction recipe from the issue.

Fixes #1339