### PR TITLE
fix(browser): give the Synchronization dialog a sane default geometry (#1346)

### DIFF
--- a/GTG/gtk/data/backends.ui
+++ b/GTG/gtk/data/backends.ui
@@ -9,6 +9,8 @@
     <property name="page_size">10</property>
   </object>
   <object class="GtkWindow" id="backends">
+    <property name="default_width">700</property>
+    <property name="default_height">500</property>
     <child>
       <object class="GtkBox" id="big_central_box">
         <child>
@@ -66,6 +68,7 @@
         <child>
           <object class="GtkScrolledWindow" id="central_pane_window">
             <property name="hexpand">True</property>
+            <property name="hscrollbar_policy">never</property>
             <property name="width_request">480</property>
             <property name="vadjustment">adjustment1</property>
             <child>


### PR DESCRIPTION
The backends window declared no default size at all, leaving the initial geometry entirely to GTK4 size negotiation, which opened the dialog cramped, as shown in the #1346 screenshot. The central pane also had no horizontal scrollbar policy, so any content one pixel wider than the allocation grew a horizontal scrollbar at the bottom of the panel.

Two properties in backends.ui: the window now opens at 700x500, and the central pane refuses horizontal scrolling, so a panel that genuinely needs more width makes the window grow instead of offering a scrollbar. Verified live: the dialog opens comfortable on first and subsequent openings, with no horizontal scrollbar on either the configuration or the add panel.

Fixes #1346