### PR TITLE
fix(editor): repair the two phantom method calls of the Dismiss path (#1355)

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -386,7 +386,7 @@ class Application(Gtk.Application):
         """Callback to mark a task as done."""
 
         try:
-            self.get_active_editor().toggle_dismiss()
+            self.get_active_editor().dismiss()
         except AttributeError:
             self.browser.on_dismiss_task()
         finally:

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -687,7 +687,7 @@ class TaskEditor(Gtk.Window):
             self.app.close_task(task.id)
 
     def dismiss(self):
-        self.task.toggle_dismissed()
+        self.task.toggle_dismiss()
         self.refresh_editor()
 
         if self.task.status != Status.ACTIVE:


### PR DESCRIPTION
Dismissing from the editor did nothing: its button handler called task.toggle_dismissed(), a method that does not exist, Task only has toggle_dismiss. The keyboard path was broken the other way around: app.dismiss called editor.toggle_dismiss(), which does not exist either, the editor method is named dismiss(). The AttributeError was silently swallowed by the try/except fallback, which then acted on the browser selection, possibly a different task than the one being edited.

Both calls now target the methods that actually exist. Verified live: the editor button dismisses the task and closes the editor, and the keyboard shortcut with an editor focused dismisses the edited task rather than the browser selection. Found while investigating #1338.

Fixes #1355