### PR TITLE
fix(browser): degrade the Synchronization dialog cleanly when no backend loads (#1337)

### DIFF
--- a/GTG/backends/__init__.py
+++ b/GTG/backends/__init__.py
@@ -54,6 +54,7 @@ class BackendFactory(Borg):
             # This object has already been constructed
             return
         self.backend_modules = {}
+        self.failed_modules = {}
         backend_files = self._find_backend_files()
         # Create module names
         module_names = [f.replace(".py", "") for f in backend_files]
@@ -64,7 +65,9 @@ class BackendFactory(Borg):
             try:
                 __import__(extended_module_name)
             except ImportError as exception:
-                # Something is wrong with this backend, skipping
+                # Something is wrong with this backend, skipping. Keep the
+                # reason: the Synchronization dialog reports it to the user.
+                self.failed_modules[module_name] = str(exception)
                 log.warning("Backend %s could not be loaded: %r",
                             module_name, exception)
                 continue

--- a/GTG/gtk/backends/__init__.py
+++ b/GTG/gtk/backends/__init__.py
@@ -198,6 +198,31 @@ class BackendsDialog():
         @param widget: not used, here only for using this as signal callback
         @param data: same as widget, disregard the content
         """
+        factory = BackendFactory()
+        if not factory.get_all_backends():
+            # Every backend module failed to load (typically a missing
+            # python dependency): showing the add panel would only offer
+            # empty widgets. Say what is wrong instead (#1337).
+            reasons = '\n'.join(
+                f'{name}: {reason}'
+                for name, reason in sorted(factory.failed_modules.items()))
+            dialog = Gtk.MessageDialog(
+                transient_for=self.dialog,
+                modal=True,
+                message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.CLOSE,
+                text=_("No synchronization service is available"),
+            )
+            dialog.props.secondary_text = _(
+                "Every synchronization service failed to load, "
+                "probably because of a missing python library:"
+            ) + f"\n\n{reasons}\n\n" + _(
+                "Install the missing library and restart GTG."
+            )
+            dialog.connect('response', lambda d, r: d.destroy())
+            dialog.present()
+            return
+
         self._show_panel("add")
         self.add_panel.refresh_backends()
 
@@ -209,6 +234,10 @@ class BackendsDialog():
         @param backend_name: the name of the type of the backend to add
                              (identified as BACKEND_NAME in the Backend class)
         """
+        if backend_name is None:
+            # Nothing was selectable in the add panel: do not switch to
+            # the configuration panel of nothing (#1337).
+            return
         # Create Backend
         backend_dic = BackendFactory().get_new_backend_dict(backend_name)
         if backend_dic:

--- a/GTG/gtk/backends/backendstree.py
+++ b/GTG/gtk/backends/backendstree.py
@@ -242,6 +242,12 @@ class BackendsTree(Gtk.TreeView):
                 # If nothing is selected, we select the first entry
                 if selection:
                     selection.select_path("0")
+                if not self._get_selected_path():
+                    # Nothing selectable at all (no backend registered):
+                    # still bring the configuration panel back, so that
+                    # cancelling the add panel returns to the initial
+                    # state instead of doing nothing (#1337).
+                    self.dialog._show_panel("configuration")
         self.dialog.on_backend_selected(self.get_selected_backend_id())
 
     def get_selected_backend_id(self):

--- a/GTG/gtk/backends/configurepanel.py
+++ b/GTG/gtk/backends/configurepanel.py
@@ -41,8 +41,10 @@ class ConfigurePanel(Gtk.Box):
         self.task_deleted_handle = None
         self.task_added_handle = None
         self.ds = ds
+        self.backend = None
         self._create_widgets()
         self._connect_signals()
+        self.show_empty()
 
     def _connect_signals(self):
         """ Connects the backends generated signals """
@@ -115,11 +117,29 @@ class ConfigurePanel(Gtk.Box):
         box.append(self.sync_status_label)
         box.append(self.sync_button)
 
+    def show_empty(self) -> None:
+        """Show an explicitly empty panel: no backend is selected.
+
+        The widgets of this panel only make sense once set_backend has
+        been called; before that (no backend registered at all, or the
+        add panel was cancelled) they must not be offered to the
+        user (#1337).
+        """
+        self.backend = None
+        for widget in (self.image_icon, self.human_name_label,
+                       self.sync_status_label, self.sync_button,
+                       self.parameters_ui):
+            widget.set_visible(False)
+
     def set_backend(self, backend_id):
         """Changes the backend to configure, refreshing this view.
 
         @param backend_id: the id of the backend to configure
         """
+        for widget in (self.image_icon, self.human_name_label,
+                       self.sync_status_label, self.sync_button,
+                       self.parameters_ui):
+            widget.set_visible(True)
         self.backend = self.dialog.ds.get_backend(backend_id)
         self.refresh_title()
         self.refresh_sync_status()
@@ -135,6 +155,8 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param data: not used, here only for signal callback compatibility
         """
+        if self.backend is None:
+            return
         markup = "<big><big><big><b>%s</b></big></big></big>" % \
             self.backend.get_human_name()
         self.human_name_label.set_markup(markup)
@@ -170,6 +192,8 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param data: not used, here only for signal callback compatibility
         """
+        if self.backend is None:
+            return
         self.refresh_sync_button()
         self.refresh_sync_status_label()
 
@@ -179,6 +203,8 @@ class ConfigurePanel(Gtk.Box):
 
         @param sender: not used, here only for signal callback compatibility
         """
+        if self.backend is None:
+            return
         self.parameters_ui.commit_changes()
         self.ds.set_backend_enabled(self.backend.get_id(),
                                      not self.backend.is_enabled())
@@ -191,7 +217,7 @@ class ConfigurePanel(Gtk.Box):
         @param sender: not used, here only for signal callback compatibility
         @param backend_id: the id of the backend that emitted this signal
         """
-        if backend_id == self.backend.get_id():
+        if self.backend and backend_id == self.backend.get_id():
             self.spinner_set_active(True)
 
     def on_sync_ended(self, sender, backend_id):
@@ -203,7 +229,7 @@ class ConfigurePanel(Gtk.Box):
         @param backend_id: the id of the backend that emitted this signal
         """
 
-        if backend_id == self.backend.get_id():
+        if self.backend and backend_id == self.backend.get_id():
             self.spinner_set_active(False)
 
     def on_spinner_show(self, sender):


### PR DESCRIPTION
On a system where the caldav python library is not installed, backend_caldav fails to import and GTG is left with zero addable backends, a case the whole Synchronization dialog assumed impossible. As shown in the #1337 video: the add panel offers only empty widgets, OK switches to the configuration panel of nothing, showing an orphan unlabeled button that raises AttributeError when clicked, and Cancel does nothing at all.

The fix adds four layers of defense, following the error-paths-first approach. The backend factory now records why each module failed to load instead of only logging it. The add button shows a clear error dialog naming the missing library when nothing is addable, rather than entering the broken panel. The configuration panel gets an explicit empty state: its widgets stay hidden until a backend is actually assigned to it, and every handler that dereferenced the backend attribute is now guarded, which also silences the negative-size warnings coming from the unlabeled sync button. Finally, cancelling the add panel now visibly returns to the initial state, a path that was inert even with caldav installed.

Verified live both ways on the reproduction from the issue: with a simulated missing caldav module the dialog stays sane and explains itself with the exact import error, and with the library present the nominal add and configure flow is unchanged.

Two further defects observed during testing are left out of scope on purpose, one problem per PR: the dialog window is badly sized on first opening, and the CalDAV parameter fields show hardcoded sample values instead of greyed placeholder text. Both predate this change and deserve their own issues.

Fixes #1337