### PR TITLE
fix(browser): hand focus back to the task list when the context menu closes (#1333)

### DIFF
--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -197,6 +197,7 @@ class TaskPane(Gtk.ScrolledWindow):
         tasks_signals.connect('unbind', self.task_unbind_cb)
 
         view = Gtk.ListView.new(self.task_selection, tasks_signals)
+        self.task_view = view
         view.set_show_separators(True)
         view.add_css_class('rich-list')
         view.add_css_class('task-list')
@@ -718,6 +719,18 @@ class TaskPane(Gtk.ScrolledWindow):
         rect.y = y
 
         menu.set_pointing_to(rect)
+
+        # The popover takes keyboard focus away from the list, so the
+        # selected row turns to the unfocused (gray) selection color
+        # and stays that way after the menu closes (#1333). Hand the
+        # focus back to the list when the popover goes away. One-shot:
+        # the menus are shared between panes, a persistent connection
+        # would pile up handlers.
+        def _refocus(popover):
+            popover.disconnect(handler)
+            self.task_view.grab_focus()
+
+        handler = menu.connect('closed', _refocus)
         menu.popup()
 
 


### PR DESCRIPTION
Right-clicking a task selects it and pops the shared context menu, which takes keyboard focus away from the list view. GTK4 then paints the selection in the unfocused gray color, and since nothing ever returned the focus to the list, the row stayed gray after the menu closed and flickered with hover, exactly as the #1333 video shows.

The pane now keeps a reference to its list view and hands the focus back when the popover emits closed. The connection is deliberately one-shot: the two context menus are shared between the three panes, so a persistent connection would pile up handlers pointing at stale panes.

One boundary stated for the record: selections still turn gray while the popover is open, or when another window such as the task editor holds the focus. That is the standard GTK unfocused rendering, identical in any GTK application, and out of scope here. The persisting gray in the focused browser window is gone, verified live on both the open and closed views, including after running a menu action.

Fixes #1333