### PR TITLE
fix(browser): bring back the Closed Date sorting order (#1334)

### DIFF
--- a/GTG/core/sorters.py
+++ b/GTG/core/sorters.py
@@ -95,6 +95,20 @@ class TaskDueSorter(ReversibleSorter):
         return self.reversible_compare(first, second)
 
 
+class TaskClosedSorter(ReversibleSorter):
+    __gtype_name__ = 'ClosedSorter'
+
+    def do_compare(self, a, b) -> Gtk.Ordering:
+
+        a = unwrap(a, Task)
+        b = unwrap(b, Task)
+
+        first = a.date_closed
+        second = b.date_closed
+
+        return self.reversible_compare(first, second)
+
+
 class TaskStartSorter(ReversibleSorter):
     __gtype_name__ = 'StartSorter'
 

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -21,7 +21,7 @@
 from gi.repository import Gtk, GObject, Gdk, Gio, GLib, Pango
 from GTG.core.tasks import Task, Status, FilteredTaskTreeManager
 from GTG.core.filters import TaskFilter
-from GTG.core.sorters import (TaskAddedSorter, TaskDueSorter,
+from GTG.core.sorters import (TaskAddedSorter, TaskClosedSorter, TaskDueSorter,
                               TaskModifiedSorter, TaskStartSorter,
                               TaskTagSorter, TaskTitleSorter)
 from GTG.gtk.browser.tag_pill import TagPill
@@ -295,6 +295,8 @@ class TaskPane(Gtk.ScrolledWindow):
             sorter = TaskStartSorter()
         if method == 'Due':
             sorter = TaskDueSorter()
+        if method == 'Closed':
+            sorter = TaskClosedSorter()
         if method == 'Modified':
             sorter = TaskModifiedSorter()
         elif method == 'Added':

--- a/GTG/gtk/data/main_window.ui
+++ b/GTG/gtk/data/main_window.ui
@@ -223,6 +223,12 @@
       </item>
 
       <item>
+        <attribute name="label" translatable="yes">Sort by Closed Date</attribute>
+        <attribute name="target">Closed</attribute>
+        <attribute name="action">win.sort</attribute>
+      </item>
+
+      <item>
         <attribute name="label" translatable="yes">Sort by Modified Date</attribute>
         <attribute name="target">Modified</attribute>
         <attribute name="action">win.sort</attribute>


### PR DESCRIPTION
GTG 0.6 sorted the Closed view by closing date through its column header. The new task pane lost that ability entirely: no sorter compares date_closed and the sort menu offers no such entry, a 0.7 regression shown in the #1334 screenshots.

A TaskClosedSorter joins the existing sorters, comparing the date_closed field, which is always a valid Date (no_date for tasks never closed, so the comparison is total). A Sort by Closed Date entry joins the sort menu, and the task pane maps it like its siblings. The per-view memory asked for in the report is already provided by #1344: once both land, the Closed view remembers this mode and its direction independently from the two other views.

Verified live: the new entry appears in the sort menu, orders the Closed view by closing date, reverses with the direction toggle, and survives switching views back and forth.

Fixes #1334