### PR TITLE
fix(browser): re-sort the task lists when a task date or title changes (#1332)

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -868,6 +868,11 @@ class TaskStore(BaseStore[Task]):
         """Signal to emit when a task was changed in a filterable way. (E.g., A tag was added.)"""
 
 
+    @GObject.Signal(name='task-sortably-changed', arg_types=(object,))
+    def task_sortably_changed_signal(self, *_):
+        """Signal to emit when a task changed in a way that can affect sorting."""
+
+
     def __str__(self) -> str:
         """String representation."""
 
@@ -1098,6 +1103,12 @@ class TaskStore(BaseStore[Task]):
         for event in ['notify::title', 'notify::is-actionable',
                       'notify::is-active', 'tags-changed']:
             item.connect(event,lambda *_: self.emit('task-filterably-changed',item))
+
+        # Date edits update the row labels through these notifies, but
+        # nothing used to re-sort the lists (#1332): relay them so the
+        # panes can ask their sort model to recompute.
+        for event in ['notify::date-due-str', 'notify::date-start-str']:
+            item.connect(event, lambda *_: self.emit('task-sortably-changed', item))
 
 
     def unparent(self, item_id: UUID) -> None:

--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -189,6 +189,14 @@ class TaskPane(Gtk.ScrolledWindow):
         self.main_sorter.set_model(self.filtered)
         self.main_sorter.set_sorter(self.sort_model)
 
+        # A task edit that changes a date or the title updates the row
+        # in place but used to leave it at its old position (#1332):
+        # ask the sorter to recompute when the store reports a change.
+        for signal in ('task-filterably-changed', 'task-sortably-changed'):
+            self.app.ds.tasks.connect(
+                signal,
+                lambda *_: self.sort_model.changed(Gtk.SorterChange.DIFFERENT))
+
         self.task_selection = Gtk.MultiSelection.new(self.main_sorter)
 
         tasks_signals = Gtk.SignalListItemFactory()


### PR DESCRIPTION
Editing the due or start date of a task updated the row label in place but left the row at its old position, as shown in the #1332 video: nothing told the sort model that anything changed. The date setters already notify the date-due-str and date-start-str properties, which is exactly how the labels refresh; the sorting side simply had no listener.

The task store now relays those notifies through a new task-sortably-changed signal, twin of the existing task-filterably-changed, and each pane asks its sorter to recompute on either signal. Title, tag and date edits therefore all reposition the row immediately. There is no startup churn: at load time the dates are set before the task enters the store, hence before the relays are connected.

Verified live on the reproduction from the video: with the list sorted by due date, changing a task due date moves the row to its new position as soon as the editor closes, and renaming a task under title sorting does the same.

Fixes #1332