### PR TITLE
fix(browser): show CalDAV field hints as placeholders, not stored values (#1347)

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -134,13 +134,13 @@ class Backend(PeriodicImportBackend):
             GenericBackend.PARAM_DEFAULT_VALUE: 15},
         "username": {
             GenericBackend.PARAM_TYPE: GenericBackend.TYPE_STRING,
-            GenericBackend.PARAM_DEFAULT_VALUE: _('insert your username')},
+            GenericBackend.PARAM_DEFAULT_VALUE: ''},
         "password": {
             GenericBackend.PARAM_TYPE: GenericBackend.TYPE_PASSWORD,
             GenericBackend.PARAM_DEFAULT_VALUE: ''},
         "service-url": {
             GenericBackend.PARAM_TYPE: GenericBackend.TYPE_STRING,
-            GenericBackend.PARAM_DEFAULT_VALUE: 'https://example.com/webdav/'},
+            GenericBackend.PARAM_DEFAULT_VALUE: ''},
         "is-first-run": {
             GenericBackend.PARAM_TYPE: GenericBackend.TYPE_BOOL,
             GenericBackend.PARAM_DEFAULT_VALUE: True},

--- a/GTG/gtk/backends/parameters_ui/__init__.py
+++ b/GTG/gtk/backends/parameters_ui/__init__.py
@@ -76,12 +76,14 @@ class ParametersUI(Gtk.Box):
             ("username", self.UI_generator(TextUI, {
                 "description": _("Username"),
                 "parameter_name": "username",
+                "placeholder": _("insert your username"),
             })),
             ("password", self.UI_generator(PasswordUI)),
             ("period", self.UI_generator(PeriodUI)),
             ("service-url", self.UI_generator(TextUI, {
                 "description": _("Service URL"),
                 "parameter_name": "service-url",
+                "placeholder": "https://example.com/webdav/",
             })),
             ("import-from-replies", self.UI_generator(CheckBoxUI, {
                 "text": _("Import tasks from @ replies directed to you"),

--- a/GTG/gtk/backends/parameters_ui/text.py
+++ b/GTG/gtk/backends/parameters_ui/text.py
@@ -23,7 +23,8 @@ class TextUI(Gtk.Box):
     """A widget to display a simple textbox and a label to describe its content
     """
 
-    def __init__(self, ds, backend, width, description, parameter_name):
+    def __init__(self, ds, backend, width, description, parameter_name,
+                 placeholder=None):
         """
         Creates the textbox and the related label. Loads the current
         content.
@@ -37,6 +38,7 @@ class TextUI(Gtk.Box):
         self.ds = ds
         self.parameter_name = parameter_name
         self.description = description
+        self.placeholder = placeholder
         self._populate_gtk(width)
 
     def _populate_gtk(self, width):
@@ -53,6 +55,8 @@ class TextUI(Gtk.Box):
         self.append(label)
         self.textbox = Gtk.Entry()
         self.textbox.set_hexpand(True)
+        if self.placeholder:
+            self.textbox.set_placeholder_text(self.placeholder)
         backend_parameters = self.backend.get_parameters()[self.parameter_name]
         self.textbox.set_text(backend_parameters)
         self.textbox.connect('changed', self.on_text_modified)


### PR DESCRIPTION
The username and server fields of the CalDAV configuration panel were prefilled with the literal strings insert your username (translated) and https://example.com/webdav/. These were not greyed hints: backend_caldav.py declared them as PARAM_DEFAULT_VALUE and parameters_ui injected them with set_text(), so they were real values. The user had to notice and erase them by hand, and saving the account untouched stored them verbatim in backends.conf as the actual configuration.

The two defaults are now empty, TextUI accepts an optional placeholder argument, and the hints moved there: greyed, vanishing as soon as the user types, and never stored. Verified live: a freshly created account shows both hints greyed and writes empty username and service-url values to backends.conf. One assumed limit: accounts already saved with the sample strings keep showing them as real text, since those are by now their stored values.

Fixes #1329, fixes #1347