### PR TITLE
fix(core): keep the closed date of dismissed tasks across saves (#1338)

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -982,6 +982,17 @@ class TaskStore(BaseStore[Task]):
             if done_element is not None and done_element.text is not None:
                 closed = Date.parse(done_element.text)
                 task.date_closed = closed
+            elif task.status is not Status.ACTIVE:
+                # A closed task without a closed date is invisible to
+                # the reaper: today minus no_date is -9999 days, never
+                # above any purge threshold (#1338). Files written by
+                # 0.7 lost the closed date of every dismissed task,
+                # since the serializer only wrote it for Done: heal
+                # them with the modification date, the same fallback
+                # the added date uses above.
+                log.warning('Closed task %s has no closed date, falling '
+                            'back on the modification date', tid)
+                task.date_closed = Date(str(task.date_modified)[:10])
 
             fuzzy_due_date = Date.parse(dates.findtext('fuzzyDue'))
             due_date = Date.parse(dates.findtext('due'))
@@ -1058,7 +1069,7 @@ class TaskStore(BaseStore[Task]):
             modified_date = SubElement(dates, 'modified')
             modified_date.text = str(task.date_modified)
 
-            if task.status == Status.DONE:
+            if task.status is not Status.ACTIVE:
                 done_date = SubElement(dates, 'done')
                 done_date.text = str(task.date_closed)
 

--- a/tests/core/test_closed_date_serialization.py
+++ b/tests/core/test_closed_date_serialization.py
@@ -1,0 +1,61 @@
+# -----------------------------------------------------------------------------
+# Getting Things GNOME! - a personal organizer for the GNOME desktop
+# -----------------------------------------------------------------------------
+
+"""Regression tests for closed date serialization (#1338).
+
+The 0.7 serializer only wrote the closed date of Done tasks: every
+Dismissed task lost its date_closed on the first save, and a closed
+task without a date is immortal for the reaper (today - no_date is
+-9999 days). These tests fail on the old serializer and loader.
+"""
+
+from GTG.core.tasks import TaskStore, Status
+from GTG.core.dates import Date
+
+
+def roundtrip(store: TaskStore) -> TaskStore:
+    new_store = TaskStore()
+    new_store.from_xml(store.to_xml(), None)
+    return new_store
+
+
+def make_closed(store: TaskStore, title: str, status: Status):
+    task = store.new(title)
+    task.status = status
+    task.is_active = False
+    task.date_closed = Date('2026-01-15')
+    return task
+
+
+def test_dismissed_task_keeps_closed_date_over_roundtrip():
+    store = TaskStore()
+    make_closed(store, 'dismissed', Status.DISMISSED)
+    loaded = roundtrip(store).data[0]
+    assert loaded.date_closed == Date('2026-01-15')
+
+
+def test_done_task_keeps_closed_date_over_roundtrip():
+    store = TaskStore()
+    make_closed(store, 'done', Status.DONE)
+    loaded = roundtrip(store).data[0]
+    assert loaded.date_closed == Date('2026-01-15')
+
+
+def test_closed_task_without_date_is_healed_from_modified():
+    store = TaskStore()
+    task = make_closed(store, 'stripped', Status.DISMISSED)
+    xml = store.to_xml()
+    for done in xml.iter('done'):
+        done.getparent().remove(done)
+    loaded = TaskStore()
+    loaded.from_xml(xml, None)
+    healed = loaded.data[0]
+    assert healed.date_closed == Date(str(task.date_modified)[:10])
+
+
+def test_active_task_keeps_no_closed_date():
+    store = TaskStore()
+    store.new('active')
+    loaded = roundtrip(store).data[0]
+    assert loaded.date_closed == Date.no_date()


### PR DESCRIPTION
The serializer only wrote the closed date of Done tasks: every Dismissed task lost its date_closed on the first save, and since GTG rewrites the whole file on exit, one 0.7 session was enough to strip every dismissed task. A closed task without a date is then invisible to the reaper, today minus no_date being -9999 days, never above any threshold. That is the dismissed half of #1338.

The serializer now writes the closed date for every closed status, and the loader heals closed tasks that have no closed date, falling back on the modification date with a warning, the same guard philosophy as the added date. That repairs files already damaged. Red before, green after: four round-trip tests, two failing on the old code. Verified live on a real dataset: ten stripped dismissed tasks healed with honest dates at load, then purged as expected at the next reaper run.

The remaining observation in #1338, done tasks not purged, traces to a distinct pre-existing defect, closed dates mass-overwritten with the current day, investigated separately.

Fixes the dismissed half of #1338