### PR TITLE
fix(browser): repair the two dead entries of the weekly recurrence menu (#1339)

### DIFF
--- a/GTG/gtk/data/recurring_menu.ui
+++ b/GTG/gtk/data/recurring_menu.ui
@@ -22,7 +22,8 @@
         <section>
           <item>
             <attribute name="label" translatable="yes">On Monday</attribute>
-            <!-- TRNASLATORS: this is locale dependant and should be the correct full
+            <attribute name="action">recurring_menu.recurr_week_day</attribute>
+            <!-- TRANSLATORS: this is locale dependant and should be the correct full
             name of the weekday -->
             <attribute name="target" translatable="yes">Monday</attribute>
           </item>
@@ -60,8 +61,7 @@
         <section>
           <item>
             <attribute name="label" translatable="yes">On This Day</attribute>
-            <attribute name="action">recurring_menu.recurr_week_day</attribute>
-            <attribute name="target">THIS</attribute>
+            <attribute name="action">recurring_menu.recurr_every_week</attribute>
           </item>
         </section>
       </submenu>

--- a/tests/gtk/test_recurring_menu_ui.py
+++ b/tests/gtk/test_recurring_menu_ui.py
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# Copyright (c) The GTG Team
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+"""Structural tests for the recurring menu definition (#1339).
+
+A menu item without an action attribute is inert in GTK4: it renders but
+activates nothing. The weekly submenu lost the action on one weekday and
+carried an orphan target on another item, so selecting them silently
+failed to enable recurrence and the task closed without duplicating.
+"""
+
+from unittest import TestCase
+
+from lxml import etree
+
+UI_FILE = 'GTG/gtk/data/recurring_menu.ui'
+
+KNOWN_ACTIONS = (
+    'recurring_menu.is_recurring',
+    'recurring_menu.recurr_every_day',
+    'recurring_menu.recurr_every_otherday',
+    'recurring_menu.recurr_every_week',
+    'recurring_menu.recurr_week_day',
+    'recurring_menu.recurr_month_today',
+    'recurring_menu.recurr_year_today',
+)
+
+
+class TestRecurringMenuUi(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = etree.parse(UI_FILE)
+
+    def _menu_items(self):
+        return self.tree.findall('.//menu//item')
+
+    def test_every_menu_item_has_an_action(self):
+        for item in self._menu_items():
+            if item.find('./attribute[@name="custom"]') is not None:
+                continue
+            label = item.find('./attribute[@name="label"]')
+            action = item.find('./attribute[@name="action"]')
+            self.assertIsNotNone(
+                action,
+                f'Menu item {label.text!r} has no action and is inert')
+
+    def test_every_action_is_installed_by_the_menu_class(self):
+        for item in self._menu_items():
+            action = item.find('./attribute[@name="action"]')
+            if action is None:
+                continue
+            self.assertIn(action.text, KNOWN_ACTIONS)
+
+    def test_week_day_targets_are_parsable_terms(self):
+        week_days = ('Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                     'Friday', 'Saturday', 'Sunday')
+        for item in self._menu_items():
+            action = item.find('./attribute[@name="action"]')
+            if action is None or action.text != 'recurring_menu.recurr_week_day':
+                continue
+            target = item.find('./attribute[@name="target"]')
+            self.assertIsNotNone(target)
+            self.assertIn(target.text, week_days)


### PR DESCRIPTION
Two entries of the Weekly recurrence submenu silently failed to enable recurrence. A task configured through them was never recurring at all, so marking it Done closed it without spawning a next occurrence, the same symptom as reported in #1339 through another path.

The "On Monday" item was the only weekday missing its `action` attribute in `recurring_menu.ui`: the translator comment sits exactly where the action stands in every sibling entry, and carries a TRNASLATORS typo suggesting the line was overwritten by hand. A GTK4 menu item without an action is inert, so clicking On Monday did nothing at all.

The "On This Day" item passed the target `THIS` as a recurring term, a value handled nowhere in the menu class or in `dates.py`: `set_recurring()` rejected it and silently fell back to non-recurring. The item now triggers the existing every-week action, which is exactly what its label promises.

A structural test on the menu definition (`tests/gtk/test_recurring_menu_ui.py`) now verifies that every item carries an action, that every action is one the menu class installs, and that every weekday target is a parsable term. It fails on the previous menu definition and would have caught both defects.

Together with the core inheritance fix in #1342, this completes #1339.