### PR TITLE
fix(caldav): stop stamping closed dates with the sync day (#1357)

### DIFF
--- a/GTG/backends/backend_caldav.py
+++ b/GTG/backends/backend_caldav.py
@@ -759,8 +759,18 @@ class Status(Field):
         return self._translate(dav_value=super().get_dav(todo, vtodo))[1]
 
     def write_gtg(self, task: Task, value, namespace: str = None):
-        value = self._translate(dav_value=value, gtg_value=value)[0]
-        return super().write_gtg(task, value, namespace)
+        status = self._translate(dav_value=value, gtg_value=value)[0]
+        # Applying the status through Task.set_status() would overwrite
+        # date_closed with today (the COMPLETED field owns that value),
+        # propagate the status to every subtask and trigger the
+        # recurrence duplication logic. A sync must do none of that:
+        # set the properties directly, like the XML loader does.
+        task.status = status
+        task.is_active = (status == TaskStatus.ACTIVE)
+        if status == TaskStatus.ACTIVE:
+            # A reopened todo carries no COMPLETED field anymore, so
+            # the date field leaves the stale value in place: clear it.
+            task.date_closed = Date.no_date()
 
 
 class PercentComplete(Field):

--- a/tests/backend/test_caldav_closed_date_stamping.py
+++ b/tests/backend/test_caldav_closed_date_stamping.py
@@ -1,0 +1,84 @@
+"""The CalDAV sync must not overwrite closed dates with the current day.
+
+Regression test for the mass closed-date stamping: filling a task from
+a VTODO whose STATUS is COMPLETED (or CANCELLED) must leave the task
+with the historical COMPLETED date carried by the payload, not with
+Date.today().
+"""
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+import vobject
+
+from GTG.backends.backend_caldav import Translator, UID_FIELD, uid_to_task_id
+from GTG.core.datastore import Datastore
+from GTG.core.tasks import Task, TaskStore, Status
+from GTG.core.tags import TagStore
+
+NAMESPACE = 'unittest'
+
+VTODO_DONE_OLD = """BEGIN:VTODO\r
+COMPLETED:20201212T172558Z\r
+CREATED:20201210T092155Z\r
+DTSTAMP:20201212T172830Z\r
+LAST-MODIFIED:20201212T172558Z\r
+STATUS:COMPLETED\r
+SUMMARY:done long ago\r
+UID:DONE-OLD\r
+END:VTODO\r\n"""
+
+VTODO_CANCELLED_OLD = """BEGIN:VTODO\r
+COMPLETED:20190301T101500Z\r
+CREATED:20190201T092155Z\r
+DTSTAMP:20190301T101600Z\r
+LAST-MODIFIED:20190301T101500Z\r
+STATUS:CANCELLED\r
+SUMMARY:dismissed long ago\r
+UID:CANCELLED-OLD\r
+END:VTODO\r\n"""
+
+
+def _get_todo(raw):
+    todo = Mock()
+    todo.instance.vtodo = vobject.readOne(raw)
+    todo.parent.name = 'My Calendar'
+    return todo
+
+
+class TestClosedDateStamping(TestCase):
+
+    def _fill(self, raw):
+        todo = _get_todo(raw)
+        uid = UID_FIELD.get_dav(todo)
+        task = Task(id=uid_to_task_id(uid), title='')
+        Translator.fill_task(todo, task, NAMESPACE, Datastore())
+        return task
+
+    def test_done_keeps_historical_closed_date(self):
+        task = self._fill(VTODO_DONE_OLD)
+        self.assertEqual(Status.DONE, task.status)
+        self.assertTrue(str(task.date_closed).startswith('2020-12-12'),
+                        'closed date was stamped over during fill_task')
+
+    def test_cancelled_keeps_historical_closed_date(self):
+        task = self._fill(VTODO_CANCELLED_OLD)
+        self.assertEqual(Status.DISMISSED, task.status)
+        self.assertTrue(str(task.date_closed).startswith('2019-03-01'),
+                        'closed date was stamped over during fill_task')
+
+    def test_closed_date_survives_save_and_reload(self):
+        """Full cycle: fill from VTODO, serialize to XML, reload."""
+        store = TaskStore()
+        todo = _get_todo(VTODO_DONE_OLD)
+        uid = UID_FIELD.get_dav(todo)
+        task = Task(id=uid_to_task_id(uid), title='')
+        Translator.fill_task(todo, task, NAMESPACE, Datastore())
+        store.add(task)
+
+        reloaded = TaskStore()
+        reloaded.from_xml(store.to_xml(), TagStore())
+        back = reloaded.lookup[task.id]
+        self.assertEqual(Status.DONE, back.status)
+        self.assertTrue(str(back.date_closed).startswith('2020-12-12'),
+                        'closed date lost across save/reload')


### PR DESCRIPTION
The CalDAV sync stamped the closed date of every closed task it filled with the day of the sync, destroying historical dates in waves. Full mechanism and field evidence on #1357.

The status field applied its value through Task.set_status(), the user action handler, which stamps date_closed with today, propagates the status to every subtask and can trigger the recurrence duplication logic. A sync must do none of that: Status.write_gtg() now sets the status properties directly, like the XML loader does, and leaves the closed date to the completed field. A todo coming back reopened has its stale closed date cleared, since it no longer carries a COMPLETED field to overwrite it.

Red before, green after, on a live Nextcloud calendar of 138 closed todos: master writes 138 tasks closed on the import day down to the data file, the fix preserves every historical server date through the full import, save and reload cycle. Three regression tests added, whole backend suite green.

Out of scope, tracked separately: the pre-existing race between the import thread and the GTK sorters that can crash the app during an import, on master as on this branch.

Fixes #1357